### PR TITLE
fix: avoid injecting IAP token in Vite dev proxy

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,8 +2,10 @@
 # come from Docker ARGs (.github/workflows/deploy-*.yml). Keep this file in git.
 #
 # In dev the SPA hits the local Vite dev server, which proxies API requests
-# to `VITE_DEV_API_TARGET` and injects `Authorization: Bearer VITE_DEV_IAP_TOKEN`.
-# So `VITE_API_BASE_URL` must stay empty → API calls become relative paths.
+# to `VITE_DEV_API_TARGET`. Do not inject a dev Bearer token here: Symfony treats
+# any Authorization Bearer value as a JWT and returns 401 for invalid tokens.
+# So `VITE_API_BASE_URL` must stay empty; dev API origin is derived from
+# `window.location.origin` in `src/shared/constants/api`.
 
 VITE_API_BASE_URL=""
 VITE_MAIN_URL="http://localhost:3000"
@@ -12,8 +14,3 @@ VITE_VKID_CLIENT_ID="54011426"
 
 # Where the dev proxy forwards. Switch to api-dev/api-prod if needed.
 VITE_DEV_API_TARGET="https://api-staging.goodsurfing.org"
-
-# IAP bypass token for the staging oauth2-proxy. The same value lives in
-# package.json's `e2e` script, so it's not really secret. Override via
-# .env.development.local if you have a different one.
-VITE_DEV_IAP_TOKEN="yiap_66fa6fb58d3632ec2a187696244db59ea858be9c"

--- a/.env.development.local.example
+++ b/.env.development.local.example
@@ -1,5 +1,4 @@
 # Personal overrides for local dev. Copy to .env.development.local (gitignored).
-# Use this for IAP tokens you don't want shared, or to point at a different env.
+# Use this to point at a different API env.
 
 # VITE_DEV_API_TARGET="https://api-dev.goodsurfing.org"
-# VITE_DEV_IAP_TOKEN="yiap_your_personal_bypass_here"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm start          # http://localhost:3000
 
 Никаких `.env` создавать не нужно — все умолчания committed в `.env.development`.
 
-Под капотом dev-сервер проксирует `/api`, `/admin`, `/auth`, `/oauth2`, `/static-media`, `/media` на `https://api-staging.goodsurfing.org` и подкладывает IAP-токен в `Authorization: Bearer …` — обходим CORS и oauth2-proxy одним движением. Конфиг — в `.env.development`, проксирование — в `vite.config.ts`.
+Под капотом dev-сервер проксирует `/api`, `/admin`, `/auth`, `/oauth2`, `/static-media`, `/media` на `https://api-staging.goodsurfing.org`. Он не подкладывает dev-токен в `Authorization`: Symfony воспринимает любой `Bearer` как JWT приложения и отвечает 401 на невалидные токены. Конфиг — в `.env.development`, проксирование — в `vite.config.ts`.
 
 ## Логин
 
@@ -28,11 +28,10 @@ VK-auth flow локально не работает (callback зарегистр
 
 ## Кастомизация
 
-Чтобы переключить target или подложить свой IAP-токен — скопируй `.env.development.local.example` в `.env.development.local` (gitignored) и переопредели:
+Чтобы переключить target — скопируй `.env.development.local.example` в `.env.development.local` (gitignored) и переопредели:
 
 ```env
 VITE_DEV_API_TARGET="https://api-dev.goodsurfing.org"
-VITE_DEV_IAP_TOKEN="yiap_..."
 ```
 
 # Build / deploy

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,20 +9,12 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), "");
 
     // When developers run `npm start`, route the API calls through the Vite
-    // dev-server proxy so they hit staging without CORS pain. The IAP token
-    // is injected as a Bearer header — same trick the e2e suite uses
-    // (see e2e/global-setup.ts).
+    // dev-server proxy so they hit staging without CORS pain.
     //
     // Behaviour selectors:
     // - VITE_DEV_API_TARGET (default https://api-staging.goodsurfing.org) — where the
     //   proxy forwards to. Override to dev/prod if needed.
-    // - VITE_DEV_IAP_TOKEN — the yiap-prefixed bypass token. If empty, the
-    //   proxy still works (you'll get 302 to /auth/login from IAP — clear signal).
     const devProxyTarget = env.VITE_DEV_API_TARGET || "https://api-staging.goodsurfing.org";
-    const devIapToken = env.VITE_DEV_IAP_TOKEN || "";
-    const devProxyHeaders: Record<string, string> = devIapToken
-        ? { Authorization: `Bearer ${devIapToken}` }
-        : {};
 
     return {
         plugins: [react()],
@@ -73,28 +65,14 @@ export default defineConfig(({ mode }) => {
             open: true,
             // Forward backend/IAP paths to the chosen target. Matches every
             // path the SPA actually uses against the API (REST + admin +
-            // IAP login flow + uploaded media). Everything else (HTML,
+            // OAuth/login flow + uploaded media). Everything else (HTML,
             // /assets/*, /locales/*) stays on the Vite dev server.
-            //
-            // We do NOT statically set `headers: { Authorization: ... }` on
-            // the proxy config: that would clobber any user JWT the SPA
-            // attaches via baseQuery prepareHeaders (Symfony then sees the
-            // IAP token, fails JWT parsing, and answers 401 to authenticated
-            // calls). Instead inject IAP only when the original request
-            // doesn't already carry an Authorization header.
             proxy: {
                 "^/(api|admin|auth|oauth2|static-media|media)(/|$)": {
                     target: devProxyTarget,
                     changeOrigin: true,
                     secure: true,
                     cookieDomainRewrite: { "*": "" },
-                    configure: (proxy) => {
-                        proxy.on("proxyReq", (proxyReq, req) => {
-                            if (devIapToken && !req.headers.authorization) {
-                                proxyReq.setHeader("Authorization", `Bearer ${devIapToken}`);
-                            }
-                        });
-                    },
                 },
             },
         },


### PR DESCRIPTION
- Убрал подстановку dev/IAP-токена в `Authorization` внутри Vite dev proxy.
- Обновил `vite.config.ts`: локальный proxy теперь только проксирует backend-пути на staging/dev target без принудительной установки `Bearer`-токена.
- Обновил `.env.development` и `.env.development.local.example`, удалив настройку `VITE_DEV_IAP_TOKEN`.
- Актуализировал `README.md`: описал, что локальный dev-сервер больше не подкладывает токен в `Authorization`, потому что Symfony воспринимает любой `Bearer` как JWT приложения и отвечает `401` на невалидные токены.

## Зачем

Раньше dev proxy мог подставлять IAP-токен в заголовок `Authorization`. Из-за этого backend пытался обработать его как JWT приложения, что ломало авторизованные запросы и приводило к `401`.

Теперь локальный запуск работает чище: proxy отвечает только за обход CORS и маршрутизацию запросов на API, не вмешиваясь в авторизацию приложения.