### PR TITLE
fix: add Поддержать section to InfoMobileHeader mobile burger menu

### DIFF
--- a/src/containers/WelcomeContainer/InfoSide/InfoMobileHeader/ui/InfoMobileHeader/InfoMobileHeader.tsx
+++ b/src/containers/WelcomeContainer/InfoSide/InfoMobileHeader/ui/InfoMobileHeader/InfoMobileHeader.tsx
@@ -15,6 +15,9 @@ import {
     getAcademyMainPageUrl,
     getAmbassadorsPageUrl,
     getBlogPageUrl,
+    getDonationRating,
+    getDonationReports,
+    getDonationsMapPageUrl,
     getFindJobPageUrl,
     getHostDashboardPageUrl,
     getJournalsPageUrl,
@@ -230,6 +233,37 @@ export const InfoMobileHeader: FC = () => {
                         to={getJournalsPageUrl(locale)}
                     >
                         {t("main.welcome.header.community.journal")}
+                    </Link>
+                </MobileSelect>
+                <MobileSelect
+                    classNameSelectContainer={styles.selectContainer}
+                    isOpen={dropdownOpened.isSupportOpened}
+                    title={t("main.welcome.header.donation.title")}
+                    onClick={() => handleOpenDropdown("SUPPORT")}
+                >
+                    <Link
+                        className={styles.dropdownLink}
+                        to={getMainPageUrl(locale)}
+                    >
+                        {t("main.welcome.header.donation.support-goodsurfing")}
+                    </Link>
+                    <Link
+                        className={styles.dropdownLink}
+                        to={getDonationsMapPageUrl(locale)}
+                    >
+                        {t("main.welcome.header.donation.support-other-projects")}
+                    </Link>
+                    <Link
+                        className={styles.dropdownLink}
+                        to={getDonationReports(locale)}
+                    >
+                        {t("main.welcome.header.donation.public-reports")}
+                    </Link>
+                    <Link
+                        className={styles.dropdownLink}
+                        to={getDonationRating(locale)}
+                    >
+                        {t("main.welcome.header.donation.rating-donations")}
                     </Link>
                 </MobileSelect>
                 <MobileSelect

--- a/src/containers/WelcomeContainer/InfoSide/InfoMobileHeader/ui/InfoMobileHeader/lib/mobileHeaderUtils.ts
+++ b/src/containers/WelcomeContainer/InfoSide/InfoMobileHeader/ui/InfoMobileHeader/lib/mobileHeaderUtils.ts
@@ -1,4 +1,4 @@
-export type ButtonNav = "OFFERS" | "COMMUNITY" | "ABOUT";
+export type ButtonNav = "OFFERS" | "COMMUNITY" | "ABOUT" | "SUPPORT";
 
 type Action = { type: ButtonNav };
 
@@ -6,12 +6,14 @@ interface DropdownState {
     isCommunityOpened: boolean;
     isAboutProjectOpened: boolean;
     isOffersOpened: boolean;
+    isSupportOpened: boolean;
 }
 
 export const initialState: DropdownState = {
     isCommunityOpened: false,
     isAboutProjectOpened: false,
     isOffersOpened: false,
+    isSupportOpened: false,
 };
 
 export const toggleDropdownReducer = (state: DropdownState, action: Action) => {
@@ -23,6 +25,8 @@ export const toggleDropdownReducer = (state: DropdownState, action: Action) => {
                 ...state,
                 isAboutProjectOpened: !state.isAboutProjectOpened,
             };
+        case "SUPPORT":
+            return { ...state, isSupportOpened: !state.isSupportOpened };
         case "OFFERS":
             return { ...state, isOffersOpened: !state.isOffersOpened };
         default:


### PR DESCRIPTION
## Проблема

На главной странице (`/`) используется отдельный компонент мобильного хедера — `InfoMobileHeader`. Когда в основной `MobileHeader` добавили пункт «Поддержать», про `InfoMobileHeader` забыли, и в мобильном бургере на главной страница этого пункта не было.

## Что изменено

- **`InfoMobileHeader.tsx`** — добавлены импорты `getDonationRating`, `getDonationReports`, `getDonationsMapPageUrl` и блок `MobileSelect` с пунктом «Поддержать»
- **`lib/mobileHeaderUtils.ts`** — добавлен тип `"SUPPORT"` в `ButtonNav`, поле `isSupportOpened` в стейт и кейс `SUPPORT` в редьюсер

## Проверка

DOM-инспекция локально подтвердила наличие пункта в меню:
`ПоддержатьПоддержать ГудсёрфингПоддержать другие проектыПубличные отчётыРейтинг донаций`