### PR TITLE
ci: фикс логина в Yandex CR и ложных фейлов rollback

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -29,13 +29,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
 
-      - name: Login to CR
-        run: |
-          echo '${{ secrets.YC_SA_KEY_JSON_PROD }}' > /tmp/sa.json
-          docker run --rm -v /tmp/sa.json:/key.json cr.yandex/yc/yc:latest \
-            --service-account-key /key.json iam create-token \
-            | docker login -u iam --password-stdin cr.yandex
-          rm /tmp/sa.json
+      - name: Login to Yandex Container Registry
+        uses: yc-actions/yc-cr-login@v3
+        with:
+          yc-sa-json-credentials: ${{ secrets.YC_SA_KEY_JSON_PROD }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,12 +27,9 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Login to Yandex Container Registry
-        run: |
-          echo '${{ secrets.YC_SA_KEY_JSON }}' > /tmp/sa.json
-          docker run --rm -v /tmp/sa.json:/key.json cr.yandex/yc/yc:latest \
-            --service-account-key /key.json iam create-token \
-            | docker login -u iam --password-stdin cr.yandex
-          rm /tmp/sa.json
+        uses: yc-actions/yc-cr-login@v3
+        with:
+          yc-sa-json-credentials: ${{ secrets.YC_SA_KEY_JSON }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -12,14 +12,13 @@ on:
         description: 'Commit SHA to rollback to (must exist as sha-<value> tag in CR)'
         required: true
 
-concurrency:
-  group: rollback-${{ inputs.env }}
-  cancel-in-progress: false
-
 jobs:
   rollback:
     runs-on: ubuntu-latest
     environment: ${{ inputs.env }}
+    concurrency:
+      group: rollback-${{ inputs.env }}
+      cancel-in-progress: false
     steps:
       - name: Resolve registry
         id: reg
@@ -32,14 +31,10 @@ jobs:
             echo "env_tag=staging" >> $GITHUB_OUTPUT
           fi
 
-      - name: Login to CR
-        run: |
-          KEY='${{ inputs.env == ''prod'' && secrets.YC_SA_KEY_JSON_PROD || secrets.YC_SA_KEY_JSON }}'
-          echo "$KEY" > /tmp/sa.json
-          docker run --rm -v /tmp/sa.json:/key.json cr.yandex/yc/yc:latest \
-            --service-account-key /key.json iam create-token \
-            | docker login -u iam --password-stdin cr.yandex
-          rm /tmp/sa.json
+      - name: Login to Yandex Container Registry
+        uses: yc-actions/yc-cr-login@v3
+        with:
+          yc-sa-json-credentials: ${{ inputs.env == 'prod' && secrets.YC_SA_KEY_JSON_PROD || secrets.YC_SA_KEY_JSON }}
 
       - name: Retag sha-<sha> as :<env>
         run: |


### PR DESCRIPTION
## Что

- Заменил ручной \`docker run cr.yandex/yc/yc:latest\` на \`yc-actions/yc-cr-login@v3\` в \`deploy-staging.yml\`, \`deploy-prod.yml\`, \`rollback.yml\`.
- Перенёс блок \`concurrency\` внутрь job \`rollback\` в \`rollback.yml\`.

## Почему

**1. Логин в CR сломан.** Образ \`cr.yandex/yc/yc:latest\` был удалён из публичного Container Registry (\`repository yc/yc not found\`), из-за чего \`deploy-staging.yml\` падает на каждый push в master на шаге «Login to Yandex Container Registry». \`yc-actions/yc-cr-login@v3\` — официальный экшен, не зависящий от внешних образов.

**2. Rollback светит ложным фейлом.** Верхнеуровневый \`concurrency.group: rollback-\${{ inputs.env }}\` вычисляется при парсинге workflow на каждый push. На push-событии \`inputs\` не существует → startup_failure → 0-секундный run с \`failure\` и уведомление. Внутри job выражение вычисляется только при реальном запуске — т.е. только при \`workflow_dispatch\`.

## Проверка

- [ ] Merge → push в master запускает \`Deploy to staging\`, шаг логина проходит.
- [ ] Уведомление о «\`.github/workflows/rollback.yml\` failed (0s)» больше не приходит.
- [ ] Ручной запуск \`Rollback\` через UI всё ещё работает.