### PR TITLE
fix(пт6): корректная обработка ошибок при добавлении видео

### DIFF
--- a/src/features/VideoForm/ui/VideoInput/VideoInput.tsx
+++ b/src/features/VideoForm/ui/VideoInput/VideoInput.tsx
@@ -31,7 +31,7 @@ export const VideoInput = memo(({
                 control={control}
                 rules={{
                     pattern: {
-                        value: /^(?:(?:https?:\/\/)?(?:www\.)?(?:youtu.be\/|youtube.com\/(?:embed\/|v\/|watch\?v=|watch?.+&v=))((\w|-){11})(?:\S+)?|(?:https?:\/\/)?(?:www\.)?(?:vimeo.com\/)(\d+)|(?:https?:\/\/)?(?:www\.)?(?:vk\.com\/(?:video|videos)-?\d+_\d+|vkvideo\.ru\/(?:video-?\d+_\d+|video_ext\.php\?(?:[^&]*&)?(?:oid|id)=-?\d+_\d+))|(?:https?:\/\/)?(?:www\.)?(?:rutube.ru\/video\/)([a-f0-9]{32})(?:\/\S*)?)$/,
+                        value: /^(?:https?:\/\/(?:www\.)?(?:youtu.be\/|youtube.com\/(?:embed\/|v\/|watch\?v=|watch?.+&v=))((\w|-){11})(?:\S+)?|https?:\/\/(?:www\.)?(?:vimeo.com\/)(\d+)|https?:\/\/(?:www\.)?(?:vk\.com\/(?:video|videos)-?\d+_\d+|vkvideo\.ru\/(?:video-?\d+_\d+|video_ext\.php\?(?:[^&]*&)?(?:oid|id)=-?\d+_\d+))|https?:\/\/(?:www\.)?(?:rutube.ru\/video\/)([a-f0-9]{32})(?:\/\S*)?)$/,
                         message: t("volunteer-gallery.Введите корректный URL"),
                     },
                 }}

--- a/src/shared/lib/getErrorText.tsx
+++ b/src/shared/lib/getErrorText.tsx
@@ -13,6 +13,10 @@ export const getErrorText = (error: unknown): string => {
             if ("title" in data) {
                 return String(data.title);
             }
+            // JWT 401 errors return { code, message } without detail/title
+            if ("message" in data) {
+                return String(data.message);
+            }
         }
         if ("message" in error) {
             return String(error.message);


### PR DESCRIPTION
Мерж develop → master. Содержит исправление пт6 из PR #291.

## Изменения

- `getErrorText`: обработка JWT 401 `{code, message}` → убирает «неизвестная ошибка»
- `VideoInput`: обязательный `https://` в regex видео-URL → блокирует невалидные URL до отправки