### PR TITLE
fix(academy): фиксы по ревью кнопки публикации курса

### DIFF
--- a/src/features/Admin/ui/AdminCourseForm/AdminCourseForm.tsx
+++ b/src/features/Admin/ui/AdminCourseForm/AdminCourseForm.tsx
@@ -254,8 +254,15 @@ export const AdminCourseForm: FC<AdminCourseFormProps> = (props) => {
     };
 
     const handleTogglePublish = () => {
-        setValue("isPublic", !isPublicValue, { shouldDirty: true });
-        handleSubmit(onSubmitForm)();
+        if (!course) {
+            setValue("isPublic", !isPublicValue, { shouldDirty: true });
+            return;
+        }
+        const newValue = !isPublicValue;
+        setValue("isPublic", newValue, { shouldDirty: true });
+        handleSubmit(onSubmitForm, () => {
+            setValue("isPublic", !newValue, { shouldDirty: false });
+        })();
     };
 
     const renderLessonsSection = () => {


### PR DESCRIPTION
## Контекст

Дополнение к PR #284 по итогам code review.

## Найденные нарушения и исправления

### 1. Create-страница: кнопка «Опубликовать» создавала курс преждевременно (CONFIRMED)
После #284 `handleTogglePublish` вызывал `handleSubmit`, что на странице создания (`course === undefined`) немедленно триггерило `createCourse()` + навигацию — без явного нажатия «Сохранить». Исправлено гуардом `if (!course)`: на create-странице кнопка только переключает `isPublic` локально.

### 2. При провале валидации кнопка застревала в неверном состоянии (CONFIRMED)
`setValue("isPublic", newValue)` срабатывал до `handleSubmit`, поэтому при ошибке валидации кнопка визуально переключалась («Опубликовать» → «Распубликовать»), но сервер запроса не получал. Добавлен `onInvalid`-колбэк, который откатывает `isPublic` обратно.

## Затронутые файлы

- `src/features/Admin/ui/AdminCourseForm/AdminCourseForm.tsx`