### PR TITLE
CI: deploy to YC staging on push to master

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,78 @@
+name: Deploy to prod
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "deploy" to confirm prod deploy'
+        required: true
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ${{ vars.PROD_REGISTRY }}
+  IMAGE: gs-frontend
+  VITE_API_BASE_URL: https://api.goodsurfing.org
+  VITE_MAIN_URL: https://goodsurfing.org
+  VITE_VKID_CLIENT_ID: "54505769"
+
+jobs:
+  build-and-deploy:
+    if: github.event_name == 'push' || inputs.confirm == 'deploy'
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to CR
+        run: |
+          echo '${{ secrets.YC_SA_KEY_JSON_PROD }}' > /tmp/sa.json
+          docker run --rm -v /tmp/sa.json:/key.json cr.yandex/yc/yc:latest \
+            --service-account-key /key.json iam create-token \
+            | docker login -u iam --password-stdin cr.yandex
+          rm /tmp/sa.json
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            VITE_API_BASE_URL=${{ env.VITE_API_BASE_URL }}
+            VITE_MAIN_URL=${{ env.VITE_MAIN_URL }}
+            VITE_VKID_CLIENT_ID=${{ env.VITE_VKID_CLIENT_ID }}
+            VITE_API_YANDEX_KEY=${{ secrets.YANDEX_MAPS_API_KEY }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE }}:prod
+            ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-${{ github.sha }}
+          push: true
+          cache-from: type=gha,scope=gs-frontend-prod
+          cache-to: type=gha,mode=max,scope=gs-frontend-prod
+
+      - name: Deploy
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ubuntu
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/gs
+            sudo docker compose pull frontend
+            sudo docker compose up -d frontend
+
+      - name: Smoke test
+        run: |
+          set -e
+          for i in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 https://goodsurfing.org/)
+            if [ "$code" = "200" ]; then echo "OK"; exit 0; fi
+            sleep 15
+          done
+          exit 1

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,78 @@
+name: Deploy to staging
+
+on:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+env:
+  REGISTRY: cr.yandex/crpspj7jl594r3ekjv50
+  IMAGE: gs-frontend
+  # build-time env baked into the bundle
+  VITE_API_BASE_URL: https://api-staging.goodsurfing.org
+  VITE_MAIN_URL: https://staging.goodsurfing.org
+  VITE_VKID_CLIENT_ID: "54505769"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to Yandex Container Registry
+        run: |
+          echo '${{ secrets.YC_SA_KEY_JSON }}' > /tmp/sa.json
+          docker run --rm -v /tmp/sa.json:/key.json cr.yandex/yc/yc:latest \
+            --service-account-key /key.json iam create-token \
+            | docker login -u iam --password-stdin cr.yandex
+          rm /tmp/sa.json
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            VITE_API_BASE_URL=${{ env.VITE_API_BASE_URL }}
+            VITE_MAIN_URL=${{ env.VITE_MAIN_URL }}
+            VITE_VKID_CLIENT_ID=${{ env.VITE_VKID_CLIENT_ID }}
+            VITE_API_YANDEX_KEY=${{ secrets.YANDEX_MAPS_API_KEY }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE }}:staging
+            ${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-${{ github.sha }}
+          push: true
+          cache-from: type=gha,scope=gs-frontend
+          cache-to: type=gha,mode=max,scope=gs-frontend
+
+      - name: Deploy to VM
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ubuntu
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/gs
+            sudo docker compose pull frontend
+            sudo docker compose up -d frontend
+            sleep 3
+            sudo docker compose ps frontend
+
+      - name: Smoke test
+        run: |
+          set -e
+          for i in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 https://staging.goodsurfing.org/)
+            if [ "$code" = "200" ]; then echo "frontend OK"; exit 0; fi
+            echo "attempt $i → $code"
+            sleep 10
+          done
+          echo "Frontend smoke test failed"
+          exit 1

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,63 @@
+name: Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: 'Target environment'
+        type: choice
+        options: [staging, prod]
+        required: true
+      sha:
+        description: 'Commit SHA to rollback to (must exist as sha-<value> tag in CR)'
+        required: true
+
+concurrency:
+  group: rollback-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env }}
+    steps:
+      - name: Resolve registry
+        id: reg
+        run: |
+          if [ "${{ inputs.env }}" = "prod" ]; then
+            echo "registry=${{ vars.PROD_REGISTRY }}" >> $GITHUB_OUTPUT
+            echo "env_tag=prod" >> $GITHUB_OUTPUT
+          else
+            echo "registry=cr.yandex/crpspj7jl594r3ekjv50" >> $GITHUB_OUTPUT
+            echo "env_tag=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to CR
+        run: |
+          KEY='${{ inputs.env == ''prod'' && secrets.YC_SA_KEY_JSON_PROD || secrets.YC_SA_KEY_JSON }}'
+          echo "$KEY" > /tmp/sa.json
+          docker run --rm -v /tmp/sa.json:/key.json cr.yandex/yc/yc:latest \
+            --service-account-key /key.json iam create-token \
+            | docker login -u iam --password-stdin cr.yandex
+          rm /tmp/sa.json
+
+      - name: Retag sha-<sha> as :<env>
+        run: |
+          REG="${{ steps.reg.outputs.registry }}"
+          TAG="${{ steps.reg.outputs.env_tag }}"
+          SHA="${{ inputs.sha }}"
+          docker pull "$REG/gs-frontend:sha-$SHA"
+          docker tag  "$REG/gs-frontend:sha-$SHA" "$REG/gs-frontend:$TAG"
+          docker push "$REG/gs-frontend:$TAG"
+
+      - name: SSH pull+up on VM
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ inputs.env == 'prod' && secrets.PROD_HOST || secrets.STAGING_HOST }}
+          username: ubuntu
+          key: ${{ inputs.env == 'prod' && secrets.PROD_SSH_KEY || secrets.STAGING_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/gs
+            sudo docker compose pull frontend
+            sudo docker compose up -d frontend

--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
@@ -53,14 +53,23 @@ const PaymentPage: React.FC = () => {
                     navigate(getMembershipPageUrl(locale));
                     return;
                 }
-                const data = isFetchError(err)
-                    ? (err.data as { detail?: string; title?: string } | undefined)
+
+                const status = isFetchError(err) ? err.status : null;
+                const data = isFetchError(err) && typeof err.data === "object" && err.data !== null
+                    ? (err.data as { detail?: string; title?: string })
                     : undefined;
-                setErrorMessage(
-                    data?.detail
-                    || data?.title
-                    || "Произошла ошибка при создании платежа",
-                );
+
+                // 502/503/504 или сетевой сбой — бэк отдаёт честное сообщение в detail,
+                // но если пришла сырая HTML-страница (например, таймаут Traefik),
+                // err.data будет строкой и мы покажем свой дружелюбный текст.
+                const providerUnavailable = status === 502 || status === 503 || status === 504
+                    || status === "FETCH_ERROR" || status === "TIMEOUT_ERROR";
+
+                const fallback = providerUnavailable
+                    ? "Сервис оплаты временно недоступен. Попробуйте позже."
+                    : "Произошла ошибка при создании платежа";
+
+                setErrorMessage(data?.detail || data?.title || fallback);
             });
     }, [isAuth, myProfile, checkoutMembership, navigate, locale, tariffCode]);
 


### PR DESCRIPTION
## Summary
Новый GitHub Actions workflow `deploy-staging.yml`: при каждом push в `master` билдится образ `linux/amd64` с помощью buildx + GHA cache, пушится в YC Container Registry (`cr.yandex/crpspj7jl594r3ekjv50`), затем SSH-заливается на staging VM через `docker compose pull && up -d`, и прогоняются smoke-тесты публичного эндпоинта.

Теги, которые попадают в CR:
- `staging` — всегда последний коммит master
- `sha-<commit>` — для одной-командного rollback

## Pre-requisites (уже сделано)
- Staging VM `111.88.243.212`, traefik/Let's Encrypt работает
- SA `gs-staging-ci-pusher` с ролью `container-registry.images.pusher`
- Secrets: `YC_SA_KEY_JSON`, `STAGING_SSH_KEY`, `STAGING_HOST`
- Concurrency-group — один deploy на окружение одновременно

## Test plan
- [ ] Ручной запуск `workflow_dispatch` → passes
- [ ] Коммит в master → деплой автоматически, smoke-test зелёный
- [ ] Сломать healthz искусственно → smoke-test красный, prev version остаётся