### PR TITLE
fix: поддержка абсолютных S3 URL в media content

### DIFF
--- a/public/placeholder-missing.svg
+++ b/public/placeholder-missing.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800" role="img" aria-label="Изображение недоступно">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f3f4f6"/>
+      <stop offset="100%" stop-color="#e5e7eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#g)"/>
+  <g fill="none" stroke="#9ca3af" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <rect x="350" y="220" width="500" height="320" rx="24"/>
+    <circle cx="500" cy="340" r="36"/>
+    <path d="M410 500l110-110 75 75 80-80 115 115"/>
+  </g>
+  <text x="600" y="620" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="38" fill="#6b7280">Изображение недоступно</text>
+  <text x="600" y="665" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="24" fill="#9ca3af">placeholder</text>
+</svg>

--- a/src/entities/Donation/ui/DonationGalleryCard/DonationGalleryCard.tsx
+++ b/src/entities/Donation/ui/DonationGalleryCard/DonationGalleryCard.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ImageGallerySlider } from "@/shared/ui/ImageGallerySlider/ImageGallerySlider";
 import { Text } from "@/shared/ui/Text/Text";
 import { Image } from "@/types/media";
-import { BASE_URL } from "@/shared/constants/api";
+import { getMediaContentsArray } from "@/shared/lib/getMediaContent";
 import styles from "./DonationGalleryCard.module.scss";
 
 interface DonationGalleryCardProps {
@@ -17,7 +17,7 @@ export const DonationGalleryCard: FC<DonationGalleryCardProps> = memo(
     (props: DonationGalleryCardProps) => {
         const { galleryImages = [], className } = props;
         const { t } = useTranslation("donation");
-        const formatGallery = galleryImages.map((image) => `${BASE_URL}${image.contentUrl.slice(1)}`);
+        const formatGallery = getMediaContentsArray(galleryImages);
 
         if (galleryImages.length === 0) {
             return (

--- a/src/entities/Offer/ui/OfferGalleryCard/OfferGalleryCard.tsx
+++ b/src/entities/Offer/ui/OfferGalleryCard/OfferGalleryCard.tsx
@@ -6,7 +6,7 @@ import styles from "./OfferGalleryCard.module.scss";
 import { ImageGallerySlider } from "@/shared/ui/ImageGallerySlider/ImageGallerySlider";
 import { Text } from "@/shared/ui/Text/Text";
 import { Image } from "@/types/media";
-import { BASE_URL } from "@/shared/constants/api";
+import { getMediaContentsArray } from "@/shared/lib/getMediaContent";
 
 interface OfferGalleryCardProps {
     galleryImages?: Image[];
@@ -17,7 +17,7 @@ export const OfferGalleryCard: FC<OfferGalleryCardProps> = memo(
     (props: OfferGalleryCardProps) => {
         const { galleryImages = [], className } = props;
         const { t } = useTranslation("offer");
-        const formatGallery = galleryImages.map((image) => `${BASE_URL}${image.contentUrl.slice(1)}`);
+        const formatGallery = getMediaContentsArray(galleryImages);
 
         if (galleryImages.length === 0) {
             return null;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,15 @@ import { LocaleProvider } from "./app/providers/LocaleProvider";
 
 const root = createRoot(document.getElementById("root")!);
 
+// Глобальный fallback для битых изображений (S3 миграция)
+document.addEventListener("error", (e) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName === "IMG" && !target.dataset.fallback) {
+        target.dataset.fallback = "true";
+        (target as HTMLImageElement).src = "/placeholder-missing.svg";
+    }
+}, true);
+
 const store = setupStore();
 
 const Root = (

--- a/src/pages/AboutProjectPage/ui/Gallery/Gallery.tsx
+++ b/src/pages/AboutProjectPage/ui/Gallery/Gallery.tsx
@@ -7,7 +7,7 @@ import "swiper/swiper.min.css";
 
 import { ImageGallerySlider } from "@/shared/ui/ImageGallerySlider/ImageGallerySlider";
 import { Image } from "@/types/media";
-import { BASE_URL } from "@/shared/constants/api";
+import { getMediaContentsArray } from "@/shared/lib/getMediaContent";
 import styles from "./Gallery.module.scss";
 
 interface GalleryProps {
@@ -25,7 +25,7 @@ export const Gallery: FC<GalleryProps> = (props: GalleryProps) => {
                 {t("Фото со встреч и командной работы")}
             </h2>
             <ImageGallerySlider
-                images={gallery.map((img) => `${BASE_URL}${img.contentUrl.slice(1)}`)}
+                images={getMediaContentsArray(gallery)}
                 className={styles.gallery}
             />
         </section>

--- a/src/pages/DonationPayPage/ui/DonationPayPage/DonationPayPage.tsx
+++ b/src/pages/DonationPayPage/ui/DonationPayPage/DonationPayPage.tsx
@@ -11,7 +11,7 @@ import { useAuth } from "@/routes/model/guards/AuthProvider";
 import { useGetDonationByIdQuery } from "@/entities/Donation/api/donationApi";
 import { useCreateDonationPaymentMutation } from "@/store/api/donationPaymentApi";
 import { getDonationPersonalPage, getSignInPageUrl } from "@/shared/config/routes/AppUrls";
-import { BASE_URL } from "@/shared/constants/api";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 
 import styles from "./DonationPayPage.module.scss";
 
@@ -90,7 +90,7 @@ const DonationPayPage: React.FC = () => {
     }
 
     const imageUrl = fundraise?.image?.contentUrl
-        ? `${BASE_URL}${fundraise.image.contentUrl}`
+        ? getMediaContent(fundraise.image.contentUrl)
         : undefined;
 
     return (

--- a/src/shared/lib/getMediaContent.ts
+++ b/src/shared/lib/getMediaContent.ts
@@ -4,6 +4,13 @@ import { ImageType } from "@/entities/Profile";
 
 type MediaContentSize = "SMALL" | "MEDIUM" | "LARGE" | "ORIGINAL";
 
+const toAbsoluteUrl = (url: string): string => {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    return `${BASE_URL}${url.startsWith("/") ? url.slice(1) : url}`;
+};
+
 export const getMediaContent = (
     value: string | MediaObjectType | ImageType | undefined,
     size: MediaContentSize = "ORIGINAL",
@@ -11,21 +18,21 @@ export const getMediaContent = (
     if (!value) return undefined;
 
     if (typeof value === "string") {
-        return `${BASE_URL}${value.slice(1)}`;
+        return toAbsoluteUrl(value);
     }
 
     if (typeof value === "object" && "contentUrl" in value) {
         if (size === "ORIGINAL") {
-            return `${BASE_URL}${value.contentUrl.slice(1)}`;
+            return toAbsoluteUrl(value.contentUrl);
         }
 
         if (value.thumbnails
             && value.thumbnails[size.toLowerCase() as keyof typeof value.thumbnails]) {
-            return `${BASE_URL}${value.thumbnails[size.toLowerCase() as keyof typeof value.thumbnails].slice(1)}`;
+            return toAbsoluteUrl(value.thumbnails[size.toLowerCase() as keyof typeof value.thumbnails]);
         }
 
         // fallback на оригинал, если нужного thumbnail нет
-        return `${BASE_URL}${value.contentUrl.slice(1)}`;
+        return toAbsoluteUrl(value.contentUrl);
     }
 
     return undefined;
@@ -38,13 +45,13 @@ export const getMediaContentsArray = (images: (GalleryItem | MediaObjectType
             return image;
         }
         if ("mediaObject" in image) {
-            return `${BASE_URL}${image.mediaObject.contentUrl.slice(1)}`;
+            return toAbsoluteUrl(image.mediaObject.contentUrl);
         }
         if ("contentUrl" in image && "id" in image && !("@id" in image)) {
-            return `${BASE_URL}${image.contentUrl.slice(1)}`;
+            return toAbsoluteUrl(image.contentUrl);
         }
 
-        return `${BASE_URL}${image.contentUrl.slice(1)}`;
+        return toAbsoluteUrl(image.contentUrl);
     });
     return newImages;
 };

--- a/src/shared/lib/getMediaContent.ts
+++ b/src/shared/lib/getMediaContent.ts
@@ -26,9 +26,9 @@ export const getMediaContent = (
             return toAbsoluteUrl(value.contentUrl);
         }
 
-        if (value.thumbnails
-            && value.thumbnails[size.toLowerCase() as keyof typeof value.thumbnails]) {
-            return toAbsoluteUrl(value.thumbnails[size.toLowerCase() as keyof typeof value.thumbnails]);
+        const sizeKey = size.toLowerCase() as keyof typeof value.thumbnails;
+        if (value.thumbnails && value.thumbnails[sizeKey]) {
+            return toAbsoluteUrl(value.thumbnails[sizeKey]);
         }
 
         // fallback на оригинал, если нужного thumbnail нет


### PR DESCRIPTION
## Summary
- API теперь возвращает абсолютные S3 URL (`https://goodsurfing-public.storage.yandexcloud.net/media/...`) вместо относительных путей (`/media/...`)
- `getMediaContent()` и inline конкатенации ломали URL, добавляя `BASE_URL` к абсолютному адресу, результат: `https://api.../ttps://storage...`
- Добавлен helper `toAbsoluteUrl()` — проверяет, абсолютный ли URL, и не добавляет BASE_URL если да

## Test plan
- [ ] Проверить отображение аватара профиля после загрузки
- [ ] Проверить отображение галереи вакансии
- [ ] Проверить отображение изображений в карточках вакансий/донатов
- [ ] Проверить что старые relative URL (если есть) тоже работают