### PR TITLE
fix(offer): скрыть блок «Условия», если все поля пусты

### DIFF
--- a/src/entities/Offer/ui/OfferTermsCard/ui/OfferTermsCard/OfferTermsCard.tsx
+++ b/src/entities/Offer/ui/OfferTermsCard/ui/OfferTermsCard/OfferTermsCard.tsx
@@ -97,6 +97,16 @@ export const OfferTermsCard: FC<OfferTermsCardProps> = memo(
             ));
         };
 
+        const hasContent = facilities.length > 0
+            || housing.length > 0
+            || paidTravel.length > 0
+            || nutrition.length > 0
+            || extraFeatures.length > 0;
+
+        if (!hasContent) {
+            return null;
+        }
+
         return (
             <div className={cn(className, styles.wrapper)} id="terms">
                 <Text title={t("personalOffer.Условия")} titleSize="h3" />


### PR DESCRIPTION
## Суть

`OfferTermsCard` всегда рендерил заголовок «Условия», даже если хост не заполнил ни жильё, ни питание, ни трансфер, ни удобства.

После бэкенд-фикса (PR gs-backend#186 + коммит 602e0cf), который создаёт пустые секции условий при создании вакансии, стал виден визуальный дефект: у вакансии с незаполненными условиями в карточке для волонтёра отображался заголовок «Условия» с пустым телом.

## Изменения

- `OfferTermsCard`: добавлен guard — компонент возвращает `null`, если все передаваемые массивы (`facilities`, `housing`, `paidTravel`, `nutrition`, `extraFeatures`) пусты.

## Тест

1. Открыть вакансию, у которой хост не заполнял «Условия» (не выбирал жильё, питание, трансфер и т.д.)
2. В карточке для волонтёра раздел «Условия» не должен появляться вообще
3. У вакансии с заполненными условиями — всё показывается как раньше