### PR TITLE
fix(header): выравнивание nav-элементов по центру — GS-4

### DIFF
--- a/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.module.scss
+++ b/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.module.scss
@@ -1,6 +1,7 @@
 .wrapper {
     display: flex;
     column-gap: 24px;
+    align-items: center;
 }
 
 .btnOffers {


### PR DESCRIPTION
## Проблема
После добавления кнопки «Членство» один из соседних пунктов меню «поехал» вниз — сбилось вертикальное выравнивание.

## Причина
`.wrapper` в `MainHeaderNav.module.scss` имел `display: flex; column-gap: 24px` без `align-items: center`. Кнопка с `padding: 8px 18px` выше остальных текстовых ссылок — без `align-items: center` флекс-элементы растягиваются по умолчанию, что сбивает базовую линию соседних элементов.

## Исправление
Добавлен `align-items: center` в `.wrapper`.