### PR TITLE
fix(dev): принудительно пустой API_ORIGIN в dev — закрыть CORS даже при stale .env

### DIFF
--- a/src/shared/constants/api/index.ts
+++ b/src/shared/constants/api/index.ts
@@ -1,4 +1,10 @@
-const API_ORIGIN = `${import.meta.env.VITE_API_BASE_URL}`.replace(/\/+$/, "");
+// In dev (`npm start`) the SPA must hit the Vite dev-server (which proxies
+// to staging) with relative paths — otherwise CORS/IAP kick in. Force an
+// empty origin so any value left over in a stray .env / .env.local from
+// a developer's previous setup doesn't poison the build.
+const API_ORIGIN = import.meta.env.DEV
+    ? ""
+    : `${import.meta.env.VITE_API_BASE_URL}`.replace(/\/+$/, "");
 
 export const BASE_URL = API_ORIGIN;
 export const BASE_URI = "/api/v1/";
@@ -13,4 +19,8 @@ export const API_USER_BASE_URL = `${API_ORIGIN}/api/users/`;
 export const API_MEDIA_BASE_URL = `${API_ORIGIN}/api/media_objects/`;
 export const API_TRANSLATION_BASE_URL = `${API_ORIGIN}/api/v1/translation`;
 export const API_YANDEX_BASE_URL = "https://geocode-maps.yandex.ru/1.x/";
-export const MAIN_URL = `${import.meta.env.VITE_MAIN_URL}`;
+// Used for OAuth/IAP redirect-back URLs. In dev — origin of the running
+// dev-server (typically http://localhost:3000), not a baked-in production URL.
+export const MAIN_URL = import.meta.env.DEV && typeof window !== "undefined"
+    ? window.location.origin
+    : `${import.meta.env.VITE_MAIN_URL}`;


### PR DESCRIPTION
## Что было после #262

Скрин из браузера показал, что у пользователя API-запрос всё ещё уходит **напрямую**:
```
Request URL: https://api-staging.goodsurfing.org/api/v3/profile
```
Vite proxy не сработал — потому что фронт в момент запроса знает абсолютный URL и хитит его без посредника.

## Почему

В рабочей копии разработчика лежит локальный `.env` (или `.env.local`) с `VITE_API_BASE_URL=https://api-staging.goodsurfing.org` — наследие ранее данных «временных» инструкций. По Vite-приоритету `.env.development` (committed в #262) должен перебивать `.env`, но это **не** срабатывает при:

- неперезапущенном dev-server (env читается на boot, не на HMR);
- наличии у разраба собственного `.env.development.local`;
- запуске через docker-wrapper, который пропихивает в env старое значение.

То есть: один правильный `.env.development` в репо — недостаточно. Слишком много мест, где значение может «всплыть».

## Что меняется

Жёсткая защита в `src/shared/constants/api/index.ts`:

```ts
const API_ORIGIN = import.meta.env.DEV
    ? ""
    : `${import.meta.env.VITE_API_BASE_URL}`.replace(/\/+$/, "");

export const MAIN_URL = import.meta.env.DEV && typeof window !== "undefined"
    ? window.location.origin
    : `${import.meta.env.VITE_MAIN_URL}`;
```

`import.meta.env.DEV` — встроенный Vite-флаг:
- `true` только при `npm start`
- `false` при `npm run build:prod` (даже если выставлен `mode=development`)

В dev → `API_ORIGIN = ""` → клиенты строят `/api/v3/...` → Vite proxy ловит → staging с IAP-bearer'ом. **Любой** .env-overrife у пользователя игнорируется.

В prod → код идентичен прежнему, `VITE_API_BASE_URL` из docker ARG диктует origin. Прод-сборка не меняется.

`MAIN_URL` дополнительно использует `window.location.origin` в dev для OAuth-редиректов (VK auth и т.п. больше не редиректят на staging-домен с локалки).

## Test plan

- [ ] Локальный `npm start` после `git pull` (без чистки .env). DevTools → Network: запрос к profile показывает Request URL `http://localhost:3000/api/v3/profile`, **не** `https://api-staging.goodsurfing.org/...`.
- [ ] `npm run build:prod` локально с `VITE_API_BASE_URL=https://api-staging.goodsurfing.org` даёт бандл, в котором origin зашит на api-staging — `grep -r "api-staging" dist/assets/*.js` находит.
- [ ] Staging deploy после мержа остаётся зелёным (контрольная точка — прод-сборка не сломана).

## Контекст

Связано с #262 — там добавлен сам proxy, тут — его strict-enforcement в коде.