### PR TITLE
fix(dev): не перетирать клиентский Authorization в Vite proxy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,13 +75,26 @@ export default defineConfig(({ mode }) => {
             // path the SPA actually uses against the API (REST + admin +
             // IAP login flow + uploaded media). Everything else (HTML,
             // /assets/*, /locales/*) stays on the Vite dev server.
+            //
+            // We do NOT statically set `headers: { Authorization: ... }` on
+            // the proxy config: that would clobber any user JWT the SPA
+            // attaches via baseQuery prepareHeaders (Symfony then sees the
+            // IAP token, fails JWT parsing, and answers 401 to authenticated
+            // calls). Instead inject IAP only when the original request
+            // doesn't already carry an Authorization header.
             proxy: {
                 "^/(api|admin|auth|oauth2|static-media|media)(/|$)": {
                     target: devProxyTarget,
                     changeOrigin: true,
                     secure: true,
-                    headers: devProxyHeaders,
                     cookieDomainRewrite: { "*": "" },
+                    configure: (proxy) => {
+                        proxy.on("proxyReq", (proxyReq, req) => {
+                            if (devIapToken && !req.headers.authorization) {
+                                proxyReq.setHeader("Authorization", `Bearer ${devIapToken}`);
+                            }
+                        });
+                    },
                 },
             },
         },


### PR DESCRIPTION
## Симптом

После #262 + #263 + #265 у разработчика на локалке всё ещё 401 на «публичных» методах (\`GET /api/v3/category/list?lang=ru\`).

## Корень

В #262 я сделал безусловный header injection в proxy:
\`\`\`ts
headers: { Authorization: \`Bearer \${IAP_TOKEN}\` }
\`\`\`

\`http-proxy\` берёт эту мапу и **перезаписывает** соответствующие заголовки в каждом проксируемом запросе. То есть:

- если в localStorage у разработчика лежит залежавшийся JWT (после прежнего логина), \`baseQuery.prepareHeaders\` ставит \`Authorization: Bearer <jwt>\`;
- proxy этот заголовок **затирает** на \`Bearer yiap_…\`;
- Symfony JWTAuthenticator получает yiap_…, парсит как JWT, фейлится с InvalidTokenException;
- ответ — \`401 Unauthorized\` с \`server: FrankenPHP Caddy\`, у разработчика выглядит как «не работают даже публичные методы».

Эксперимент подтвердил картину:
\`\`\`
$ curl -sI https://api-staging.goodsurfing.org/api/v3/category/list?lang=ru
HTTP/2 401   server: FrankenPHP Caddy   www-authenticate: Bearer

$ curl -s   https://api-staging.goodsurfing.org/api/v3/category/list?lang=ru | head -c 100
[{"id":12,"name":"On-line",...}]
\`\`\`

Public GET с body отдаётся, а HEAD без Authorization → 401, причём отдаёт **Symfony** (не IAP, иначе был бы 302 на /auth/login). Любой невалидный Bearer тоже даст 401.

## Что меняется

\`vite.config.ts\` → инжекция IAP-токена теперь per-request через event-handler:

\`\`\`ts
configure: (proxy) => {
    proxy.on("proxyReq", (proxyReq, req) => {
        if (devIapToken && !req.headers.authorization) {
            proxyReq.setHeader("Authorization", \`Bearer \${devIapToken}\`);
        }
    });
}
\`\`\`

Если SPA уже шлёт свой Authorization (JWT) — proxy не лезет. Если запрос анонимный — добавляем IAP bearer как раньше.

## Что разработчику сделать на своей стороне

После \`git pull\`:

1. Полный рестарт dev-server (Ctrl+C → \`npm start\`) — Vite кешит proxy на boot.
2. Очистить localStorage в браузере: DevTools → Application → Local Storage → http://localhost:3000 → Clear All. Тогда залежавшийся JWT не подкладывается в Authorization и Symfony обрабатывает запрос как анонимный.
3. Hard refresh (Ctrl+Shift+R).

После этого \`/api/v3/category/list?lang=ru\` должен отдать 200 с категориями. Для авторизованных эндпоинтов — залогиниться тестовым аккаунтом (\`vol@test.com\` / \`Test1234!\`), и JWT пойдёт корректно (proxy его не затрёт).

## Test plan

- [ ] Локально \`npm start\` после \`git pull\` + чистый localStorage → \`GET /api/v3/category/list?lang=ru\` → 200.
- [ ] Логин через \`POST /api/v2/token\` → JWT в localStorage → \`GET /api/v3/profile\` → 200.