### PR TITLE
fix(academy): кнопка «Опубликовать» теперь сохраняет курс

### DIFF
--- a/src/features/Admin/ui/AdminCourseForm/AdminCourseForm.tsx
+++ b/src/features/Admin/ui/AdminCourseForm/AdminCourseForm.tsx
@@ -65,7 +65,7 @@ export const AdminCourseForm: FC<AdminCourseFormProps> = (props) => {
     });
     const {
         handleSubmit, reset, control, formState: { errors },
-        watch,
+        watch, setValue,
     } = form;
 
     const isPublicValue = watch("isPublic");
@@ -254,10 +254,8 @@ export const AdminCourseForm: FC<AdminCourseFormProps> = (props) => {
     };
 
     const handleTogglePublish = () => {
-        reset((prev) => ({
-            ...prev,
-            isPublic: !prev.isPublic,
-        }));
+        setValue("isPublic", !isPublicValue, { shouldDirty: true });
+        handleSubmit(onSubmitForm)();
     };
 
     const renderLessonsSection = () => {


### PR DESCRIPTION
## Проблема

Кнопка «Опубликовать» в форме редактирования курса меняла только локальное состояние формы (`isPublic`), но не отправляла запрос на сервер. Пользователь нажимал кнопку — ничего не происходило, курс оставался неопубликованным.

## Причина

`handleTogglePublish` вызывал `reset((prev) => ({ ...prev, isPublic: !prev.isPublic }))` — это обновляло дефолтные значения формы, но кнопка имела `type="button"`, поэтому сабмит не происходил.

## Исправление

Заменено на `setValue("isPublic", !isPublicValue, { shouldDirty: true })` + немедленный вызов `handleSubmit(onSubmitForm)()`. Теперь клик по «Опубликовать» / «Распубликовать» сразу отправляет PATCH-запрос.

## Затронутые файлы

- `src/features/Admin/ui/AdminCourseForm/AdminCourseForm.tsx`