### PR TITLE
fix(prod): VK app 54505769 (redirect goodsurfing.org уже настроен)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,7 @@ env:
   IMAGE: gs-frontend
   VITE_API_BASE_URL: https://api-prod.goodsurfing.org
   VITE_MAIN_URL: https://goodsurfing.org
-  VITE_VKID_CLIENT_ID: "6499153"
+  VITE_VKID_CLIENT_ID: "54505769"
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Переключаем прод-фронт на VK-приложение `54505769` — оно уже содержит доверенные redirect URL для `goodsurfing.org` в кабинете VK ID.

Бэкенд прода уже обновлён: `OAUTH_VKONTAKTE_CLIENT_ID=54505769` + secret в `/opt/gs/.env.local`, контейнер пересоздан.