### PR TITLE
fix(host): поле «Другое» обязательно при типе организации «Другое»

### DIFF
--- a/src/features/HostDescription/ui/HostDescriptionOrganization/HostDescriptionOrganization.tsx
+++ b/src/features/HostDescription/ui/HostDescriptionOrganization/HostDescriptionOrganization.tsx
@@ -27,6 +27,8 @@ export const HostDescriptionOrganization = memo((props: HostDescriptionOrganizat
     const { control, formState: { errors } } = useFormContext<HostDescriptionFormFields>();
     const formWatch = useWatch<HostDescriptionFormFields>({ control });
 
+    const isOtherType = formWatch.type?.organizationType === "Другое";
+
     const otherInputDisabled = () => {
         if (formWatch.type && formWatch.type.organizationType) {
             if (formWatch.type.organizationType !== "Другое") {
@@ -101,7 +103,19 @@ export const HostDescriptionOrganization = memo((props: HostDescriptionOrganizat
                     control={control}
                     maxLength={1000}
                     disabled={otherInputDisabled()}
+                    isError={!!errors.type?.otherOrganizationType?.message}
+                    rules={{
+                        validate: (value) => !isOtherType
+                            || (typeof value === "string" && value.trim().length > 0)
+                            || t("hostDescription.Это поле является обязательным"),
+                    }}
                 />
+                {errors.type?.otherOrganizationType?.message && (
+                    <ErrorText
+                        text={errors.type.otherOrganizationType.message}
+                        className={styles.error}
+                    />
+                )}
             </div>
             <div className={styles.website}>
                 <InputControl


### PR DESCRIPTION
## Что

При типе организации «Другое» поле свободного ввода теперь обязательно (client-side валидация) с понятной ошибкой, вместо серверной 422.

## Зачем

\`PATCH /api/v1/organizations/:id\` падал **422 «type: This value should not be blank»**, когда в форме «Описание организации» выбран тип «Другое», а поле свободного ввода пустое.

Причина: \`hostDescriptionApiAdapterUpdate\` (и \`...Create\`) при \`organizationType === "Другое"\` отправляют \`type = otherOrganizationType\`. У этого поля **не было** валидации \`required\` (в отличие от названия организации). Пустое поле → \`type=""\` → \`Assert\NotBlank\` на \`Organization.type\` → 422 → пользователю показывалось невнятное \`hostDescription.Произошла ошибка\`.

Особенно затрагивает организации с **пустым \`type\` в БД** (сид/миграция, ~1000 шт на проде): форма грузит их как «Другое» с пустым полем, и любое сохранение (даже правка описания) падало.

Обнаружено при ручной проверке на проде (скриншот пользователя: тип «Другое» → ошибка при сохранении). Подтверждено на уровне API: \`type=""\` → 422, \`type="<непусто>"\` → 200.

## Фикс

В \`HostDescriptionOrganization\` добавлена \`validate\`-проверка на \`type.otherOrganizationType\`: при \`organizationType === "Другое"\` значение обязано быть непустым, иначе выводится ошибка поля. Покрывает создание и редактирование (общий компонент).

\`\`\`tsx
rules={{
  validate: (value) => !isOtherType
    || (typeof value === "string" && value.trim().length > 0)
    || t("hostDescription.Это поле является обязательным"),
}}
\`\`\`

## Тест-план

- [ ] dev: организация с типом «Другое» и пустым полем → при «Сохранить» появляется ошибка поля, запрос не уходит.
- [ ] Заполнить поле → сохранение проходит (200).
- [ ] Стандартные типы (ИП/ОАО/ООО/ООПТ) — поле «Другое» disabled, валидация не мешает, сохранение работает.

## Заметка (отдельно)

На проде ~1000 организаций имеют \`type=''\` (вероятно сид из staging-копии). Бэкфилл данных рискован (неизвестен реальный тип) — данные «самовылечатся» при следующем редактировании с этим фиксом. При желании можно завести отдельную задачу на разбор сид-данных.