### PR TITLE
fix(gallery): исправить сломанный IRI в галерее организации

### DIFF
--- a/src/features/Gallery/ui/HostGallery/HostGallery.tsx
+++ b/src/features/Gallery/ui/HostGallery/HostGallery.tsx
@@ -4,7 +4,7 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { ImagesUploader } from "@/shared/ui/ImagesUploader/ImagesUploader";
 import { MediaObjectType } from "@/types/media";
-import { getHostMediaContentsApiArray, getMediaContentsApiArray } from "@/shared/lib/getMediaContent";
+import { getHostMediaContentsApiArray } from "@/shared/lib/getMediaContent";
 import HintPopup from "@/shared/ui/HintPopup/HintPopup";
 import { HintType, ToastAlert } from "@/shared/ui/HintPopup/HintPopup.interface";
 import { Host, useUpdateHostMutation } from "@/entities/Host";
@@ -61,13 +61,13 @@ export const HostGallery: FC<HostGalleryProps> = (props) => {
         const currentGalleryImages = hostData.galleryImages;
 
         const updatedGalleryImages = currentGalleryImages.filter(
-            (image) => image["@id"] !== mediaObjectUrl,
+            (image) => image.id !== mediaObjectUrl,
         );
 
         await updateHost({
             id: hostData.id,
             body: {
-                galleryImages: getMediaContentsApiArray(updatedGalleryImages),
+                galleryImages: getHostMediaContentsApiArray(updatedGalleryImages),
             },
         }).unwrap()
             .then(() => {

--- a/src/shared/lib/getMediaContent.ts
+++ b/src/shared/lib/getMediaContent.ts
@@ -61,10 +61,7 @@ export const getMediaContentsApiArray = (images: Image[]) => {
     return newImages;
 };
 
-export const getHostMediaContentsApiArray = (images: MediaObjectType[]) => {
-    const newImages = images.map((image) => `${BASE_URL}${image["@id"].slice(1)}`);
-    return newImages;
-};
+export const getHostMediaContentsApiArray = (images: MediaObjectType[]) => images.map((image) => image["@id"]);
 
 export const getImageDetails = (image: GalleryItem | string | MediaObjectType) => {
     if (typeof image === "string") {


### PR DESCRIPTION
## Проблема

На странице `/host/gallery` при попытке загрузить или удалить фото появлялась ошибка «Произошла ошибка с обновлением галереи». В логах прода:

```
Invalid IRI "https://api-prod.goodsurfing.orgapi/v1/media_objects/..."
No routes found for "/v1/media_objects/.../".
```

## Причина

`getHostMediaContentsApiArray` строил IRI как `${BASE_URL}${image["@id"].slice(1)}`. `BASE_URL` не имеет trailing-slash, `.slice(1)` убирал leading-slash из `@id` — строки склеивались без разделителя → невалидный URL.

Дополнительно: в `handleOnDelete` фильтр сравнивал `image["@id"]` (вида `/api/v1/media_objects/uuid`) с `mediaObjectUrl` (вида `uuid`) — значения никогда не совпадали, удаление не работало.

## Исправление

- `getHostMediaContentsApiArray`: использует `image["@id"]` напрямую (уже содержит `/api/v1/media_objects/uuid`)
- `HostGallery.handleOnDelete`: фильтр по `image.id`, тело запроса через `getHostMediaContentsApiArray`

## Тест

Проверить на staging: загрузить фото → успех, удалить фото → успех.