### PR TITLE
fix(api): слать cookies на cross-origin API через credentials: include

### DIFF
--- a/src/entities/Chat/lib/useGetChatListData.tsx
+++ b/src/entities/Chat/lib/useGetChatListData.tsx
@@ -33,6 +33,7 @@ export const useGetChatListData = (
             const chatListResponse = await fetch(
                 `${API_BASE_URL}personal/chats${queryPart}`,
                 {
+                    credentials: "include",
                     headers: {
                         Authorization: `Bearer ${token}`,
                     },

--- a/src/entities/Gallery/model/services/galleryApi.ts
+++ b/src/entities/Gallery/model/services/galleryApi.ts
@@ -13,7 +13,7 @@ import { RootState } from "@/store/store";
 export const galleryApi = createApi({
     reducerPath: "galleryApi",
     baseQuery: fetchBaseQuery({
-        credentials: "same-origin",
+        credentials: "include",
         baseUrl: `${API_BASE_URL}`,
         prepareHeaders: (headers, { getState }) => {
             const state = getState() as RootState;

--- a/src/features/VerifyEmailForm/ui/VerifyEmailForm.tsx
+++ b/src/features/VerifyEmailForm/ui/VerifyEmailForm.tsx
@@ -53,6 +53,7 @@ export const VerifyEmailForm = () => {
         try {
             const response = await fetch(`${API_BASE_URL_V3}send-email`, {
                 method: "POST",
+                credentials: "include",
                 headers: {
                     "Content-Type": "application/json",
                     Authorization: `Bearer ${token}`,

--- a/src/pages/VerifyEmailHashPage/ui/VerifyEmailHashPage.tsx
+++ b/src/pages/VerifyEmailHashPage/ui/VerifyEmailHashPage.tsx
@@ -30,6 +30,7 @@ const VerifyEmailHashPage = () => {
         try {
             const response = await fetch(`${API_BASE_URL_V3}verify/email/${id}`, {
                 method: "GET",
+                credentials: "include",
                 headers: {
                     "Content-Type": "application/json",
                     Authorization: `Bearer ${token}`,

--- a/src/shared/api/baseQuery/baseQuery.ts
+++ b/src/shared/api/baseQuery/baseQuery.ts
@@ -7,6 +7,7 @@ import { TOKEN_LOCALSTORAGE_KEY } from "@/shared/constants/localstorage";
 
 export const baseQuery = fetchBaseQuery({
     baseUrl: API_BASE_URL,
+    credentials: "include",
     prepareHeaders: (headers, { getState }) => {
         const state = getState() as RootState;
         const token = state.user.authData?.token
@@ -24,6 +25,7 @@ export const baseQuery = fetchBaseQuery({
 
 export const baseQueryAcceptJson = fetchBaseQuery({
     baseUrl: API_BASE_URL,
+    credentials: "include",
     prepareHeaders: (headers, { getState }) => {
         const state = getState() as RootState;
         const token = state.user.authData?.token
@@ -45,6 +47,7 @@ export const baseQueryAcceptJson = fetchBaseQuery({
 
 export const baseQueryV3 = fetchBaseQuery({
     baseUrl: API_BASE_URL_V3,
+    credentials: "include",
     prepareHeaders: (headers, { getState }) => {
         const state = getState() as RootState;
         const token = state.user.authData?.token
@@ -65,6 +68,7 @@ export const baseQueryV3 = fetchBaseQuery({
 
 export const baseAdminQueryAcceptJson = fetchBaseQuery({
     baseUrl: API_ADMIN_BASE_URL,
+    credentials: "include",
     prepareHeaders: (headers, { getState }) => {
         const state = getState() as RootState;
         const token = state.user.authData?.token

--- a/src/shared/hooks/files/useUploadFile.tsx
+++ b/src/shared/hooks/files/useUploadFile.tsx
@@ -32,6 +32,7 @@ const sendRequestForGenerateUploadLink = async (
     formData.append("file", data);
     const response = await fetch(`${API_BASE_URL}media_objects`, {
         method: "POST",
+        credentials: "include",
         headers: new Headers({
             Accept: "application/ld+json",
             Authorization: `Bearer ${token}`,

--- a/src/store/api/authApi.ts
+++ b/src/store/api/authApi.ts
@@ -21,6 +21,7 @@ export const authApi = createApi({
     reducerPath: "authApi",
     baseQuery: fetchBaseQuery({
         baseUrl: API_BASE_URL,
+        credentials: "include",
         prepareHeaders: (headers) => {
             headers.set("Content-Type", "application/json");
             headers.set("accept", "application/json");

--- a/src/store/api/localeApi.ts
+++ b/src/store/api/localeApi.ts
@@ -8,6 +8,7 @@ export const localeApi = createApi({
     reducerPath: "localeApi",
     baseQuery: fetchBaseQuery({
         baseUrl: API_TRANSLATION_BASE_URL,
+        credentials: "include",
         prepareHeaders: (headers) => {
             const token = localStorage.getItem(TOKEN_LOCALSTORAGE_KEY);
 

--- a/src/store/api/organizationApi.ts
+++ b/src/store/api/organizationApi.ts
@@ -10,6 +10,7 @@ export const organizationApi = createApi({
     reducerPath: "organizationApi",
     baseQuery: fetchBaseQuery({
         baseUrl: API_ORGANIZATIONS_BASE_URL,
+        credentials: "include",
         prepareHeaders(headers) {
             const token = localStorage.getItem(TOKEN_LOCALSTORAGE_KEY);
 

--- a/src/store/api/userOrganizationInfoApi.ts
+++ b/src/store/api/userOrganizationInfoApi.ts
@@ -7,6 +7,7 @@ export const userOrganizationInfoApi = createApi({
     reducerPath: "userOrganizationInfoApi",
     baseQuery: fetchBaseQuery({
         baseUrl: API_ORGANIZATIONS_BASE_URL,
+        credentials: "include",
         prepareHeaders: (headers) => {
             const token = localStorage.getItem(TOKEN_LOCALSTORAGE_KEY);
             if (token) {


### PR DESCRIPTION
## Проблема

Фронт и API на staging/dev живут на разных субдоменах одного eTLD+1:

- `https://staging.goodsurfing.org` ↔ `https://api-staging.goodsurfing.org`
- `https://dev.goodsurfing.org` ↔ `https://api-dev.goodsurfing.org`

Это cross-origin. Без `credentials: 'include'` браузер **не отправляет cookies cross-origin**, даже same-site. Из-за этого IAP-сессионная cookie не долетает до бэкенда, IAP получает анонимный запрос и отдаёт `302 /auth/login` без CORS-заголовков — в результате публичные эндпойнты API (например, карта вакансий) падают с CORS-ошибкой прямо в браузере.

На проде IAP нет, запрос анонимный по задумке, и текущий дефолт `credentials: 'same-origin'` работает. На staging/dev — ломается.

## Что поменялось

`credentials: 'include'` добавлен во все HTTP-клиенты, которые ходят на наш API:

- `src/shared/api/baseQuery/baseQuery.ts` — четыре главных RTK-baseQuery (`baseQuery`, `baseQueryV3`, `baseQueryAcceptJson`, `baseAdminQueryAcceptJson`)
- `src/store/api/authApi.ts`, `organizationApi.ts`, `userOrganizationInfoApi.ts`, `localeApi.ts`
- `src/entities/Gallery/model/services/galleryApi.ts` — заменил `"same-origin"` на `"include"`
- Сырые `fetch()` на backend: `useUploadFile`, `useGetChatListData`, `VerifyEmailForm`, `VerifyEmailHashPage`

Не трогал: fetch на Yandex Maps, VK, SVG-ассеты — там cookies не нужны.

## Сопряжённые PR

Сам по себе этот патч недостаточен — нужны ещё:

- [voknil/yandex-iap#1](https://github.com/voknil/yandex-iap/pull/1): IAP теперь отдаёт `Access-Control-Allow-Origin` (reflect Origin для same-site с `COOKIE_DOMAIN`), `Access-Control-Allow-Credentials: true` и обрабатывает preflight OPTIONS. Плюс configurable `COOKIE_SAMESITE=none` через env.
- PR в `gs-backend` (добавит `allow_credentials: true` и расширит `CORS_ALLOW_ORIGIN` regex на субдомены `goodsurfing.org`).
- PR в `gs-infra` (включает `COOKIE_SAMESITE=none` в iap.env на staging/dev).

## Проверка

Локально ничего наблюдать нельзя: на `localhost:3000` → `localhost` всё same-origin, `credentials: 'include'` эффекта не даёт. Полный тест — на staging после мерджа всех четырёх PR.