### PR TITLE
ci(staging): смоук-тест ходит в /healthz в обход IAP

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -e
           for i in 1 2 3 4 5; do
-            code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 https://staging.goodsurfing.org/)
+            code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 https://staging.goodsurfing.org/healthz)
             if [ "$code" = "200" ]; then echo "frontend OK"; exit 0; fi
             echo "attempt $i → $code"
             sleep 10


### PR DESCRIPTION
## Что

Смоук-тест в \`deploy-staging.yml\` теперь дёргает \`https://staging.goodsurfing.org/healthz\` вместо корня \`/\`.

## Почему

Staging закрыт forward-auth через yandex-iap. Неавторизованный \`GET /\` возвращает 302 на страницу логина — смоук всегда фейлится, хотя фронт задеплоен нормально. \`/healthz\` у nginx/IAP в bypass-списке и отвечает 200. Ровно так же сделано в \`deploy-dev.yml\`.