### PR TITLE
fix(host): убрать ссылки на Facebook/Instagram со страницы хоста

### DIFF
--- a/src/features/HostDescription/ui/HostDescriptionSocial/HostDescriptionSocial.module.scss
+++ b/src/features/HostDescription/ui/HostDescriptionSocial/HostDescriptionSocial.module.scss
@@ -8,6 +8,13 @@
     .instagram {
         margin-top: 1.875rem;
     }
+
+    .bannedNotice {
+        grid-column: 1 / -1;
+        margin-top: 0.75rem;
+        font-size: 0.8125rem;
+        color: #8494A1;
+    }
 }
 
 @media (max-width: 800px) {

--- a/src/features/HostDescription/ui/HostDescriptionSocial/HostDescriptionSocial.tsx
+++ b/src/features/HostDescription/ui/HostDescriptionSocial/HostDescriptionSocial.tsx
@@ -5,8 +5,6 @@ import cn from "classnames";
 import { InputControl } from "@/shared/ui/InputControl/InputControl";
 
 import {
-    facebookIcon,
-    instaIcon,
     telegramIcon,
     vkIcon,
 } from "@/shared/data/icons/socialIcons";
@@ -31,23 +29,6 @@ export const HostDescriptionSocial = memo((props: HostDescriptionSocialProps) =>
                 type="url"
             />
             <InputControl
-                label="Facebook"
-                img={facebookIcon}
-                id="fb"
-                name="socialMedia.facebook"
-                control={control}
-                type="url"
-            />
-            <InputControl
-                className={styles.telegram}
-                label="Instagram"
-                img={instaIcon}
-                id="inst"
-                name="socialMedia.instagram"
-                control={control}
-                type="url"
-            />
-            <InputControl
                 className={styles.instagram}
                 label="Telegram"
                 img={telegramIcon}
@@ -56,6 +37,9 @@ export const HostDescriptionSocial = memo((props: HostDescriptionSocialProps) =>
                 control={control}
                 type="url"
             />
+            <p className={styles.bannedNotice}>
+                Ссылки на Facebook и Instagram не отображаются на публичной странице — эти сервисы заблокированы на территории РФ.
+            </p>
         </div>
     );
 });

--- a/src/pages/HostPersonalPage/ui/HostlHeaderCard/HostlHeaderCard.tsx
+++ b/src/pages/HostPersonalPage/ui/HostlHeaderCard/HostlHeaderCard.tsx
@@ -8,8 +8,6 @@ import { getMediaContent } from "@/shared/lib/getMediaContent";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
 import Button from "@/shared/ui/Button/Button";
 import {
-    facebookIcon,
-    instaIcon,
     telegramIcon,
     vkIcon,
 } from "@/shared/data/icons/socialIcons";
@@ -30,7 +28,7 @@ export const HostlHeaderCard: FC<HostlHeaderCardProps> = memo(
     (props: HostlHeaderCardProps) => {
         const {
             host: {
-                name, type, address, avatar, vk, telegram, facebook, instagram,
+                name, type, address, avatar, vk, telegram,
             },
             isEdit,
             isAuth,
@@ -95,18 +93,6 @@ export const HostlHeaderCard: FC<HostlHeaderCardProps> = memo(
                             <a href={telegram} target="_blank" rel="noreferrer" className={styles.social}>
                                 <ReactSVG src={telegramIcon} />
                                 <p className={styles.socialLabel}>Telegram</p>
-                            </a>
-                        )}
-                        {facebook !== "" && (
-                            <a href={facebook} target="_blank" rel="noreferrer" className={styles.social}>
-                                <ReactSVG src={facebookIcon} />
-                                <p className={styles.socialLabel}>Facebook</p>
-                            </a>
-                        )}
-                        {instagram !== "" && (
-                            <a href={instagram} target="_blank" rel="noreferrer" className={styles.social}>
-                                <ReactSVG src={instaIcon} />
-                                <p className={styles.socialLabel}>Instagram</p>
                             </a>
                         )}
                     </div>


### PR DESCRIPTION
## Что изменилось

**Публичная страница хоста (`/host/info`)**
- Ссылки на Facebook и Instagram больше не отображаются в хедере хоста

**Форма редактирования профиля хоста**
- Поля Facebook и Instagram удалены из формы социальных сетей
- Добавлено уведомление: «Ссылки на Facebook и Instagram не отображаются на публичной странице — эти сервисы заблокированы на территории РФ»

## Что осталось

- Данные facebook/instagram в БД не затронуты (бэкенд-чистка — отдельная задача)
- Бэкенд-валидация при сохранении — отдельная задача

## Задача

Closes GS-45