### PR TITLE
Шапка: pill наезжает на контент

### DIFF
--- a/src/widgets/MainHeader/MainHeader.module.scss
+++ b/src/widgets/MainHeader/MainHeader.module.scss
@@ -1,7 +1,3 @@
-.spacer {
-    height: 88px;
-}
-
 .wrapper {
     position: fixed;
     top: 16px;
@@ -152,10 +148,6 @@
 }
 
 @media (max-width: 992px) {
-    .spacer {
-        display: none;
-    }
-
     .wrapper {
         position: sticky;
         top: 0;

--- a/src/widgets/MainHeader/MainHeader.tsx
+++ b/src/widgets/MainHeader/MainHeader.tsx
@@ -40,8 +40,7 @@ const MainHeader: FC = () => {
     }, []);
 
     return (
-        <>
-            <div className={cn(styles.wrapper, { [styles.scrolled]: scrolled })}>
+        <div className={cn(styles.wrapper, { [styles.scrolled]: scrolled })}>
                 <header className={styles.header}>
                     <div className={styles.left}>
                         <LocaleLink
@@ -97,8 +96,7 @@ const MainHeader: FC = () => {
                         </ButtonLink>
                     </div>
                 )}
-            </div>
-        </>
+        </div>
     );
 };
 

--- a/src/widgets/MainHeader/MainHeader.tsx
+++ b/src/widgets/MainHeader/MainHeader.tsx
@@ -41,7 +41,6 @@ const MainHeader: FC = () => {
 
     return (
         <>
-            <div className={styles.spacer} aria-hidden="true" />
             <div className={cn(styles.wrapper, { [styles.scrolled]: scrolled })}>
                 <header className={styles.header}>
                     <div className={styles.left}>


### PR DESCRIPTION
Убран spacer (88px) — теперь pill парит поверх hero, контент начинается с y=0.

## Test plan
- [ ] dev.goodsurfing.org/ru/ — pill наезжает на верх hero
- [ ] /ru/membership — pill поверх зелёного баннера