### PR TITLE
fix(payment): fallback-текст при недоступности Paygine

### DIFF
--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
@@ -53,14 +53,23 @@ const PaymentPage: React.FC = () => {
                     navigate(getMembershipPageUrl(locale));
                     return;
                 }
-                const data = isFetchError(err)
-                    ? (err.data as { detail?: string; title?: string } | undefined)
+
+                const status = isFetchError(err) ? err.status : null;
+                const data = isFetchError(err) && typeof err.data === "object" && err.data !== null
+                    ? (err.data as { detail?: string; title?: string })
                     : undefined;
-                setErrorMessage(
-                    data?.detail
-                    || data?.title
-                    || "Произошла ошибка при создании платежа",
-                );
+
+                // 502/503/504 или сетевой сбой — бэк отдаёт честное сообщение в detail,
+                // но если пришла сырая HTML-страница (например, таймаут Traefik),
+                // err.data будет строкой и мы покажем свой дружелюбный текст.
+                const providerUnavailable = status === 502 || status === 503 || status === 504
+                    || status === "FETCH_ERROR" || status === "TIMEOUT_ERROR";
+
+                const fallback = providerUnavailable
+                    ? "Сервис оплаты временно недоступен. Попробуйте позже."
+                    : "Произошла ошибка при создании платежа";
+
+                setErrorMessage(data?.detail || data?.title || fallback);
             });
     }, [isAuth, myProfile, checkoutMembership, navigate, locale, tariffCode]);
 


### PR DESCRIPTION
## Summary

После бэкенд-фикса [gs-backend#140](https://github.com/Goodsurfing/gs-backend/pull/140) сервер отдаёт 502 JSON при сбое Paygine. На стейдже такой ответ выглядел бы как «Сервис оплаты временно недоступен: …» из detail — но закрываем два пограничных случая, когда detail отсутствует (raw HTML-страница от обратного прокси, сетевой таймаут RTK Query).

### Изменения
- `src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx` — для статусов 502/503/504 и FETCH_ERROR/TIMEOUT_ERROR показываем понятный fallback. `detail`/`title` из бэка по-прежнему приоритетны.

## Test plan
- [ ] Открыть `/ru/payment?tariff=volunteer_990` на стейдже после раскатки fx бэка — показать текст из detail: «Сервис оплаты временно недоступен: Ошибка Paygine (код: 109): Invalid signature»
- [ ] Имитировать таймаут (DevTools, throttle offline) — показать fallback «Сервис оплаты временно недоступен. Попробуйте позже.»
- [ ] Кейс 201 c paymentUrl работает как прежде (редирект на страницу Paygine).