### PR TITLE
fix: TypeScript — AdminAboutProjectInfo null → empty string

### DIFF
--- a/src/widgets/Admin/ui/AdminAboutProjectInfo/AdminAboutProjectInfo.tsx
+++ b/src/widgets/Admin/ui/AdminAboutProjectInfo/AdminAboutProjectInfo.tsx
@@ -25,8 +25,8 @@ export const AdminAboutProjectInfo: FC = () => {
         }
 
         return {
-            mission: aboutProjectData.mission,
-            howAllStart: aboutProjectData.howAllStart,
+            mission: aboutProjectData.mission ?? "",
+            howAllStart: aboutProjectData.howAllStart ?? "",
             principles: aboutProjectData.principles,
             galleryImages: aboutProjectData.galleryImages,
         };


### PR DESCRIPTION
## Контекст

Предыдущий PR #286 сделал `GetAboutProjectInfo.mission` и `howAllStart` типами `string | null`.
Компонент `AdminAboutProjectInfo` использует эти поля для инициализации формы редактирования,
где ожидается `string` (не nullable).

## Исправление

```ts
mission: aboutProjectData.mission ?? "",   // было: aboutProjectData.mission
howAllStart: aboutProjectData.howAllStart ?? "", // было: aboutProjectData.howAllStart
```

Пустая строка — корректное начальное значение для текстового поля в форме.