### PR TITLE
GS-25 follow-up: правки UI по ревью

### DIFF
--- a/src/pages/MembershipPage/ui/ForHost/ForHost.tsx
+++ b/src/pages/MembershipPage/ui/ForHost/ForHost.tsx
@@ -10,9 +10,7 @@ import styles from "./ForHost.module.scss";
 import { useLocale } from "@/app/providers/LocaleProvider";
 import { getPaymentPageUrl, getProfileRolePageUrl } from "@/shared/config/routes/AppUrls";
 import { useGetTariffsQuery } from "@/store/api/membershipApi";
-
-const HOST_TARIFF_CODE = "host_4990";
-const HOST_FALLBACK_PRICE_RUB = 4990;
+import { TARIFF_CODE, TARIFF_FALLBACK_PRICE_RUB } from "@/shared/constants/membership";
 
 interface ForHostProps {
     className?: string;
@@ -25,15 +23,15 @@ export const ForHost: FC<ForHostProps> = (props: ForHostProps) => {
     const { locale } = useLocale();
 
     const { data: tariffs } = useGetTariffsQuery("HOST");
-    const tariff = tariffs?.find((item) => item.code === HOST_TARIFF_CODE);
-    const priceRub = tariff?.priceRub ?? HOST_FALLBACK_PRICE_RUB;
+    const tariff = tariffs?.find((item) => item.code === TARIFF_CODE.HOST);
+    const priceRub = tariff?.priceRub ?? TARIFF_FALLBACK_PRICE_RUB[TARIFF_CODE.HOST];
 
     const handleNavigateToRole = () => {
         navigate(getProfileRolePageUrl(locale));
     };
 
     const handleGetMembership = () => {
-        navigate(`${getPaymentPageUrl(locale)}?tariff=${HOST_TARIFF_CODE}`);
+        navigate(`${getPaymentPageUrl(locale)}?tariff=${TARIFF_CODE.HOST}`);
     };
 
     return (

--- a/src/pages/MembershipPage/ui/ForVolunteer/ForVolunteer.tsx
+++ b/src/pages/MembershipPage/ui/ForVolunteer/ForVolunteer.tsx
@@ -10,9 +10,7 @@ import styles from "./ForVolunteer.module.scss";
 import { getPaymentPageUrl, getProfileRolePageUrl } from "@/shared/config/routes/AppUrls";
 import { useLocale } from "@/app/providers/LocaleProvider";
 import { useGetTariffsQuery } from "@/store/api/membershipApi";
-
-const VOLUNTEER_TARIFF_CODE = "volunteer_990";
-const VOLUNTEER_FALLBACK_PRICE_RUB = 990;
+import { TARIFF_CODE, TARIFF_FALLBACK_PRICE_RUB } from "@/shared/constants/membership";
 
 interface ForVolunteerProps {
     className?: string;
@@ -27,15 +25,15 @@ export const ForVolunteer: FC<ForVolunteerProps> = (
     const { locale } = useLocale();
 
     const { data: tariffs } = useGetTariffsQuery("VOLUNTEER");
-    const tariff = tariffs?.find((item) => item.code === VOLUNTEER_TARIFF_CODE);
-    const priceRub = tariff?.priceRub ?? VOLUNTEER_FALLBACK_PRICE_RUB;
+    const tariff = tariffs?.find((item) => item.code === TARIFF_CODE.VOLUNTEER);
+    const priceRub = tariff?.priceRub ?? TARIFF_FALLBACK_PRICE_RUB[TARIFF_CODE.VOLUNTEER];
 
     const handleNavigateToRole = () => {
         navigate(getProfileRolePageUrl(locale));
     };
 
     const handleGetMembership = () => {
-        navigate(`${getPaymentPageUrl(locale)}?tariff=${VOLUNTEER_TARIFF_CODE}`);
+        navigate(`${getPaymentPageUrl(locale)}?tariff=${TARIFF_CODE.VOLUNTEER}`);
     };
 
     return (

--- a/src/pages/MembershipPage/ui/Header/Header.tsx
+++ b/src/pages/MembershipPage/ui/Header/Header.tsx
@@ -6,23 +6,20 @@ import Button from "@/shared/ui/Button/Button";
 import { useLocale } from "@/app/providers/LocaleProvider";
 import { getPaymentPageUrl } from "@/shared/config/routes/AppUrls";
 import { useGetTariffsQuery } from "@/store/api/membershipApi";
+import { TARIFF_CODE, TARIFF_FALLBACK_PRICE_RUB } from "@/shared/constants/membership";
 import styles from "./Header.module.scss";
-
-const DEFAULT_TARIFF_CODE = "volunteer_990";
-const DEFAULT_FALLBACK_PRICE_RUB = 990;
 
 export const Header = () => {
     const { t } = useTranslation("membership");
     const navigate = useNavigate();
     const { locale } = useLocale();
 
-    const { data: tariffs } = useGetTariffsQuery();
-    const minPriceRub = tariffs && tariffs.length > 0
-        ? Math.min(...tariffs.map((item) => item.priceRub))
-        : DEFAULT_FALLBACK_PRICE_RUB;
+    const { data: tariffs } = useGetTariffsQuery("VOLUNTEER");
+    const tariff = tariffs?.find((item) => item.code === TARIFF_CODE.VOLUNTEER);
+    const priceRub = tariff?.priceRub ?? TARIFF_FALLBACK_PRICE_RUB[TARIFF_CODE.VOLUNTEER];
 
     const handleGetMembership = () => {
-        navigate(`${getPaymentPageUrl(locale)}?tariff=${DEFAULT_TARIFF_CODE}`);
+        navigate(`${getPaymentPageUrl(locale)}?tariff=${TARIFF_CODE.VOLUNTEER}`);
     };
 
     return (
@@ -51,7 +48,7 @@ export const Header = () => {
                     {t("header.Получить членство")}
                 </Button>
                 <span className={styles.price}>
-                    {`от ${minPriceRub.toLocaleString("ru-RU")} руб`}
+                    {`от ${priceRub.toLocaleString("ru-RU")} руб`}
                 </span>
             </div>
         </section>

--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 
 import { MainPageLayout } from "@/widgets/MainPageLayout";
 import Button from "@/shared/ui/Button/Button";
@@ -9,10 +10,13 @@ import { useAuth } from "@/routes/model/guards/AuthProvider";
 import { useCheckoutMembershipMutation } from "@/store/api/membershipApi";
 import { useLocale } from "@/app/providers/LocaleProvider";
 import { getMembershipPageUrl } from "@/shared/config/routes/AppUrls";
+import { TARIFF_CODE } from "@/shared/constants/membership";
 
 import styles from "./PaymentPage.module.scss";
 
-const DEFAULT_TARIFF_CODE = "volunteer_990";
+const isFetchError = (err: unknown): err is FetchBaseQueryError => (
+    typeof err === "object" && err !== null && "status" in err
+);
 
 const PaymentPage: React.FC = () => {
     const { locale } = useLocale();
@@ -23,34 +27,41 @@ const PaymentPage: React.FC = () => {
     const [checkoutMembership, { isLoading }] = useCheckoutMembershipMutation();
     const [paymentUrl, setPaymentUrl] = useState<string | null>(null);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const startedRef = useRef(false);
 
-    const tariffCode = searchParams.get("tariff") || DEFAULT_TARIFF_CODE;
+    const tariffCode = searchParams.get("tariff") || TARIFF_CODE.VOLUNTEER;
 
     useEffect(() => {
         if (!isAuth || !myProfile) {
             navigate(`/${locale}/signin`);
             return;
         }
+        if (startedRef.current) return;
+        startedRef.current = true;
 
-        const initializeCheckout = async () => {
-            try {
-                const result = await checkoutMembership({ tariffCode }).unwrap();
-
+        checkoutMembership({ tariffCode }).unwrap()
+            .then((result) => {
                 if (result.paymentUrl) {
                     setPaymentUrl(result.paymentUrl);
                     window.location.href = result.paymentUrl;
                 } else {
                     setErrorMessage("Не удалось получить ссылку на оплату");
                 }
-            } catch (err: any) {
-                const detail = err?.data?.detail
-                    || err?.data?.title
-                    || err?.data?.error;
-                setErrorMessage(detail || "Произошла ошибка при создании платежа");
-            }
-        };
-
-        initializeCheckout();
+            })
+            .catch((err: unknown) => {
+                if (isFetchError(err) && err.status === 409) {
+                    navigate(getMembershipPageUrl(locale));
+                    return;
+                }
+                const data = isFetchError(err)
+                    ? (err.data as { detail?: string; title?: string } | undefined)
+                    : undefined;
+                setErrorMessage(
+                    data?.detail
+                    || data?.title
+                    || "Произошла ошибка при создании платежа",
+                );
+            });
     }, [isAuth, myProfile, checkoutMembership, navigate, locale, tariffCode]);
 
     const handlePayClick = () => {

--- a/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.tsx
+++ b/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { MainPageLayout } from "@/widgets/MainPageLayout";
@@ -8,9 +8,27 @@ import Preloader from "@/shared/ui/Preloader/Preloader";
 import { useAuth } from "@/routes/model/guards/AuthProvider";
 import { useGetCurrentMembershipQuery } from "@/store/api/membershipApi";
 import { useLocale } from "@/app/providers/LocaleProvider";
-import { getOffersMapPageUrl } from "@/shared/config/routes/AppUrls";
+import { getMyOffersPageUrl, getOffersMapPageUrl } from "@/shared/config/routes/AppUrls";
 
 import styles from "./PaymentSuccessPage.module.scss";
+
+const VOLUNTEER_BENEFITS = [
+    "Неограниченный доступ ко всем направлениям и видам путешествий",
+    "Прямое общение с хостом",
+    "Поддержка в путешествиях со стороны Гудсёрфинга",
+    "Доступ к образовательным материалам",
+    "Поддержка интересного и важного проекта",
+];
+
+const HOST_BENEFITS = [
+    "Неограниченная публикация объявлений на платформе",
+    "Доступ к уникальным чатам платформы",
+    "Метка «Партнёр Гудсёрфинга» в профиле",
+    "Доступ к Академии и офлайн-мероприятиям",
+    "Скидки на платные размещения",
+];
+
+const POLL_INTERVAL_MS = 3000;
 
 const PaymentSuccessPage: React.FC = () => {
     const { locale } = useLocale();
@@ -20,17 +38,18 @@ const PaymentSuccessPage: React.FC = () => {
 
     const paymentId = searchParams.get("payment_id");
 
-    // Обновляем статус членства после успешной оплаты
-    const { isLoading, refetch } = useGetCurrentMembershipQuery(undefined, {
+    const [shouldPoll, setShouldPoll] = useState<boolean>(Boolean(paymentId));
+
+    const { data: membership, isLoading } = useGetCurrentMembershipQuery(undefined, {
         skip: !isAuth,
+        pollingInterval: shouldPoll && isAuth ? POLL_INTERVAL_MS : 0,
     });
 
     useEffect(() => {
-        // Обновляем статус членства при загрузке страницы успеха
-        if (isAuth && paymentId) {
-            refetch();
+        if (membership?.isActive) {
+            setShouldPoll(false);
         }
-    }, [isAuth, paymentId, refetch]);
+    }, [membership?.isActive]);
 
     useEffect(() => {
         if (!isAuth) {
@@ -42,7 +61,7 @@ const PaymentSuccessPage: React.FC = () => {
         return <Preloader />;
     }
 
-    if (isLoading) {
+    if (isLoading && !membership) {
         return (
             <MainPageLayout>
                 <div className={styles.container}>
@@ -53,6 +72,13 @@ const PaymentSuccessPage: React.FC = () => {
     }
 
     const userName = myProfile.firstName || myProfile.email || "пользователь";
+    const isHost = membership?.tariff?.forRole === "HOST";
+    const benefits = isHost ? HOST_BENEFITS : VOLUNTEER_BENEFITS;
+    const ctaText = isHost ? "Перейти к объявлениям" : "Искать путешествия";
+    const ctaUrl = isHost ? getMyOffersPageUrl(locale) : getOffersMapPageUrl(locale);
+    const callToAction = isHost
+        ? "Самое время опубликовать объявление и принять волонтёров."
+        : "Самое время подобрать для себя идеальное путешествие со смыслом в этом году.";
 
     return (
         <MainPageLayout>
@@ -84,26 +110,22 @@ const PaymentSuccessPage: React.FC = () => {
                     <div className={styles.benefits}>
                         <h2 className={styles.benefitsTitle}>Теперь для вас доступно:</h2>
                         <ul className={styles.benefitsList}>
-                            <li>Неограниченный доступ ко всем направлениям и видам путешествий</li>
-                            <li>Прямое общение с хостом</li>
-                            <li>Поддержка в путешествиях со стороны Гудсёрфинга</li>
-                            <li>Доступ к образовательным материалам</li>
-                            <li>Поддержка интересного и важного проекта</li>
+                            {benefits.map((item) => (
+                                <li key={item}>{item}</li>
+                            ))}
                         </ul>
                     </div>
 
-                    <p className={styles.callToAction}>
-                        Самое время подобрать для себя идеальное путешествие со смыслом в этом году.
-                    </p>
+                    <p className={styles.callToAction}>{callToAction}</p>
 
                     <div className={styles.buttonWrapper}>
                         <Button
                             color="BLUE"
                             size="LARGE"
                             variant="FILL"
-                            onClick={() => navigate(getOffersMapPageUrl(locale))}
+                            onClick={() => navigate(ctaUrl)}
                         >
-                            Искать путешествия
+                            {ctaText}
                         </Button>
                     </div>
                 </div>

--- a/src/shared/constants/membership.ts
+++ b/src/shared/constants/membership.ts
@@ -1,0 +1,11 @@
+export const TARIFF_CODE = {
+    VOLUNTEER: "volunteer_990",
+    HOST: "host_4990",
+} as const;
+
+export const TARIFF_FALLBACK_PRICE_RUB = {
+    [TARIFF_CODE.VOLUNTEER]: 990,
+    [TARIFF_CODE.HOST]: 4990,
+} as const;
+
+export type TariffCode = typeof TARIFF_CODE[keyof typeof TARIFF_CODE];

--- a/src/widgets/MainHeader/MainHeader.tsx
+++ b/src/widgets/MainHeader/MainHeader.tsx
@@ -80,7 +80,7 @@ const MainHeader: FC = () => {
                                     className={styles.membership}
                                     disabled={hasMembership}
                                 >
-                                    {hasMembership ? "Членство получено" : "Членство"}
+                                    {hasMembership ? "Членство активно" : "Членство"}
                                 </Button>
                             </LocaleLink>
                         </>


### PR DESCRIPTION
Follow-up к [#217](https://github.com/Goodsurfing/gs-frontend/pull/217). Закрывает замечания из ревью.

## Critical

- **PaymentPage**: добавлен `useRef`-guard от повторного вызова `checkoutMembership` при любом ре-рендере / смене deps (раньше каждое изменение `tariffCode`/`locale` создавало дубль PENDING-Membership в БД).
- **PaymentPage**: 409 (`MembershipAlreadyActiveException`) больше не отображается как generic «Произошла ошибка» — редирект на `/membership`.
- **PaymentPage**: `err: any` → типизация через `FetchBaseQueryError` с type-guard.

## Major

- **PaymentSuccessPage**: бенефиты и CTA теперь разные для `VOLUNTEER` и `HOST` (раньше host видел «Искать путешествия» и волонтёрский онбординг).
- **PaymentSuccessPage**: однократный `refetch()` заменён на `pollingInterval: 3s` с остановкой как только `isActive: true`. Это защищает от race condition, когда Paygine webhook ещё не успел долететь до бэка.
- **Header (hero)**: цена считается не из `Math.min` по всем тарифам, а из тарифа `volunteer_990` — хедер уже семантически про волонтёра, плюс это исключает рассинхрон при появлении промо-тарифов.

## Minor

- Новый `src/shared/constants/membership.ts`: `TARIFF_CODE` + `TARIFF_FALLBACK_PRICE_RUB` — единый источник. Убран дубль `volunteer_990`/`host_4990`/`990`/`4990` из 4 файлов.
- **MainHeader**: «Членство получено» → «Членство активно».

## Что осталось (не в этом PR)

- **Оптимизация запросов /tariffs.** Сейчас `MembershipPage` делает 2 запроса (`?forRole=VOLUNTEER` и `?forRole=HOST`). Слить в один на уровне `MembershipPage` и пробросить пропсами в `ForVolunteer`/`ForHost` — хороший next step, но это отдельная переделка архитектуры страницы.

## Test plan

- [x] Локально: `/membership` отрисовывает цены 990 / 4 990 / «от 990» из API
- [x] Fallback цен работает (отдельно подтверждено, что без API показываются 990/4990 из `TARIFF_FALLBACK_PRICE_RUB`)
- [ ] Стейдж: проверить что повторный checkout одним юзером редиректит на `/membership`, а не показывает ошибку
- [ ] Стейдж: после успешной оплаты host-тарифа — увидеть «Перейти к объявлениям» (не «Искать путешествия»)