### PR TITLE
GS-42: исправить навигацию на /donation-personal

### DIFF
--- a/src/entities/Donation/ui/DonationDonorsCard/DonationDonorsCard.tsx
+++ b/src/entities/Donation/ui/DonationDonorsCard/DonationDonorsCard.tsx
@@ -28,7 +28,7 @@ export const DonationDonorsCard = memo((props: DonationDonorsCardProps) => {
 
     if (!data || data.donationCount === 0) {
         return (
-            <div className={cn(className, styles.wrapper)}>
+            <div className={cn(className, styles.wrapper)} id="participants">
                 <h3 className={styles.title}>
                     {t("donationPersonal.Участники сбора")}
                 </h3>
@@ -42,7 +42,7 @@ export const DonationDonorsCard = memo((props: DonationDonorsCardProps) => {
     const formatAmount = (amount: number) => amount.toLocaleString("ru-RU");
 
     return (
-        <div className={cn(className, styles.wrapper)}>
+        <div className={cn(className, styles.wrapper)} id="participants">
             <h3 className={styles.title}>
                 {t("donationPersonal.Участники сбора")}
             </h3>

--- a/src/shared/hooks/useTranslateDonationSubmenu.tsx
+++ b/src/shared/hooks/useTranslateDonationSubmenu.tsx
@@ -13,12 +13,12 @@ export const useTranslateDonationSubmenu = () => {
             id: "address",
         },
         {
-            text: t("donationPersonal.Фотографии", "Фотографии"),
-            id: "gallery",
-        },
-        {
             text: t("donationPersonal.Организация", "Организация"),
             id: "organization",
+        },
+        {
+            text: t("donationPersonal.Фотографии", "Фотографии"),
+            id: "gallery",
         },
         {
             text: t("donationPersonal.Участники", "Участники"),


### PR DESCRIPTION
## Что изменено

1. **«Участники» не скроллил** — добавлен `id="participants"` в оба состояния `DonationDonorsCard` (пустое и с данными)
2. **Порядок кнопок** — поменяны местами «Организация» и «Фотографии» в `useTranslateDonationSubmenu`, теперь соответствует порядку разделов на странице: Организация → Фотографии → Участники

## Задача

[GS-42](https://linear.app/goodsurfing/issue/GS-42)