### PR TITLE
fix(dev): API_ORIGIN = window.location.origin в dev (а не пустая строка)

### DIFF
--- a/src/shared/constants/api/index.ts
+++ b/src/shared/constants/api/index.ts
@@ -1,9 +1,14 @@
 // In dev (`npm start`) the SPA must hit the Vite dev-server (which proxies
-// to staging) with relative paths — otherwise CORS/IAP kick in. Force an
-// empty origin so any value left over in a stray .env / .env.local from
-// a developer's previous setup doesn't poison the build.
-const API_ORIGIN = import.meta.env.DEV
-    ? ""
+// to staging) so CORS/IAP doesn't kick in. We use the running page origin
+// (typically http://localhost:3000) — NOT an empty string — because several
+// RTK Query endpoints inject API_BASE_URL_V3 directly into `url:` while
+// using `baseQuery` with baseUrl=API_BASE_URL (a.k.a. /api/v1/). When both
+// are relative, RTK joins them and you get nonsense like
+// `/api/v1/api/v3/profile`. When the injected URL is absolute, RTK's
+// `isAbsoluteUrl` short-circuits and uses it verbatim. Browser still hits
+// localhost:3000 so the Vite proxy catches it.
+const API_ORIGIN = import.meta.env.DEV && typeof window !== "undefined"
+    ? window.location.origin
     : `${import.meta.env.VITE_API_BASE_URL}`.replace(/\/+$/, "");
 
 export const BASE_URL = API_ORIGIN;


### PR DESCRIPTION
## Что было после #263

Скрин из браузера:
```
Request URL: http://localhost:3000/api/v1/api/v3/profile  → 404
```

Двойной префикс — `/api/v1/api/v3/profile`. То же самое случается ещё для `~55` других endpoint'ов по коду.

## Почему

В RTK Query по коду повторяется анти-паттерн:

```ts
const profileApi = createApi({
  baseQuery: baseQueryAcceptJson,         // baseUrl = API_BASE_URL = `${API_ORIGIN}/api/v1/`
  endpoints: (build) => ({
    getProfile: build.query<Profile, void>({
      query: () => ({ url: `${API_BASE_URL_V3}profile` })   // ← запекает V3 в url
    }),
  }),
});
```

`fetchBaseQuery` внутри RTK склеивает url с baseUrl только когда `isAbsoluteUrl(url) === false`.

- **До #263**: `API_BASE_URL_V3 = "https://api-staging.goodsurfing.org/api/v3/"` → `url` абсолютный → base игнорировался → `https://api-staging.goodsurfing.org/api/v3/profile` ✓
- **После #263** (`API_ORIGIN = ""`): `API_BASE_URL_V3 = "/api/v3/"` → `url = "/api/v3/profile"` относительный → склейка с baseUrl=`/api/v1/` → `/api/v1/api/v3/profile` ❌

Чинить все 55 endpoint'ов — много (и они не сломаны прод-режиме, я бы просто наводил рябь). Делаю один точечный фикс.

## Что меняется

В `src/shared/constants/api/index.ts`:

```ts
const API_ORIGIN = import.meta.env.DEV && typeof window !== "undefined"
    ? window.location.origin               // http://localhost:3000
    : `${import.meta.env.VITE_API_BASE_URL}`.replace(/\/+$/, "");
```

В dev `API_ORIGIN` теперь **абсолютный** (origin самой страницы). `API_BASE_URL_V3 = "http://localhost:3000/api/v3/"` — снова абсолютный → RTK не склеивает с baseUrl → запрос идёт на `http://localhost:3000/api/v3/profile` → Vite proxy ловит `^/api/...` → форвардит на staging.

Прод-сборка не меняется (`import.meta.env.DEV === false` в build).

## Test plan

- [ ] `npm start` локально, в DevTools → Network запрос к profile показывает `Request URL: http://localhost:3000/api/v3/profile` (один префикс, не два). Status 200.
- [ ] Аналогично для остальных endpoint'ов (`/api/v3/vacancy/list`, `/api/v3/donation`, ...) — все 200.
- [ ] `npm run build:prod` локально с `VITE_API_BASE_URL=https://api-staging.goodsurfing.org` даёт бандл, в котором origin зашит на api-staging.
- [ ] Staging-deploy после мержа остаётся зелёным.

## Long-term

Анти-паттерн с `${API_BASE_URL_V3}` внутри url still остаётся — стоит почистить отдельной задачей (использовать `baseQueryV3` или относительный путь). Но это не блокер, и не в скоупе этого фикса.