### PR TITLE
fix: donation donors not shown on fundraise card

### DIFF
--- a/src/entities/Donation/ui/DonationDonorsCard/DonationDonorsCard.tsx
+++ b/src/entities/Donation/ui/DonationDonorsCard/DonationDonorsCard.tsx
@@ -71,7 +71,7 @@ export const DonationDonorsCard = memo((props: DonationDonorsCardProps) => {
                             <span className={styles.donorName}>
                                 {donor.isAnonymous
                                     ? t("donationPersonal.Аноним")
-                                    : donor.donorName || t("donationPersonal.Аноним")}
+                                    : donor.fullName || t("donationPersonal.Аноним")}
                             </span>
                             <span className={styles.donorDate}>
                                 {new Date(donor.createdAt).toLocaleDateString("ru-RU")}

--- a/src/store/api/donationPaymentApi.ts
+++ b/src/store/api/donationPaymentApi.ts
@@ -18,7 +18,7 @@ export interface DonationListItem {
     id: string;
     amount: number;
     isAnonymous: boolean;
-    donorName: string | null;
+    fullName: string | null;
     createdAt: string;
 }
 
@@ -78,7 +78,7 @@ export const donationPaymentApi = createApi({
         { fundraiseId: string; page?: number; limit?: number }
         >({
             query: ({ fundraiseId, page = 1, limit = 20 }) => ({
-                url: `${API_BASE_URL_V3}donation/fundraise/${fundraiseId}?page=${page}&limit=${limit}`,
+                url: `${API_BASE_URL_V3}donation/fundraise/${fundraiseId}/list?page=${page}&limit=${limit}`,
                 method: "GET",
             }),
             providesTags: ["donationList"],


### PR DESCRIPTION
## Problem

After merging the donations feature, donors (participants) were not displayed on the fundraise card.

## Root causes

1. **Wrong URL** — \`getDonationsByFundraise\` called \`/donation/fundraise/${id}\` but the backend route is \`/donation/fundraise/${id}/list\`.

2. **Field name mismatch** — \`DonationListItem\` interface declared \`donorName\`, but the backend returns \`fullName\`. The component rendered an empty string for every donor.

## Changes

- \`donationPaymentApi.ts\` — fix URL (add \`/list\`), rename \`donorName\` → \`fullName\` in \`DonationListItem\`.
- \`DonationDonorsCard.tsx\` — use \`donor.fullName\` instead of \`donor.donorName\`.

## Related

- Backend fix: Goodsurfing/gs-backend#134