### PR TITLE
fix(offer): скрыть блок «Условия», если все поля пусты

### DIFF
--- a/src/entities/Offer/ui/OfferTermsCard/ui/OfferTermsCard/OfferTermsCard.tsx
+++ b/src/entities/Offer/ui/OfferTermsCard/ui/OfferTermsCard/OfferTermsCard.tsx
@@ -97,6 +97,16 @@ export const OfferTermsCard: FC<OfferTermsCardProps> = memo(
             ));
         };
 
+        const hasContent = facilities.length > 0
+            || housing.length > 0
+            || paidTravel.length > 0
+            || nutrition.length > 0
+            || extraFeatures.length > 0;
+
+        if (!hasContent) {
+            return null;
+        }
+
         return (
             <div className={cn(className, styles.wrapper)} id="terms">
                 <Text title={t("personalOffer.Условия")} titleSize="h3" />


### PR DESCRIPTION
Мержит develop → master. Исправление пт7.

OfferTermsCard теперь возвращает null, если все массивы пусты (housing, paidTravel, nutrition, facilities, extraFeatures). Устраняет визуальный дефект: пустой заголовок «Условия» у вакансий с незаполненными условиями.