### PR TITLE
GS-50: проверка авторизации при отправке комментария

### DIFF
--- a/src/widgets/Journal/ui/JournalPersonal/JournalPersonal.tsx
+++ b/src/widgets/Journal/ui/JournalPersonal/JournalPersonal.tsx
@@ -105,6 +105,13 @@ export const JournalPersonal: FC<JournalPersonalProps> = (props) => {
     };
 
     const onComment = async (description: string) => {
+        if (!isAuth) {
+            setToast({
+                text: "Чтобы оставить комментарий, нужно авторизоваться",
+                type: HintType.Error,
+            });
+            return;
+        }
         try {
             await createReview({ journalId, description }).unwrap();
             await fetchReviews(1);

--- a/src/widgets/News/ui/NewsPersonal/NewsPersonal.tsx
+++ b/src/widgets/News/ui/NewsPersonal/NewsPersonal.tsx
@@ -90,6 +90,13 @@ export const NewsPersonal: FC<NewsPersonalProps> = (props) => {
     };
 
     const onComment = async (description: string) => {
+        if (!isAuth) {
+            setToast({
+                text: "Чтобы оставить комментарий, нужно авторизоваться",
+                type: HintType.Error,
+            });
+            return;
+        }
         try {
             await createNews({ newsId, description }).unwrap();
             await fetchReviews(1);


### PR DESCRIPTION
## Проблема

Гость при попытке оставить комментарий к новости/журналу видел «Произошла ошибка» без объяснений.

## Решение

Добавлена проверка `isAuth` перед отправкой комментария — по аналогии с лайком. Неавторизованный пользователь видит тост «Чтобы оставить комментарий, нужно авторизоваться».

## Изменения

- `NewsPersonal.tsx`: добавлена проверка `!isAuth` в `onComment`
- `JournalPersonal.tsx`: то же самое

## Проверка

- [ ] Lint
- [ ] Deploy to dev