### PR TITLE
fix(mercure): слэш между BASE_URL и path

### DIFF
--- a/src/app/providers/MessengerProvider/ui/MessengerProvider.tsx
+++ b/src/app/providers/MessengerProvider/ui/MessengerProvider.tsx
@@ -80,8 +80,8 @@ export const MessengerProvider: FC<MessengerProviderProps> = ({ children }) => {
     useEffect(() => {
         if (!mercureToken || !myProfile?.id || !isAuth) return;
 
-        const url = new URL(`${BASE_URL}.well-known/mercure`);
-        url.searchParams.append("topic", `${BASE_URL}api/v1/users/${myProfile.id}/messages/{?chat}`);
+        const url = new URL(`${BASE_URL}/.well-known/mercure`);
+        url.searchParams.append("topic", `${BASE_URL}/api/v1/users/${myProfile.id}/messages/{?chat}`);
         url.searchParams.append("authorization", mercureToken);
 
         const eventSource = new EventSource(url);

--- a/src/entities/Chat/lib/useGetChatMessages.tsx
+++ b/src/entities/Chat/lib/useGetChatMessages.tsx
@@ -48,8 +48,8 @@ export const useGetChatMessages = (
     useEffect(() => {
         if (!mercureToken || !chatId || !profileId) return;
 
-        const url = new URL(`${BASE_URL}.well-known/mercure`);
-        url.searchParams.append("topic", `${BASE_URL}api/v1/users/${profileId}/messages/?chat=${chatId}`);
+        const url = new URL(`${BASE_URL}/.well-known/mercure`);
+        url.searchParams.append("topic", `${BASE_URL}/api/v1/users/${profileId}/messages/?chat=${chatId}`);
         url.searchParams.append("authorization", mercureToken);
 
         const eventSource = new EventSource(url);

--- a/src/features/HostDescription/lib/hostDescriptionAdapter.ts
+++ b/src/features/HostDescription/lib/hostDescriptionAdapter.ts
@@ -47,7 +47,7 @@ export const hostDescriptionFormAdapter = (data?: Host): Partial<HostDescription
         socialMedia: hostSocialFields,
         address: data.address,
         avatar: data?.avatar ? {
-            id: `${BASE_URL}api/v1/media_objects/${data.avatar.id}`,
+            id: `${BASE_URL}/api/v1/media_objects/${data.avatar.id}`,
             contentUrl: data.avatar.contentUrl,
             thumbnails: data.avatar.thumbnails,
         } : undefined,


### PR DESCRIPTION
## Что

Добавлен `/` в склейки `${BASE_URL}xxx` для Mercure-URL и id media_objects.

## Зачем

`BASE_URL` хранится без trailing slash (`.replace(/\/+$/, "")` в `shared/constants/api`). Шаблоны вида `${BASE_URL}.well-known/mercure` давали ломаный URL без слэша — браузер уходил на несуществующий поддомен `api-prod.goodsurfing.org.well-known` и ловил 503 от DNS catch-all.

Обнаружено при ручной проверке регистрации на проде: после логина EventSource на Mercure падал с 503.

## Файлы

- `src/app/providers/MessengerProvider/ui/MessengerProvider.tsx`
- `src/entities/Chat/lib/useGetChatMessages.tsx`
- `src/features/HostDescription/lib/hostDescriptionAdapter.ts`

## Зависимость

Чтобы реально заработал чат, нужно ещё включить mercure-блок в `gs-backend/frankenphp/Caddyfile` и задать `MERCURE_*` секреты на проде — оформлено отдельным PR в gs-backend.

## Тест-план

- [ ] После деплоя залогиниться на dev → DevTools/Network: запрос `/.well-known/mercure` идёт на правильный домен.