### PR TITLE
fix(GS-39): инвалидировать profile кэш после обновления волонтёра

### DIFF
--- a/src/entities/Volunteer/api/volunteerApi.ts
+++ b/src/entities/Volunteer/api/volunteerApi.ts
@@ -2,7 +2,7 @@ import { createApi } from "@reduxjs/toolkit/dist/query/react";
 import { baseQueryAcceptJson } from "@/shared/api/baseQuery/baseQuery";
 import { VolunteerApi, VolunteerType } from "../model/types/volunteer";
 import { WhatToDoSkillType } from "@/types/skills";
-import { Profile } from "@/entities/Profile";
+import { Profile, profileApi } from "@/entities/Profile";
 import { MediaObjectType } from "@/types/media";
 
 interface UpdateVolunteerParams {
@@ -41,6 +41,10 @@ export const volunteerApi = createApi({
                 body,
             }),
             invalidatesTags: ["volunteer"],
+            async onQueryStarted(_, { dispatch, queryFulfilled }) {
+                await queryFulfilled;
+                dispatch(profileApi.util.invalidateTags(["profile"]));
+            },
         }),
         getVolunteerById: build.query<GetVolunteerResponse, string>({
             query: (profileId) => ({
@@ -59,6 +63,10 @@ export const volunteerApi = createApi({
                 body: JSON.stringify(body),
             }),
             invalidatesTags: ["volunteer"],
+            async onQueryStarted(_, { dispatch, queryFulfilled }) {
+                await queryFulfilled;
+                dispatch(profileApi.util.invalidateTags(["profile"]));
+            },
         }),
     }),
 });

--- a/src/widgets/ProfileRoleWidget/ProfileRoleWidget.tsx
+++ b/src/widgets/ProfileRoleWidget/ProfileRoleWidget.tsx
@@ -8,8 +8,9 @@ import { useLocale } from "@/app/providers/LocaleProvider";
 
 import { RoleCard } from "@/features/ProfileRole";
 
-import { useGetProfileInfoQuery } from "@/entities/Profile";
+import { profileApi, useGetProfileInfoQuery } from "@/entities/Profile";
 import { CreateVolunteerRequest, useCreateVolunteerMutation } from "@/entities/Volunteer";
+import { useAppDispatch } from "@/shared/hooks/redux";
 
 import { getHostRegisterPageUrl, getOfferPersonalPageUrl, getVolunteerDashboardPageUrl } from "@/shared/config/routes/AppUrls";
 import { getErrorText } from "@/shared/lib/getErrorText";
@@ -43,6 +44,7 @@ export const ProfileRoleWidget: FC<ProfileRoleWidgetProps> = (props) => {
 
     const { roleData } = useRoleData();
 
+    const dispatch = useAppDispatch();
     const [createVolunteer, { isLoading }] = useCreateVolunteerMutation();
     const { data: myProfile, refetch: profileRefetch } = useGetProfileInfoQuery();
 
@@ -96,6 +98,7 @@ export const ProfileRoleWidget: FC<ProfileRoleWidgetProps> = (props) => {
                         type: HintType.Success,
                     });
                     profileRefetch();
+                    dispatch(profileApi.util.invalidateTags(["profile"]));
                     setTimeout(() => {
                         if (next) {
                             navigate(getOfferPersonalPageUrl(locale, next));


### PR DESCRIPTION
## Проблема
После редактирования навыков в профиле волонтёра (`updateVolunteerById`) инвалидировался только тег `["volunteer"]` из `volunteerApi`. Публичная страница волонтёра использует `useGetProfileInfoByIdQuery` из `profileApi` (тег `["profile"]`), который не обновлялся — данные обновлялись только после перелогина.

## Решение
Добавлен `onQueryStarted` в мутации `updateVolunteerById` и `createVolunteer`: после успешного выполнения диспатчится `profileApi.util.invalidateTags(["profile"])`, что форсирует рефетч профильных данных.

## Тест
1. Войти как волонтёр
2. Добавить/изменить навыки в дашборде
3. Перейти на публичную страницу профиля — навыки обновляются сразу без перелогина

Closes GS-39