### PR TITLE
fix(profile): сбросить isDirty после сохранения формы описания хоста

### DIFF
--- a/src/features/HostDescription/ui/HostDescriptionForm/HostDescriptionForm.tsx
+++ b/src/features/HostDescription/ui/HostDescriptionForm/HostDescriptionForm.tsx
@@ -124,6 +124,9 @@ export const HostDescriptionForm = memo((props: HostDescriptionFormProps) => {
                 });
             }
             sessionStorage.removeItem(HOST_DESCRIPTION_FORM);
+            // Сбрасываем isDirty, чтобы эффект сохранения в sessionStorage
+            // не успел перезаписать только что удалённые данные до прихода рефетча
+            reset(data);
         } catch {
             setToast({
                 text: t("hostDescription.Произошла ошибка"),


### PR DESCRIPTION
## Что

После успешного `handleSubmit` в `HostDescriptionForm` вызов `sessionStorage.removeItem(HOST_DESCRIPTION_FORM)` не предотвращал повторную запись в sessionStorage: эффект `isDirty` успевал сработать раньше, чем приходил рефетч, и перезаписывал только что удалённые данные. После этого первый эффект читал sessionStorage и сбрасывал форму на устаревшие данные вместо серверных.

## Фикс

Добавлен `reset(data)` сразу после `removeItem`, чтобы очистить `isDirty` до следующего рендера и предотвратить гонку с эффектом сохранения.

## Тест

1. Открыть профиль организации → форма описания
2. Изменить поле → сохранить
3. Убедиться, что после сохранения форма отражает серверные данные, а не предыдущий черновик из sessionStorage