### PR TITLE
GS-38: исправить lang атрибут HTML для предотвращения авто-перевода Chrome

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ru">
     <head>
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/app/providers/LocaleProvider/ui/LocaleProvider.tsx
+++ b/src/app/providers/LocaleProvider/ui/LocaleProvider.tsx
@@ -1,5 +1,5 @@
 import {
-    createContext, useState, useMemo, FC, ReactNode,
+    createContext, useState, useMemo, useEffect, FC, ReactNode,
 } from "react";
 
 export type Locale = "ru" | "en" | "es";
@@ -25,6 +25,10 @@ interface LocaleProviderProps {
 
 export const LocaleProvider: FC<LocaleProviderProps> = ({ initialLanguage, children }) => {
     const [locale, setLocale] = useState(initialLanguage || defaultLocale);
+
+    useEffect(() => {
+        document.documentElement.lang = locale;
+    }, [locale]);
 
     const defaultProps = useMemo(() => ({
         locale,


### PR DESCRIPTION
## Что изменено

- `public/index.html`: `lang="en"` → `lang="ru"` (дефолтный язык)
- `LocaleProvider.tsx`: добавлен `useEffect` для динамического обновления `document.documentElement.lang` при смене локали

## Проблема

Chrome автоматически предлагал перевести русскоязычный контент на английский, так как HTML-документ был помечен как `lang="en"`.

## Задача

[GS-38](https://linear.app/goodsurfing/issue/GS-38)