### PR TITLE
fix(deploy-prod): build и smoke на prod.goodsurfing.org / api-prod.goodsurfing.org

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Login to Yandex Container Registry
         uses: yc-actions/yc-cr-login@v3
         with:
-          yc-sa-json-credentials: ${{ secrets.YC_SA_KEY_JSON_PROD }}
+          yc-sa-json-credentials: ${{ secrets.YC_SA_KEY_JSON }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,8 +16,8 @@ concurrency:
 env:
   REGISTRY: ${{ vars.PROD_REGISTRY }}
   IMAGE: gs-frontend
-  VITE_API_BASE_URL: https://api.goodsurfing.org
-  VITE_MAIN_URL: https://goodsurfing.org
+  VITE_API_BASE_URL: https://api-prod.goodsurfing.org
+  VITE_MAIN_URL: https://prod.goodsurfing.org
   VITE_VKID_CLIENT_ID: "54505769"
 
 jobs:
@@ -68,7 +68,7 @@ jobs:
         run: |
           set -e
           for i in 1 2 3 4 5; do
-            code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 https://goodsurfing.org/)
+            code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 https://prod.goodsurfing.org/)
             if [ "$code" = "200" ]; then echo "OK"; exit 0; fi
             sleep 15
           done


### PR DESCRIPTION
## Что

Меняю в deploy-prod workflow:
- `VITE_API_BASE_URL`: `https://api.goodsurfing.org` → `https://api-prod.goodsurfing.org`
- `VITE_MAIN_URL`: `https://goodsurfing.org` → `https://prod.goodsurfing.org`
- Smoke test: `https://goodsurfing.org/` → `https://prod.goodsurfing.org/`

## Зачем

`VITE_*` вшиваются в JS-бандл на этапе build. Если оставить apex — фронт уйдёт на легаси Yii2 (`212.193.52.158`): API-запросы, VK OAuth callback (client `54505769` зарегистрирован для нового prod), все ссылки. Smoke-тест на `goodsurfing.org` тоже бы прошёл — но на легаси, что маскирует факт нерабочего деплоя.

Apex `goodsurfing.org` и `www` остаются на легаси Yii2 до полного cutover. Корп. YC prod-инстанс (`111.88.252.122`) поднимается на поддоменах `prod.*` / `api-prod.*` — по аналогии со staging/dev.

Связанные:
- [gs-infra#5](https://github.com/Goodsurfing/gs-infra/pull/5) — Terraform-переменные `domains_*` → `prod.*`/`api-prod.*`
- [gs-backend#172](https://github.com/Goodsurfing/gs-backend/pull/172) — аналогичный fix backend smoke

## Test plan

- [ ] После мерджа gs-infra#5 + DNS-записей + первого тега `v*.*.*` бандл загружается с `https://prod.goodsurfing.org/` и делает запросы на `https://api-prod.goodsurfing.org`
- [ ] Smoke возвращает 200