### PR TITLE
fix(api): нормализовать VITE_API_BASE_URL (trailing slash)

### DIFF
--- a/src/shared/constants/api/index.ts
+++ b/src/shared/constants/api/index.ts
@@ -1,14 +1,16 @@
-export const BASE_URL = `${import.meta.env.VITE_API_BASE_URL}`;
+const API_ORIGIN = `${import.meta.env.VITE_API_BASE_URL}`.replace(/\/+$/, "");
+
+export const BASE_URL = API_ORIGIN;
 export const BASE_URI = "/api/v1/";
-export const API_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}api/v1/`;
-export const API_BASE_URL_V2 = `${import.meta.env.VITE_API_BASE_URL}api/v2/`;
-export const API_BASE_URL_V3 = `${import.meta.env.VITE_API_BASE_URL}api/v3/`;
-export const BASE_VK_URI = `${import.meta.env.VITE_API_BASE_URL}api/vk/`;
-export const API_ADMIN_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}admin/v3/`;
-export const API_ORGANIZATIONS_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}api/organizations/`;
-export const API_VACANCY_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}api/vacancies/`;
-export const API_USER_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}api/users/`;
-export const API_MEDIA_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}api/media_objects/`;
-export const API_TRANSLATION_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}api/v1/translation`;
+export const API_BASE_URL = `${API_ORIGIN}/api/v1/`;
+export const API_BASE_URL_V2 = `${API_ORIGIN}/api/v2/`;
+export const API_BASE_URL_V3 = `${API_ORIGIN}/api/v3/`;
+export const BASE_VK_URI = `${API_ORIGIN}/api/vk/`;
+export const API_ADMIN_BASE_URL = `${API_ORIGIN}/admin/v3/`;
+export const API_ORGANIZATIONS_BASE_URL = `${API_ORIGIN}/api/organizations/`;
+export const API_VACANCY_BASE_URL = `${API_ORIGIN}/api/vacancies/`;
+export const API_USER_BASE_URL = `${API_ORIGIN}/api/users/`;
+export const API_MEDIA_BASE_URL = `${API_ORIGIN}/api/media_objects/`;
+export const API_TRANSLATION_BASE_URL = `${API_ORIGIN}/api/v1/translation`;
 export const API_YANDEX_BASE_URL = "https://geocode-maps.yandex.ru/1.x/";
 export const MAIN_URL = `${import.meta.env.VITE_MAIN_URL}`;


### PR DESCRIPTION
## Проблема

На staging фронт ходил по битому URL:

```
https://api-staging.goodsurfing.orgapi/v3/category/list?lang=ru
```

— домен и путь склеились без слеша.

## Причина

В `src/shared/constants/api/index.ts` все константы собирались так:

```ts
export const API_BASE_URL_V3 = `${import.meta.env.VITE_API_BASE_URL}api/v3/`;
```

Код рассчитывал, что `VITE_API_BASE_URL` кончается на `/`. Локальный `.env` так и задан (`http://localhost/`), а во всех трёх CI-workflow значение без слеша:

- `deploy-staging.yml`: `https://api-staging.goodsurfing.org`
- `deploy-dev.yml`: `https://api-dev.goodsurfing.org`
- `deploy-prod.yml`: `https://api.goodsurfing.org`

## Решение

Нормализуем в одном месте: срезаем любой trailing slash у `VITE_API_BASE_URL` и явно добавляем `/` перед путём. Теперь неважно, со слешем задан env или без — URL собирается корректно.

## Test plan

- [ ] После мерджа на staging проверить запрос `GET /api/v3/category/list?lang=ru` в DevTools — должен идти по адресу `https://api-staging.goodsurfing.org/api/v3/category/list?lang=ru`
- [ ] Локально запустить dev-сервер, убедиться что запросы по-прежнему идут в `http://localhost/api/...`