### PR TITLE
ci(dev): исправить логин в Container Registry

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,12 +26,9 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Login to Yandex Container Registry
-        run: |
-          echo '${{ secrets.YC_SA_KEY_JSON }}' > /tmp/sa.json
-          docker run --rm -v /tmp/sa.json:/key.json cr.yandex/yc/yc:latest \
-            --service-account-key /key.json iam create-token \
-            | docker login -u iam --password-stdin cr.yandex
-          rm /tmp/sa.json
+        uses: yc-actions/yc-cr-login@v3
+        with:
+          yc-sa-json-credentials: ${{ secrets.YC_SA_KEY_JSON }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Шаг `Login to Yandex Container Registry` в `.github/workflows/deploy-dev.yml` всегда падал — образ `cr.yandex/yc/yc:latest` отсутствует ("repository yc/yc not found"), предыдущие запуски `deploy-dev.yml` не завершались успехом.

Заменено на официальное действие `yc-actions/yc-cr-login@v3`, которое корректно логинится в CR по SA-ключу.

## Test plan
- [ ] После мерджа запустить `gh workflow run deploy-dev.yml --repo Goodsurfing/gs-frontend --ref master`
- [ ] Workflow успешно проходит до шагов build/push и деплоя на dev VM
- [ ] `curl -o /dev/null -w '%{http_code}' https://dev.goodsurfing.org/healthz` == 200

Аналогичный фикс на gs-backend: Goodsurfing/gs-backend#143