### PR TITLE
GS-43: формат инфографики пожертвований «собрано / цель (%)»

### DIFF
--- a/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.tsx
+++ b/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.tsx
@@ -16,6 +16,8 @@ interface DonationWhenCardProps {
     isSuccess: boolean;
 }
 
+const fmt = new Intl.NumberFormat("ru-RU");
+
 export const DonationWhenCard = memo((props: DonationWhenCardProps) => {
     const {
         className,
@@ -34,6 +36,12 @@ export const DonationWhenCard = memo((props: DonationWhenCardProps) => {
         return dateStart || emptyMessage;
     };
 
+    const showProgress = percentAmountCollect !== null && amount !== null;
+    const progressText = showProgress
+        ? `${fmt.format(Math.round((amount * percentAmountCollect) / 100))} ₽`
+            + ` / ${fmt.format(amount)} ₽ (${percentAmountCollect}%)`
+        : null;
+
     return (
         <div className={cn(className)} id="description">
             <InfoCard className={styles.wrapper}>
@@ -50,13 +58,18 @@ export const DonationWhenCard = memo((props: DonationWhenCardProps) => {
                         className={styles.infoCard}
                     />
                 )}
-                {percentAmountCollect && (
+                {showProgress && (
                     <InfoCardItem
-                        title={isSuccess ? t("donationPersonal.Проект собрал") : t("donationPersonal.Средств собрано")}
-                        text={`${percentAmountCollect}%/${amount} ₽`}
+                        title={isSuccess
+                            ? t("donationPersonal.Проект собрал")
+                            : t("donationPersonal.Средств собрано")}
+                        text={progressText ?? undefined}
                         className={styles.infoCard}
                     >
-                        <DonationProgressBar value={percentAmountCollect} isSuccess={isSuccess} />
+                        <DonationProgressBar
+                            value={percentAmountCollect as number}
+                            isSuccess={isSuccess}
+                        />
                     </InfoCardItem>
                 )}
             </InfoCard>


### PR DESCRIPTION
## Проблема

Отображалось «Средств собрано 3%/100000 ₽» — процент и сумма цели без форматирования, непонятный формат.

## Решение

- Формат изменён на: `3 000 ₽ / 100 000 ₽ (3%)`
- Собранная сумма вычисляется: `Math.round(amount * percentAmountCollect / 100)`
- Числа форматируются через `Intl.NumberFormat("ru-RU")` — разрядные пробелы

## Изменения

- `DonationWhenCard.tsx`: новый формат строки, добавлен `Intl.NumberFormat`

## Проверка

- [ ] Lint
- [ ] Deploy to dev