### PR TITLE
fix: pass VITE_* build args in compose.yaml, fix VK auth headers

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,11 @@ services:
   frontend:
     build:
       context: .
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+        VITE_API_YANDEX_KEY: ${VITE_API_YANDEX_KEY:-}
+        VITE_MAIN_URL: ${VITE_MAIN_URL}
+        VITE_VKID_CLIENT_ID: ${VITE_VKID_CLIENT_ID:-54011426}
     restart: unless-stopped
     container_name: gs_frontend
     labels:

--- a/src/features/AuthByVk/ui/AuthByVk.tsx
+++ b/src/features/AuthByVk/ui/AuthByVk.tsx
@@ -83,6 +83,9 @@ export const AuthByVk: FC<AuthByVkProps> = (props) => {
                     try {
                         const responseAccessToken = await fetch(`${BASE_VK_URI}access-token`, {
                             method: "POST",
+                            headers: {
+                                "Content-Type": "application/json",
+                            },
                             body: JSON.stringify({
                                 code,
                                 deviceId,


### PR DESCRIPTION
## Summary
- compose.yaml was missing `args:` section in the `build:` block, so `VITE_API_BASE_URL` and other env vars were not passed to Docker during build
- This caused all API URLs to be relative (e.g. `api/v1/token` instead of `https://api.gudserfing.ru/api/v1/token`), completely breaking auth on UAT
- Login POST went to `https://gudserfing.ru/ru/api/v1/token` (405) instead of backend
- VK auth fetch also had a missing `Content-Type: application/json` header on the access-token POST

## Test plan
- [ ] Rebuild frontend container on UAT: `docker compose build --no-cache && docker compose up -d`
- [ ] Verify login form sends request to `api.gudserfing.ru`
- [ ] Verify VK auth button initializes without errors
- [ ] Test login with valid credentials