### PR TITLE
fix(conditions): switchState теперь зависит от наличия данных

### DIFF
--- a/src/entities/Admin/lib/adminOfferAdapter.ts
+++ b/src/entities/Admin/lib/adminOfferAdapter.ts
@@ -273,13 +273,17 @@ export const offerConditionsAdapter = (
         transferIds,
     } = offerConditions;
 
+    const normalizedHouseIds = houseIds || [];
+    const normalizedFoodIds = foodIds || [];
+    const normalizedTransferIds = transferIds || [];
+
     return {
         extraConditions: additionalConditions || "",
         extraFeatures: { extraFeatures: additionalFeatures },
         facilities: { facilities: conveniences },
-        housing: { switchState: true, housing: houseIds || [] },
-        nutrition: { switchState: true, nutrition: foodIds || [] },
-        travel: { switchState: true, travel: transferIds || [] },
+        housing: { switchState: normalizedHouseIds.length > 0, housing: normalizedHouseIds },
+        nutrition: { switchState: normalizedFoodIds.length > 0, nutrition: normalizedFoodIds },
+        travel: { switchState: normalizedTransferIds.length > 0, travel: normalizedTransferIds },
         payment: {
             currency: currency ?? "RUB",
             contribution: volunteerContributions ?? 0,

--- a/src/features/OfferConditions/lib/offerConditionsAdapter.ts
+++ b/src/features/OfferConditions/lib/offerConditionsAdapter.ts
@@ -52,9 +52,9 @@ export const offerConditionsAdapter = (
         extraConditions: additionalConditions || "",
         extraFeatures: { extraFeatures: additionalFeatures },
         facilities: { facilities: conveniences },
-        housing: { switchState: true, housing: housesTemp || [] },
-        nutrition: { switchState: true, nutrition: foodTemp || [] },
-        travel: { switchState: true, travel: transferTemp || [] },
+        housing: { switchState: housesTemp.length > 0, housing: housesTemp },
+        nutrition: { switchState: foodTemp.length > 0, nutrition: foodTemp },
+        travel: { switchState: transferTemp.length > 0, travel: transferTemp },
         payment: {
             currency,
             contribution: volunteerContributions,


### PR DESCRIPTION
## Проблема

Раздел «Условия вакансии» не давал сохранить данные и показывал ошибку.

**Причина:** Адаптер загрузки данных (`offerConditionsAdapter`) всегда выставлял `switchState: true` для блоков жилья, питания и транспорта — независимо от того, выбраны ли там элементы. Если вакансия новая (или условия ещё не заполнены), сервер возвращает пустые массивы, а форма открывалась с переключателями «Да» без выбранных опций.

При попытке сохранить — форма-валидация срабатывала: `switchState === true && array.length === 0 → "NOT_SELECTED"`, запрос не уходил.

## Фикс

`switchState: true` → `switchState: array.length > 0` в двух адаптерах:
- `src/entities/Admin/lib/adminOfferAdapter.ts` — Admin-панель (основной кейс)
- `src/features/OfferConditions/lib/offerConditionsAdapter.ts` — не-admin поток

## Проверка

- Открыть условия вакансии с пустыми полями → все переключатели должны быть в положении «Нет»
- Сохранить без изменений → должно сохраниться без ошибки
- Выставить жильё → переключатель «Да», выбрать тип → сохранить → OK