### PR TITLE
fix: адрес показывает «undefined» при загрузке сохранённых координат

### DIFF
--- a/src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx
+++ b/src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx
@@ -174,7 +174,7 @@ const FundraiseStepPage = () => {
         if (geoObject) {
             return {
                 address: {
-                    address: `${geoObject.description}, ${geoObject.name}`,
+                    address: `${geoObject.description ? `${geoObject.description}, ` : ""}${geoObject.name}`,
                     geoObject: {
                         name: geoObject.name,
                         description: geoObject.description,

--- a/src/widgets/Admin/ui/AdminOfferWhere/AdminOfferWhere.tsx
+++ b/src/widgets/Admin/ui/AdminOfferWhere/AdminOfferWhere.tsx
@@ -46,7 +46,7 @@ export const AdminOfferWhere: FC<AdminOfferWhereProps> = (props) => {
         if (geoObject) {
             return {
                 address: {
-                    address: `${geoObject.description}, ${geoObject.name}`,
+                    address: `${geoObject.description ? `${geoObject.description}, ` : ""}${geoObject.name}`,
                     geoObject: {
                         name: geoObject.name,
                         description: geoObject.description,

--- a/src/widgets/Offer/ui/OfferWhere/OfferWhere.tsx
+++ b/src/widgets/Offer/ui/OfferWhere/OfferWhere.tsx
@@ -40,7 +40,7 @@ export const OfferWhere: FC<OfferWhereProps> = (props) => {
         if (geoObject) {
             return {
                 address: {
-                    address: `${geoObject.description}, ${geoObject.name}`,
+                    address: `${geoObject.description ? `${geoObject.description}, ` : ""}${geoObject.name}`,
                     geoObject: {
                         name: geoObject.name,
                         description: geoObject.description,


### PR DESCRIPTION
## Проблема

При загрузке страницы «Где вы находитесь» для существующей вакансии, поле адреса показывало строку `«undefined, Название города»` (или `«undefined, Россия»`).

## Причина

Функция `fetchGeoObject` вызывает обратный геокодер Yandex (координаты → адрес). Yandex API может вернуть GeoObject без поля `description` (например для географических объектов верхнего уровня — страна, регион без уточнения). Шаблонная строка без проверки:

```ts
address: `${geoObject.description}, ${geoObject.name}`, // "undefined, Name"
```

## Исправление

Тот же условный паттерн, что уже применялся в `MapWithAddress.handleMapClick`:

```ts
address: `${geoObject.description ? `${geoObject.description}, ` : ""}${geoObject.name}`,
```

## Файлы

- `src/widgets/Offer/ui/OfferWhere/OfferWhere.tsx`
- `src/widgets/Admin/ui/AdminOfferWhere/AdminOfferWhere.tsx`
- `src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx`