### PR TITLE
feat: геокодер через бэкенд-прокси

### DIFF
--- a/src/features/MapWithAddress/model/lib/makeGeoUrl.ts
+++ b/src/features/MapWithAddress/model/lib/makeGeoUrl.ts
@@ -1,5 +1,5 @@
 export const makeGeoUrl = (geocode: string) => {
-    const url = new URL("https://geocode-maps.yandex.ru/1.x");
+    const url = new URL("https://geocode-maps.yandex.ru/v1");
     const format = "json";
     const geocodeParam = geocode;
     url.searchParams.set("apikey", import.meta.env.VITE_API_YANDEX_KEY || "");

--- a/src/features/MapWithAddress/model/services/getGeoObjectCollection/getGeoObjectCollection.ts
+++ b/src/features/MapWithAddress/model/services/getGeoObjectCollection/getGeoObjectCollection.ts
@@ -26,8 +26,6 @@ export const getGeoObjectCollection = async (
             `${API_YANDEX_BASE_URL}`,
             {
                 params: {
-                    apikey: import.meta.env.VITE_API_YANDEX_KEY,
-                    format: "json",
                     geocode: address,
                     lang: languageList[language],
                 },
@@ -46,8 +44,6 @@ export const getGeoObjectByAddress = async (address: string) => {
             `${API_YANDEX_BASE_URL}`,
             {
                 params: {
-                    apikey: import.meta.env.VITE_API_YANDEX_KEY,
-                    format: "json",
                     geocode: address,
                 },
             },
@@ -74,8 +70,6 @@ export const getGeoObjectByCoordinates = async (
         const roundedLatitude = latitude.toFixed(6);
         const res = await axios.get(`${API_YANDEX_BASE_URL}`, {
             params: {
-                apikey: import.meta.env.VITE_API_YANDEX_KEY,
-                format: "json",
                 geocode: `${roundedLongitude}, ${roundedLatitude}`,
             },
         });

--- a/src/shared/constants/api/index.ts
+++ b/src/shared/constants/api/index.ts
@@ -23,7 +23,7 @@ export const API_VACANCY_BASE_URL = `${API_ORIGIN}/api/vacancies/`;
 export const API_USER_BASE_URL = `${API_ORIGIN}/api/users/`;
 export const API_MEDIA_BASE_URL = `${API_ORIGIN}/api/media_objects/`;
 export const API_TRANSLATION_BASE_URL = `${API_ORIGIN}/api/v1/translation`;
-export const API_YANDEX_BASE_URL = "https://geocode-maps.yandex.ru/1.x/";
+export const API_YANDEX_BASE_URL = "https://geocode-maps.yandex.ru/v1/";
 // Used for OAuth/IAP redirect-back URLs. In dev — origin of the running
 // dev-server (typically http://localhost:3000), not a baked-in production URL.
 export const MAIN_URL = import.meta.env.DEV && typeof window !== "undefined"

--- a/src/shared/constants/api/index.ts
+++ b/src/shared/constants/api/index.ts
@@ -23,7 +23,7 @@ export const API_VACANCY_BASE_URL = `${API_ORIGIN}/api/vacancies/`;
 export const API_USER_BASE_URL = `${API_ORIGIN}/api/users/`;
 export const API_MEDIA_BASE_URL = `${API_ORIGIN}/api/media_objects/`;
 export const API_TRANSLATION_BASE_URL = `${API_ORIGIN}/api/v1/translation`;
-export const API_YANDEX_BASE_URL = "https://geocode-maps.yandex.ru/v1/";
+export const API_YANDEX_BASE_URL = `${API_ORIGIN}/api/v1/geocode`;
 // Used for OAuth/IAP redirect-back URLs. In dev — origin of the running
 // dev-server (typically http://localhost:3000), not a baked-in production URL.
 export const MAIN_URL = import.meta.env.DEV && typeof window !== "undefined"

--- a/src/shared/utils/url/ymapUrlHelpers.ts
+++ b/src/shared/utils/url/ymapUrlHelpers.ts
@@ -1,9 +1,8 @@
-const API_KEY = "32dcfbe4-583a-4e13-be77-83d32a181111";
 export const makeGeoUrl = (geocode: string) => {
-    const url = new URL("https://geocode-maps.yandex.ru/1.x");
+    const url = new URL("https://geocode-maps.yandex.ru/v1");
     const format = "json";
     const geocodeParam = geocode;
-    url.searchParams.set("apikey", API_KEY);
+    url.searchParams.set("apikey", import.meta.env.VITE_API_YANDEX_KEY || "");
     url.searchParams.set("format", format);
     url.searchParams.set("geocode", geocodeParam);
     return url.toString();


### PR DESCRIPTION
## Что изменилось

- `API_YANDEX_BASE_URL` теперь указывает на `/api/v1/geocode` (бэкенд-прокси) вместо `geocode-maps.yandex.ru`
- Из axios-запросов убраны `apikey` и `format` — бэкенд добавляет их сам с серверным ключом
- API-ключ больше **не попадает в JS-бандл**

## Связанные PR

- Backend: Goodsurfing/gs-backend#187 — новый эндпоинт `/api/v1/geocode` (**мержить первым**)

## Порядок деплоя

1. Смержить и задеплоить backend PR #187
2. Добавить `YANDEX_GEOCODER_API_KEY=<ключ>` в `.env.local` на серверах (или в CI-секреты)
3. Смержить и задеплоить этот PR