### PR TITLE
fix(prod): VK ID логин — прод-приложение 6499153

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,7 @@ env:
   IMAGE: gs-frontend
   VITE_API_BASE_URL: https://api-prod.goodsurfing.org
   VITE_MAIN_URL: https://prod.goodsurfing.org
-  VITE_VKID_CLIENT_ID: "54505769"
+  VITE_VKID_CLIENT_ID: "6499153"
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Фронт прода собирался со staging-овым VK-приложением `54505769` (`deploy-prod.yml`), тогда как бэк прода обменивает `code` в приложении `6499153` (полная пара `OAUTH_VKONTAKTE_CLIENT_ID`+`CLIENT_SECRET` лежит на VM прода). Из-за рассинхрона `client_id` обмен `code` на токен в `id.vk.ru/oauth2/auth` отклонялся → VK-логин на проде не работал.

Приводим фронт прода к прод-приложению `6499153`. На staging всё остаётся как есть (`54505769`).

## После мерджа
1. Прод не деплоится на push в master — задеплоить тегом `v*.*.*` или `workflow_dispatch` (`deploy-prod.yml`, ввести `deploy`).
2. Убедиться в кабинете VK ID приложения `6499153`, что в Доверенных redirect URL есть:
   - `https://prod.goodsurfing.org/ru/signin`, `/en/signin`, `/es/signin`
   - `https://prod.goodsurfing.org/ru/signup`, `/en/signup`, `/es/signup`
3. Проверить вход через VK на https://prod.goodsurfing.org/ru/signin