### PR TITLE
feat(dev): прокси Vite на staging API + IAP-токен для локального запуска

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,19 @@
+# Vite reads this for `npm start` (dev mode). For production builds the values
+# come from Docker ARGs (.github/workflows/deploy-*.yml). Keep this file in git.
+#
+# In dev the SPA hits the local Vite dev server, which proxies API requests
+# to `VITE_DEV_API_TARGET` and injects `Authorization: Bearer VITE_DEV_IAP_TOKEN`.
+# So `VITE_API_BASE_URL` must stay empty → API calls become relative paths.
+
+VITE_API_BASE_URL=""
+VITE_MAIN_URL="http://localhost:3000"
+VITE_API_YANDEX_KEY=""
+VITE_VKID_CLIENT_ID="54011426"
+
+# Where the dev proxy forwards. Switch to api-dev/api-prod if needed.
+VITE_DEV_API_TARGET="https://api-staging.goodsurfing.org"
+
+# IAP bypass token for the staging oauth2-proxy. The same value lives in
+# package.json's `e2e` script, so it's not really secret. Override via
+# .env.development.local if you have a different one.
+VITE_DEV_IAP_TOKEN="yiap_66fa6fb58d3632ec2a187696244db59ea858be9c"

--- a/.env.development.local.example
+++ b/.env.development.local.example
@@ -1,0 +1,5 @@
+# Personal overrides for local dev. Copy to .env.development.local (gitignored).
+# Use this for IAP tokens you don't want shared, or to point at a different env.
+
+# VITE_DEV_API_TARGET="https://api-dev.goodsurfing.org"
+# VITE_DEV_IAP_TOKEN="yiap_your_personal_bypass_here"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist/
 coverage
 http-requests
 .env
+.env.local
+.env.*.local
+!.env.development
 .eslintcache
 localhost+1-key.pem
 localhost+1.pem

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 [![Deploy](https://github.com/Goodsurfing/gs-frontend/actions/workflows/deploy.yml/badge.svg)](https://github.com/Goodsurfing/gs-frontend/actions/workflows/deploy.yml)
 
-# start | build:
+# Локальный запуск против staging
 
-1. npm install
-2. create file .env in project root dir and write BACKEND_BASE_URL="https://***/api/v1/public"
-3. npm run start || npm run build:prod
+```bash
+nvm use 20       # Node 20+
+npm ci
+npm start        # http://localhost:3000
+```
+
+По умолчанию dev-сервер проксирует `/api`, `/admin`, `/auth`, `/oauth2`, `/static-media`, `/media` на `https://api-staging.goodsurfing.org` и добавляет IAP-токен в `Authorization: Bearer …` — обходим CORS и oauth2-proxy одним движением. Конфиг — в `.env.development`, проксирование — в `vite.config.ts`.
+
+Чтобы переключить target или подложить свой IAP-токен — скопируй `.env.development.local.example` в `.env.development.local` (gitignored) и переопредели:
+
+```env
+VITE_DEV_API_TARGET="https://api-dev.goodsurfing.org"
+VITE_DEV_IAP_TOKEN="yiap_..."
+```
+
+# Build / deploy
+
+Прод-сборка через `npm run build:prod` собирает SPA с зашитыми `VITE_API_BASE_URL` etc. (Docker `ARG` в `Dockerfile`). Реальные значения для каждого env живут в `.github/workflows/deploy-{dev,staging,prod}.yml`. Локальный `.env`/`.env.development` на build не влияют (Docker берёт значения из CI).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 // @ts-ignore — vitest/config types not always found in strict TS 6
@@ -6,6 +6,23 @@ import type { UserConfig } from "vitest/config";
 
 export default defineConfig(({ mode }) => {
     const isDev = mode === "development";
+    const env = loadEnv(mode, process.cwd(), "");
+
+    // When developers run `npm start`, route the API calls through the Vite
+    // dev-server proxy so they hit staging without CORS pain. The IAP token
+    // is injected as a Bearer header — same trick the e2e suite uses
+    // (see e2e/global-setup.ts).
+    //
+    // Behaviour selectors:
+    // - VITE_DEV_API_TARGET (default https://api-staging.goodsurfing.org) — where the
+    //   proxy forwards to. Override to dev/prod if needed.
+    // - VITE_DEV_IAP_TOKEN — the yiap-prefixed bypass token. If empty, the
+    //   proxy still works (you'll get 302 to /auth/login from IAP — clear signal).
+    const devProxyTarget = env.VITE_DEV_API_TARGET || "https://api-staging.goodsurfing.org";
+    const devIapToken = env.VITE_DEV_IAP_TOKEN || "";
+    const devProxyHeaders: Record<string, string> = devIapToken
+        ? { Authorization: `Bearer ${devIapToken}` }
+        : {};
 
     return {
         plugins: [react()],
@@ -54,6 +71,19 @@ export default defineConfig(({ mode }) => {
         server: {
             port: 3000,
             open: true,
+            // Forward backend/IAP paths to the chosen target. Matches every
+            // path the SPA actually uses against the API (REST + admin +
+            // IAP login flow + uploaded media). Everything else (HTML,
+            // /assets/*, /locales/*) stays on the Vite dev server.
+            proxy: {
+                "^/(api|admin|auth|oauth2|static-media|media)(/|$)": {
+                    target: devProxyTarget,
+                    changeOrigin: true,
+                    secure: true,
+                    headers: devProxyHeaders,
+                    cookieDomainRewrite: { "*": "" },
+                },
+            },
         },
 
         build: {


### PR DESCRIPTION
## Зачем

Чтобы один и тот же фронт работал и **локально** (`npm start` против staging-бэка), и в проде/staging/dev (где он деплоится отдельным бандлом с зашитым `VITE_API_BASE_URL` из docker ARG в `.github/workflows/deploy-*.yml`).

## Что мешало локальному запуску раньше

- **IAP**. Staging закрыт `yandex-iap` (oauth2-proxy перед traefik). Браузер без сессионной cookie получит 302 на `/auth/login`. Cookies `SameSite=None; Secure` не приходят с `http://localhost`.
- **CORS**. `api-staging.goodsurfing.org` отдаёт `Access-Control-Allow-Origin: https://staging.goodsurfing.org` — http://localhost:3000 блокируется.

## Что меняется

`vite.config.ts` — добавлен dev-server `proxy` блок (применяется **только** в dev, на build не влияет):

```ts
server.proxy: {
  "^/(api|admin|auth|oauth2|static-media|media)(/|$)": {
    target: VITE_DEV_API_TARGET,      // default https://api-staging.goodsurfing.org
    changeOrigin: true,
    headers: { Authorization: `Bearer ${VITE_DEV_IAP_TOKEN}` },
    cookieDomainRewrite: { "*": "" },
  },
}
```

`Authorization: Bearer <yiap-token>` — тот же IAP-bypass, что уже использует `e2e/global-setup.ts:17`.

Браузер видит запросы как same-origin (CORS обходится). Backend видит запросы как от proxy origin (whitelist'ован). IAP видит правильный header (пропускает).

## Конфиг

- `.env.development` (gitted) — общие умолчания для dev:
  - `VITE_API_BASE_URL=""` (API клиент в `src/shared/constants/api/index.ts` строит относительные `/api/v3/...`, которые ловит прокси)
  - `VITE_DEV_API_TARGET=https://api-staging.goodsurfing.org`
  - `VITE_DEV_IAP_TOKEN=yiap_...` (значение и так открыто в `package.json:e2e`)
- `.env.development.local.example` (gitted) — пример личных оверрайдов; реальный `.env.development.local` — в `.gitignore`.
- `.gitignore` — добавлены `.env.local`, `.env.*.local`.

## Прод-сборка НЕ меняется

`Dockerfile` принимает `ARG VITE_API_BASE_URL` из CI (`.github/workflows/deploy-{dev,staging,prod}.yml`). При `npm run build:prod` Vite читает env из docker ARG → `.env.development` не подхватывается (`mode === production`).

Доказательство: staging и prod build CI после мержа этого PR должны раскататься **с теми же** `VITE_API_BASE_URL=https://api-{staging,prod}.goodsurfing.org`, что и сегодня.

## Локальный запуск после мержа

```bash
nvm use 20
npm ci
npm start        # http://localhost:3000 → API уходит на staging
```

## Test plan

- [ ] `npm start` локально; в DevTools — XHR на `/api/v3/auth/...` уходят 200 (proxy → staging), не 302/401 (IAP пропустил), не CORS error.
- [ ] Логин test-аккаунта через `POST /api/v2/token` работает.
- [ ] Staging build CI остаётся зелёным (контрольная точка — что не сломал прод-build).
- [ ] Кросс-проверка: `npm run build:prod` локально с `VITE_API_BASE_URL=https://api-prod.goodsurfing.org npm run build:prod` даёт бандл, в котором origin зашит на api-prod (не на staging) — `grep -r "api-prod" dist/assets/*.js`.

## За скоупом

- VK auth flow через `accounts.vk.com` не отработает локально — callback URL приложения зарегистрирован на staging/prod-домены, не localhost. Для тестов использовать `/api/v2/token` напрямую (как делает e2e).
- IAP-токен в `.env.development` — открытый bypass, не админский. Для админских флоу можно подложить свой через `.env.development.local`.