### PR TITLE
GS-40: улучшить экран ошибки на /offer-personal

### DIFF
--- a/src/pages/OfferPersonalPage/ui/OfferPersonalPage/OfferPersonalPage.module.scss
+++ b/src/pages/OfferPersonalPage/ui/OfferPersonalPage/OfferPersonalPage.module.scss
@@ -17,9 +17,19 @@
 }
 
 .error {
-    height: 80vh;
     display: flex;
     justify-content: center;
+    margin-bottom: 16px;
+}
+
+.backButton {
+    padding: 10px 24px;
+    background: var(--accent-color, #2563eb);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 1rem;
 }
 
 @media(max-width: 992px) {

--- a/src/pages/OfferPersonalPage/ui/OfferPersonalPage/OfferPersonalPage.tsx
+++ b/src/pages/OfferPersonalPage/ui/OfferPersonalPage/OfferPersonalPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -18,6 +18,7 @@ import styles from "./OfferPersonalPage.module.scss";
 
 export const OfferPersonalPage = () => {
     const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
     const [offerData, setOfferData] = useState<Offer>();
     const { myProfile } = useAuth();
     const { ready } = useTranslation();
@@ -54,8 +55,15 @@ export const OfferPersonalPage = () => {
                     <Text
                         className={styles.error}
                         textSize="primary"
-                        text="Произошла ошибка"
+                        text="Вакансия не найдена или произошла ошибка"
                     />
+                    <button
+                        type="button"
+                        className={styles.backButton}
+                        onClick={() => navigate(-1)}
+                    >
+                        Назад
+                    </button>
                 </div>
                 <Footer />
             </div>


### PR DESCRIPTION
## Проблема

При переходе на `/offer-personal/{id}` для несуществующей или удалённой вакансии показывался пустой текст «Произошла ошибка» без возможности вернуться назад.

## Что изменено (фронтенд)

- Уточнён текст ошибки: «Вакансия не найдена или произошла ошибка»
- Добавлена кнопка «Назад» (`navigate(-1)`)
- Исправлен CSS: убрана фиксированная высота 80vh у `.error`

## Что изменено (бэкенд, отдельный коммит в gs-backend)

В `ElementHandler::handler()` добавлен null-check после `find($id)`:
```php
if ($vacancy === null) {
    throw new NotFoundHttpException('Vacancy not found');
}
```
Без этого при запросе несуществующей вакансии бэкенд падал с PHP Fatal Error (500) вместо возврата 404.

## Задача

[GS-40](https://linear.app/goodsurfing/issue/GS-40)