### PR TITLE
feat(GS-5, GS-6): навигация «Стать хостом» и футер «Поддержать»

### DIFF
--- a/src/containers/NewMainSliderContainer/NewMainSliderContainer.tsx
+++ b/src/containers/NewMainSliderContainer/NewMainSliderContainer.tsx
@@ -16,6 +16,7 @@ import { useLocale } from "@/app/providers/LocaleProvider";
 import { getUserAuthData, userActions } from "@/entities/User";
 import {
     getAboutProjectPageUrl, getAcademyMainPageUrl, getAmbassadorsPageUrl,
+    getBecomeHostPageUrl,
     getBlogPageUrl,
     getFindJobPageUrl, getHostDashboardPageUrl, getJournalsPageUrl,
     getMainPageUrl, getMembershipPageUrl,
@@ -290,6 +291,11 @@ export const NewMainSliderContainer = () => {
                             </Link>
                         </Popup>
                     </div>
+                    <div className={styles.link}>
+                        <Link to={getBecomeHostPageUrl(locale)}>
+                            {t("main.welcome.header.for-organizers.become-a-host")}
+                        </Link>
+                    </div>
                     {isAuth ? (
                         <>
                             <div className={styles.link}>
@@ -556,6 +562,12 @@ export const NewMainSliderContainer = () => {
                         {t("main.welcome.header.about-project.find-job")}
                     </Link>
                 </MobileSelect>
+                <ButtonMenu
+                    onClick={() => navigate(getBecomeHostPageUrl(locale))}
+                    className={styles.button}
+                >
+                    {t("main.welcome.header.for-organizers.become-a-host")}
+                </ButtonMenu>
                 {authData ? (
                     <>
                         <ButtonMenu

--- a/src/pages/MainPage/ui/WelcomeContainer/InfoSide/InfoHeader/InfoHeader.tsx
+++ b/src/pages/MainPage/ui/WelcomeContainer/InfoSide/InfoHeader/InfoHeader.tsx
@@ -13,6 +13,7 @@ import {
     getAboutProjectPageUrl,
     getAcademyMainPageUrl,
     getAmbassadorsPageUrl,
+    getBecomeHostPageUrl,
     getBlogPageUrl,
     getDonationRating,
     getDonationReports,
@@ -221,6 +222,11 @@ const InfoHeader = memo(() => {
                                 {t("main.welcome.header.about-project.find-job")}
                             </Link>
                         </Popup>
+                    </div>
+                    <div className={styles.link}>
+                        <Link to={getBecomeHostPageUrl(locale)}>
+                            {t("main.welcome.header.for-organizers.become-a-host")}
+                        </Link>
                     </div>
                     {isAuth && (
                         <div className={styles.link}>

--- a/src/pages/MainPage/ui/WelcomeContainer/InfoSide/InfoMobileHeader/ui/InfoMobileHeader/InfoMobileHeader.tsx
+++ b/src/pages/MainPage/ui/WelcomeContainer/InfoSide/InfoMobileHeader/ui/InfoMobileHeader/InfoMobileHeader.tsx
@@ -14,6 +14,7 @@ import {
     getAboutProjectPageUrl,
     getAcademyMainPageUrl,
     getAmbassadorsPageUrl,
+    getBecomeHostPageUrl,
     getBlogPageUrl,
     getDonationRating,
     getDonationReports,
@@ -309,6 +310,12 @@ export const InfoMobileHeader: FC = () => {
                         {t("main.welcome.header.about-project.find-job")}
                     </Link>
                 </MobileSelect>
+                <Button
+                    onClick={() => navigate(getBecomeHostPageUrl(locale))}
+                    className={styles.button}
+                >
+                    {t("main.welcome.header.for-organizers.become-a-host")}
+                </Button>
                 {authData ? (
                     <>
                         <Button

--- a/src/widgets/Footer/ui/Footer.module.scss
+++ b/src/widgets/Footer/ui/Footer.module.scss
@@ -10,7 +10,9 @@
 
 .copyright {
 	display: flex;
+	align-items: center;
 	justify-content: center;
+	gap: 24px;
 
 	padding-top: 15px;
 	padding-bottom: 40px;
@@ -24,6 +26,24 @@
 		font-size: 0.875rem;
 		font-weight: 500;
 		line-height: 171%;
+	}
+
+	&__links {
+		display: flex;
+		gap: 16px;
+	}
+
+	&__link {
+		color: #82949F;
+
+		font-size: 0.875rem;
+		font-weight: 500;
+		line-height: 171%;
+		text-decoration: underline;
+
+		&:hover {
+			color: var(--color-white);
+		}
 	}
 }
 
@@ -174,5 +194,10 @@
 		&__item {
 			margin-bottom: 30px;
 		}
+	}
+
+	.copyright {
+		flex-direction: column;
+		gap: 8px;
 	}
 }

--- a/src/widgets/Footer/ui/Footer.tsx
+++ b/src/widgets/Footer/ui/Footer.tsx
@@ -234,6 +234,25 @@ export const Footer = memo(() => {
                                 </Link>
                             </div>
                         </div>
+                        <div className={styles.menu__item}>
+                            <h4 className={styles.menu__title}>
+                                {t("main.welcome.header.donation.title")}
+                            </h4>
+                            <div className={styles.menu__content}>
+                                <Link
+                                    className={styles.link}
+                                    to={getMembershipPageUrl(locale)}
+                                >
+                                    {t("main.welcome.header.donation.support-goodsurfing")}
+                                </Link>
+                                <Link
+                                    className={styles.link}
+                                    to={getNPOPageUrl(locale)}
+                                >
+                                    {t("main.welcome.header.donation.public-reports")}
+                                </Link>
+                            </div>
+                        </div>
                     </nav>
                 </div>
             </footer>
@@ -242,6 +261,20 @@ export const Footer = memo(() => {
                     © GoodSurfing, 2017-
                     {new Date().getFullYear()}
                 </p>
+                <div className={styles.copyright__links}>
+                    <Link
+                        className={styles.copyright__link}
+                        to={getRulesPageUrl(locale)}
+                    >
+                        {t("main.welcome.header.about-project.rules")}
+                    </Link>
+                    <Link
+                        className={styles.copyright__link}
+                        to={getPrivacyPolicyPageUrl(locale)}
+                    >
+                        {t("main.welcome.header.about-project.privacy-policy")}
+                    </Link>
+                </div>
             </div>
         </>
     );

--- a/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.tsx
+++ b/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.tsx
@@ -12,6 +12,7 @@ import {
     getAboutProjectPageUrl,
     getAcademyMainPageUrl,
     getAmbassadorsPageUrl,
+    getBecomeHostPageUrl,
     getBlogPageUrl,
     getDonationRating,
     getDonationsMapPageUrl,
@@ -346,6 +347,11 @@ export const MainHeaderNav = () => {
                         {t("main.welcome.header.about-project.find-job")}
                     </Link>
                 </Popup>
+            </div>
+            <div>
+                <Link className={styles.btnNav} to={getBecomeHostPageUrl(locale)}>
+                    {t("main.welcome.header.for-organizers.become-a-host")}
+                </Link>
             </div>
         </div>
     );

--- a/src/widgets/MobileHeader/ui/MobileHeader/MobileHeader.tsx
+++ b/src/widgets/MobileHeader/ui/MobileHeader/MobileHeader.tsx
@@ -17,6 +17,7 @@ import {
     getAboutProjectPageUrl,
     getAcademyMainPageUrl,
     getAmbassadorsPageUrl,
+    getBecomeHostPageUrl,
     getBlogPageUrl,
     getDonationRating,
     getDonationsMapPageUrl,
@@ -324,6 +325,12 @@ const MobileHeader: FC = () => {
                         {t("main.welcome.header.about-project.find-job")}
                     </Link>
                 </MobileSelect>
+                <Button
+                    onClick={() => navigate(getBecomeHostPageUrl(locale))}
+                    className={styles.button}
+                >
+                    {t("main.welcome.header.for-organizers.become-a-host")}
+                </Button>
                 {authData ? (
                     <>
                         <Button


### PR DESCRIPTION
## Summary
- **GS-5**: добавлен пункт «Стать хостом» в главную навигацию — десктоп и мобильное меню на всех 4 компонентах (MainHeaderNav, MobileHeader, InfoHeader, InfoMobileHeader, NewMainSliderContainer)
- **GS-6**: в футер добавлена колонка «Поддержать» с ссылками «Поддержать Гудсёрфинг» и «Публичная отчётность»; в строку копирайта добавлены ссылки «Правила» и «Политика конфиденциальности»

## Test plan
- [ ] «Стать хостом» видно в десктопном меню и ведёт на /ru/become-host
- [ ] «Стать хостом» видно в мобильном меню (hamburger)
- [ ] Колонка «Поддержать» присутствует в футере
- [ ] Ссылки «Правила» и «Политика конфиденциальности» в строке копирайта
- [ ] Обе локали (ru/en) отображают корректно