### PR TITLE
fix(пт6): корректная обработка ошибок при добавлении видео в профиле

### DIFF
--- a/src/features/VideoForm/ui/VideoInput/VideoInput.tsx
+++ b/src/features/VideoForm/ui/VideoInput/VideoInput.tsx
@@ -31,7 +31,7 @@ export const VideoInput = memo(({
                 control={control}
                 rules={{
                     pattern: {
-                        value: /^(?:(?:https?:\/\/)?(?:www\.)?(?:youtu.be\/|youtube.com\/(?:embed\/|v\/|watch\?v=|watch?.+&v=))((\w|-){11})(?:\S+)?|(?:https?:\/\/)?(?:www\.)?(?:vimeo.com\/)(\d+)|(?:https?:\/\/)?(?:www\.)?(?:vk\.com\/(?:video|videos)-?\d+_\d+|vkvideo\.ru\/(?:video-?\d+_\d+|video_ext\.php\?(?:[^&]*&)?(?:oid|id)=-?\d+_\d+))|(?:https?:\/\/)?(?:www\.)?(?:rutube.ru\/video\/)([a-f0-9]{32})(?:\/\S*)?)$/,
+                        value: /^(?:https?:\/\/(?:www\.)?(?:youtu.be\/|youtube.com\/(?:embed\/|v\/|watch\?v=|watch?.+&v=))((\w|-){11})(?:\S+)?|https?:\/\/(?:www\.)?(?:vimeo.com\/)(\d+)|https?:\/\/(?:www\.)?(?:vk\.com\/(?:video|videos)-?\d+_\d+|vkvideo\.ru\/(?:video-?\d+_\d+|video_ext\.php\?(?:[^&]*&)?(?:oid|id)=-?\d+_\d+))|https?:\/\/(?:www\.)?(?:rutube.ru\/video\/)([a-f0-9]{32})(?:\/\S*)?)$/,
                         message: t("volunteer-gallery.Введите корректный URL"),
                     },
                 }}

--- a/src/shared/lib/getErrorText.tsx
+++ b/src/shared/lib/getErrorText.tsx
@@ -13,6 +13,10 @@ export const getErrorText = (error: unknown): string => {
             if ("title" in data) {
                 return String(data.title);
             }
+            // JWT 401 errors return { code, message } without detail/title
+            if ("message" in data) {
+                return String(data.message);
+            }
         }
         if ("message" in error) {
             return String(error.message);


### PR DESCRIPTION
## Что исправлено

**пт6** — «В профиле организации невозможно добавить ссылку на видео — неизвестная ошибка»

## Причины «неизвестной ошибки»

### 1. `getErrorText` не обрабатывал JWT 401 ответы

API Platform возвращает `{ detail, title }` для 422/403, но Symfony JWT bundle возвращает `{ code, message }` для 401 (просроченный/невалидный токен). В `getErrorText` не было ветки для `data.message`, поэтому 401 всегда давал «Произошла неизвестная ошибка.»

**Фикс:** добавлен fallback `if ("message" in data) return String(data.message)`.

### 2. Frontend regex допускал URL без протокола

Regex позволял `www.youtube.com/watch?v=...` (без `https://`), но бэкенд `Assert\Url()` требует протокол. Кнопка не блокировалась → запрос уходил → API возвращал 422.

**Фикс:** `https?://` сделан обязательным во всех ветках regex.

## Затронутые файлы

- `src/shared/lib/getErrorText.tsx` — fallback `data.message`
- `src/features/VideoForm/ui/VideoInput/VideoInput.tsx` — обязательный протокол в regex

## Проверка regex

```
✅ https://www.youtube.com/watch?v=dQw4w9WgXcQ
✅ https://youtu.be/dQw4w9WgXcQ
✅ https://vk.com/video-123_456789
✅ https://rutube.ru/video/aabbccddeeff00112233445566778899/
✅ https://vimeo.com/123456789
❌ www.youtube.com/watch?v=... (без https — блокируется)
❌ https://example.com/video (чужой домен)
```