### PR TITLE
fix(payment): таймаут поллинга и обработка отмены на странице успеха

### DIFF
--- a/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.tsx
+++ b/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.tsx
@@ -6,9 +6,16 @@ import Button from "@/shared/ui/Button/Button";
 import Preloader from "@/shared/ui/Preloader/Preloader";
 
 import { useAuth } from "@/routes/model/guards/AuthProvider";
-import { useGetCurrentMembershipQuery } from "@/store/api/membershipApi";
+import {
+    useGetCurrentMembershipQuery,
+    useGetPaymentStatusQuery,
+} from "@/store/api/membershipApi";
 import { useLocale } from "@/app/providers/LocaleProvider";
-import { getMyOffersPageUrl, getOffersMapPageUrl } from "@/shared/config/routes/AppUrls";
+import {
+    getMyOffersPageUrl,
+    getMembershipPageUrl,
+    getOffersMapPageUrl,
+} from "@/shared/config/routes/AppUrls";
 
 import styles from "./PaymentSuccessPage.module.scss";
 
@@ -29,6 +36,9 @@ const HOST_BENEFITS = [
 ];
 
 const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 60_000;
+
+const FAIL_STATUSES = new Set(["CANCELLED", "FAILED", "REFUNDED"]);
 
 const PaymentSuccessPage: React.FC = () => {
     const { locale } = useLocale();
@@ -38,18 +48,49 @@ const PaymentSuccessPage: React.FC = () => {
 
     const paymentId = searchParams.get("payment_id");
 
-    const [shouldPoll, setShouldPoll] = useState<boolean>(Boolean(paymentId));
+    const [shouldPoll, setShouldPoll] = useState(Boolean(paymentId));
+    const [timedOut, setTimedOut] = useState(false);
 
-    const { data: membership, isLoading } = useGetCurrentMembershipQuery(undefined, {
-        skip: !isAuth,
-        pollingInterval: shouldPoll && isAuth ? POLL_INTERVAL_MS : 0,
+    const { data: membership, isLoading: membershipLoading } = useGetCurrentMembershipQuery(
+        undefined,
+        {
+            skip: !isAuth,
+            pollingInterval: shouldPoll && isAuth ? POLL_INTERVAL_MS : 0,
+        },
+    );
+
+    const { data: payment } = useGetPaymentStatusQuery(paymentId!, {
+        skip: !paymentId || !isAuth,
+        pollingInterval: shouldPoll && isAuth
+            ? POLL_INTERVAL_MS
+            : 0,
     });
 
+    // Таймаут поллинга — если через 60 сек не пришёл webhook
+    useEffect(() => {
+        if (!shouldPoll) return undefined;
+        const timer = setTimeout(() => {
+            setShouldPoll(false);
+            setTimedOut(true);
+        }, POLL_TIMEOUT_MS);
+        return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // Остановить поллинг при активном членстве
     useEffect(() => {
         if (membership?.isActive) {
             setShouldPoll(false);
         }
     }, [membership?.isActive]);
+
+    // Редирект при отменённом или проваленном платеже
+    useEffect(() => {
+        if (!payment) return;
+        if (FAIL_STATUSES.has(payment.status)) {
+            navigate(`/${locale}/payment/fail?reason=cancelled`);
+        }
+    }, [payment, navigate, locale]);
 
     useEffect(() => {
         if (!isAuth) {
@@ -61,11 +102,51 @@ const PaymentSuccessPage: React.FC = () => {
         return <Preloader />;
     }
 
-    if (isLoading && !membership) {
+    // Первичная загрузка
+    if (membershipLoading && !membership) {
         return (
             <MainPageLayout>
                 <div className={styles.container}>
                     <Preloader />
+                </div>
+            </MainPageLayout>
+        );
+    }
+
+    // Ждём подтверждения от платёжного провайдера
+    if (shouldPoll && !membership?.isActive) {
+        return (
+            <MainPageLayout>
+                <div className={styles.container}>
+                    <Preloader />
+                </div>
+            </MainPageLayout>
+        );
+    }
+
+    // Webhook не пришёл за 60 секунд
+    if (timedOut && !membership?.isActive) {
+        return (
+            <MainPageLayout>
+                <div className={styles.container}>
+                    <div className={styles.content}>
+                        <h1 className={styles.title}>Платёж обрабатывается</h1>
+                        <p className={styles.subtitle}>
+                            Подтверждение занимает дольше обычного.
+                            Проверьте статус на странице членства через несколько минут
+                            или обратитесь в службу поддержки.
+                        </p>
+                        <div className={styles.buttonWrapper}>
+                            <Button
+                                color="BLUE"
+                                size="LARGE"
+                                variant="FILL"
+                                onClick={() => navigate(getMembershipPageUrl(locale))}
+                            >
+                                На страницу членства
+                            </Button>
+                        </div>
+                    </div>
                 </div>
             </MainPageLayout>
         );

--- a/src/store/api/membershipApi.ts
+++ b/src/store/api/membershipApi.ts
@@ -46,6 +46,22 @@ export interface CheckoutResponse {
     tariffCode: string;
 }
 
+export type PaymentStatusValue =
+    | "PENDING"
+    | "PROCESSING"
+    | "SUCCESS"
+    | "CANCELLED"
+    | "FAILED"
+    | "REFUNDED";
+
+export interface PaymentStatusResponse {
+    id: string;
+    status: PaymentStatusValue;
+    amount: string;
+    currency: string;
+    paidAt: string | null;
+}
+
 export const membershipApi = createApi({
     reducerPath: "membershipApi",
     baseQuery,
@@ -74,6 +90,12 @@ export const membershipApi = createApi({
             }),
             invalidatesTags: ["membership"],
         }),
+        getPaymentStatus: build.query<PaymentStatusResponse, string>({
+            query: (id) => ({
+                url: `${API_BASE_URL}payments/${id}`,
+                method: "GET",
+            }),
+        }),
     }),
 });
 
@@ -81,4 +103,5 @@ export const {
     useGetTariffsQuery,
     useGetCurrentMembershipQuery,
     useCheckoutMembershipMutation,
+    useGetPaymentStatusQuery,
 } = membershipApi;


### PR DESCRIPTION
## Что сломано

`PaymentSuccessPage` — два бага в логике поллинга после возврата с ЮКассы.

## Изменения

**Баг 1 — бесконечный поллинг при отмене платежа**

Если пользователь нажал «Отмена» на странице ЮКассы, он возвращается на `/payment/success` (у ЮКассы нет отдельного `cancel_url`). `membership.isActive` никогда не становится `true`, поллинг не останавливается.

Теперь: параллельно поллится `GET /api/v1/payments/{id}`. При статусе `CANCELLED`, `FAILED` или `REFUNDED` — немедленный редирект на `/payment/fail?reason=cancelled`. Страница `/payment/fail` теперь достижима в реальном ЮКасса-флоу.

**Баг 2 — нет таймаута поллинга**

Если webhook от ЮКассы не приходит (провайдер недоступен, сетевая ошибка), страница крутила спиннер бесконечно.

Теперь: таймаут 60 секунд. По истечении — экран «Платёж обрабатывается» с кнопкой на страницу членства.

**`membershipApi.ts`** — добавлен endpoint `getPaymentStatus` (`GET /api/v1/payments/{id}`), тип `PaymentStatusValue`, интерфейс `PaymentStatusResponse`, хук `useGetPaymentStatusQuery`.

## Проверка

Для полной проверки нужен рабочий ключ ЮКассы (текущий `live__X5Z0V...` возвращает `invalid_credentials` — отдельная задача).

Через fake-провайдер (`PAYMENT_PROVIDER=fake`) оба сценария воспроизводятся локально:
- нажать «Отменить» → должен редиректить на `/payment/fail`
- имитировать задержку webhook (убрать вызов `syncLinkedEntities` в `FakeCheckoutController.approve`) → через 60 сек должен показать «Платёж обрабатывается»