### PR TITLE
fix(prod): VK-редирект на апекс goodsurfing.org (VITE_MAIN_URL)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,7 +17,7 @@ env:
   REGISTRY: ${{ vars.PROD_REGISTRY }}
   IMAGE: gs-frontend
   VITE_API_BASE_URL: https://api-prod.goodsurfing.org
-  VITE_MAIN_URL: https://prod.goodsurfing.org
+  VITE_MAIN_URL: https://goodsurfing.org
   VITE_VKID_CLIENT_ID: "6499153"
 
 jobs:


### PR DESCRIPTION
Продолжение [#293](https://github.com/Goodsurfing/gs-frontend/pull/293).

После apex-cutover боевые юзеры прода сидят на `goodsurfing.org`, но фронт собран с `VITE_MAIN_URL=https://prod.goodsurfing.org`. В VK-флоу `redirectUrl = ${VITE_MAIN_URL}/${locale}/${redirect}`, поэтому VK редиректил юзера с `goodsurfing.org` на `prod.goodsurfing.org` — другой origin, где нет сохранённого в localStorage `code_verifier` → обмен не выполнялся, логин зависал на OneTap.

Ставим `VITE_MAIN_URL=https://goodsurfing.org`, чтобы редирект возвращал на тот же апекс.

## После мерджа
1. Задеплоить прод (`workflow_dispatch` → `deploy`, либо тег `v*.*.*`).
2. В кабинете VK ID приложения `6499153` в Доверенные redirect URL добавить апекс: `https://goodsurfing.org/{ru,en,es}/{signin,signup}`.
3. Проверить вход через VK на https://goodsurfing.org/ru/signin.