### PR TITLE
GS-53: стили для сообщения о недоступном видео

### DIFF
--- a/src/shared/ui/VideoPlayer/VideoPlayer.module.scss
+++ b/src/shared/ui/VideoPlayer/VideoPlayer.module.scss
@@ -42,3 +42,16 @@
     // width: 100%;
     // height: 100%;
 }
+
+.error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 200px;
+    background-color: #f5f5f5;
+    border-radius: 8px;
+    color: #8494A1;
+    font-size: 0.9375rem;
+    text-align: center;
+    padding: 1.5rem;
+}


### PR DESCRIPTION
## Проблема

На страницах с видео, у которых отсутствует или неподдерживаемый URL, компонент `VideoPlayer` рендерил `<div className={styles.error}>` — но CSS-класс `.error` не был объявлен в SCSS. Сообщение «Неподдерживаемая ссылка на видео.» было невидимо.

## Решение

Добавлен CSS-класс `.error` в `VideoPlayer.module.scss`: центрированный текст, серый фон, `min-height: 200px`.

## Проверка

- [ ] Lint
- [ ] Deploy to dev