### PR TITLE
fix(menu): ссылки в меню «Поддержать» — /membership и /npo

### DIFF
--- a/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.tsx
+++ b/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.tsx
@@ -274,7 +274,7 @@ export const MainHeaderNav = () => {
                 >
                     <Link
                         className={styles.dropdownLink}
-                        to={getMainPageUrl(locale)}
+                        to={getMembershipPageUrl(locale)}
                     >
                         {t("main.welcome.header.donation.support-goodsurfing")}
                     </Link>
@@ -286,7 +286,7 @@ export const MainHeaderNav = () => {
                     </Link>
                     <Link
                         className={styles.dropdownLink}
-                        to={getDonationReports(locale)}
+                        to={getNPOPageUrl(locale)}
                     >
                         {t("main.welcome.header.donation.public-reports")}
                     </Link>

--- a/src/widgets/MobileHeader/ui/MobileHeader/MobileHeader.tsx
+++ b/src/widgets/MobileHeader/ui/MobileHeader/MobileHeader.tsx
@@ -259,7 +259,7 @@ const MobileHeader: FC = () => {
                 >
                     <Link
                         className={styles.dropdownLink}
-                        to={getMainPageUrl(locale)}
+                        to={getMembershipPageUrl(locale)}
                     >
                         {t("main.welcome.header.donation.support-goodsurfing")}
                     </Link>
@@ -271,7 +271,7 @@ const MobileHeader: FC = () => {
                     </Link>
                     <Link
                         className={styles.dropdownLink}
-                        to={getDonationReports(locale)}
+                        to={getNPOPageUrl(locale)}
                     >
                         {t("main.welcome.header.donation.public-reports")}
                     </Link>


### PR DESCRIPTION
## Что изменилось

- «Поддержать Гудсёрфинг» → `/ru/membership` (раньше вела на главную)
- «Публичная отчётность» → `/ru/npo` (раньше вела на `/donation-reports`)

Исправлено в десктопном (`MainHeaderNav`) и мобильном (`MobileHeader`) хедере.

## Задачи

Closes GS-44, GS-7