### PR TITLE
fix: страница «О Гудсерфинге» — скрываем пустые секции

### DIFF
--- a/src/entities/Admin/model/types/adminSchema.ts
+++ b/src/entities/Admin/model/types/adminSchema.ts
@@ -759,8 +759,8 @@ export interface AboutProjectPrinciples {
 }
 
 export interface GetAboutProjectInfo {
-    mission: string;
-    howAllStart: string;
+    mission: string | null;
+    howAllStart: string | null;
     today: {
         volunteerCount: number;
         vacancyCountryCount: number;

--- a/src/pages/AboutProjectPage/ui/AboutProjectPage/AboutProjectPage.tsx
+++ b/src/pages/AboutProjectPage/ui/AboutProjectPage/AboutProjectPage.tsx
@@ -28,17 +28,25 @@ const AboutProjectPage = () => {
         <MainPageLayout>
             <div className={styles.wrapper}>
                 <Header />
-                <Mission className={styles.section} description={data.mission} />
-                <HowItStarted className={styles.section} description={data.howAllStart} />
-                <Principles
-                    className={cn(styles.section, styles.extraPadding)}
-                    principles={data.principles}
-                />
+                {data.mission && (
+                    <Mission className={styles.section} description={data.mission} />
+                )}
+                {data.howAllStart && (
+                    <HowItStarted className={styles.section} description={data.howAllStart} />
+                )}
+                {data.principles.length > 0 && (
+                    <Principles
+                        className={cn(styles.section, styles.extraPadding)}
+                        principles={data.principles}
+                    />
+                )}
                 <GoodsurfingNow
                     className={cn(styles.section, styles.extraPadding)}
                     today={data.today}
                 />
-                <Gallery className={styles.section} gallery={data.galleryImages} />
+                {data.galleryImages.length > 0 && (
+                    <Gallery className={styles.section} gallery={data.galleryImages} />
+                )}
             </div>
         </MainPageLayout>
     );

--- a/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.tsx
+++ b/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.tsx
@@ -6,7 +6,7 @@ import styles from "./HowItStarted.module.scss";
 
 interface HowItStartedProps {
     className?: string;
-    description: string;
+    description: string | null;
 }
 
 export const HowItStarted: FC<HowItStartedProps> = (

--- a/src/pages/AboutProjectPage/ui/Mission/Mission.tsx
+++ b/src/pages/AboutProjectPage/ui/Mission/Mission.tsx
@@ -11,7 +11,7 @@ import { getNPOPageUrl } from "@/shared/config/routes/AppUrls";
 
 interface MissionProps {
     className?: string;
-    description: string;
+    description: string | null;
 }
 
 export const Mission: FC<MissionProps> = (props: MissionProps) => {


### PR DESCRIPTION
## Проблема

Страница «О Гудсерфинге» выглядела «пустой» — секции с заголовками (Миссия, Как всё началось, Принципы, Галерея) рендерились без контента, потому что в базе нет записи в таблице `page` с кодом `gudserfing`.

API возвращает: `{ mission: null, howAllStart: null, principles: [], galleryImages: [] }`

## Причина

Типы `GetAboutProjectInfo.mission` и `howAllStart` были `string` (не nullable), а в реальности API может вернуть `null`. Компоненты `Mission` и `HowItStarted` рендерили пустые `<p>` без проверки.

## Исправление

- `GetAboutProjectInfo`: `mission: string | null`, `howAllStart: string | null`
- `Mission` и `HowItStarted` props: `description: string | null`
- `AboutProjectPage`: секции `Mission`, `HowItStarted`, `Principles`, `Gallery` рендерятся только при наличии данных
- `GoodsurfingNow` (живая статистика — волонтёры, вакансии, страны, отзывы) рендерится всегда

## Примечание

Контент для страницы нужно заполнить через панель администратора (`/auth/admin`), раздел «О Гудсерфинге».