### PR TITLE
GS-41: исправить белый экран при поиске на /donation-rating

### DIFF
--- a/src/pages/DonationRatingPage/ui/DonationRating/DonationRating.tsx
+++ b/src/pages/DonationRatingPage/ui/DonationRating/DonationRating.tsx
@@ -54,7 +54,7 @@ export const DonationRating = () => {
 
         if (searchValue) {
             const q = searchValue.toLowerCase();
-            mapped = mapped.filter((r) => r.name.toLowerCase().includes(q));
+            mapped = mapped.filter((r) => r.name?.toLowerCase().includes(q) ?? false);
         }
 
         mapped.sort((a, b) => {


### PR DESCRIPTION
## Проблема

При вводе текста в поле «Поиск участника» страница крашилась с белым экраном. Причина: в API-ответе поле `userName` может быть `null`, а код вызывал `r.name.toLowerCase()` без проверки.

## Что изменено

`DonationRating.tsx`, строка 57: добавлена optional chaining защита:

```ts
// было:
mapped = mapped.filter((r) => r.name.toLowerCase().includes(q));

// стало:
mapped = mapped.filter((r) => r.name?.toLowerCase().includes(q) ?? false);
```

## Задача

[GS-41](https://linear.app/goodsurfing/issue/GS-41)