### PR TITLE
fix(academy): показывать файлы, прикреплённые к уроку

### DIFF
--- a/src/entities/Academy/model/types/academy.ts
+++ b/src/entities/Academy/model/types/academy.ts
@@ -154,6 +154,7 @@ export interface GetLesson {
     averageRating: number;
     image: Image;
     isCanReview: boolean;
+    files: Image[];
     course: {
         id: string;
         name: string;

--- a/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.module.scss
+++ b/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.module.scss
@@ -37,6 +37,47 @@
     margin: 40px auto;
 }
 
+.filesSection {
+    margin-top: 32px;
+    margin-bottom: 8px;
+}
+
+.filesTitle {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.filesList {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.filesItem {
+    display: flex;
+    align-items: center;
+}
+
+.filesLink {
+    color: var(--text-primary-1);
+    text-decoration: none;
+    font-size: 15px;
+    padding: 8px 16px;
+    border: 1px solid var(--border-primary-1, #e0e0e0);
+    border-radius: 8px;
+    transition: background-color 0.2s ease;
+    word-break: break-all;
+
+    &:hover {
+        background-color: var(--bg-secondary-1, #f5f5f5);
+        text-decoration: underline;
+    }
+}
+
 .buttons {
     width: 100%;
     display: flex;

--- a/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx
+++ b/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx
@@ -7,6 +7,7 @@ import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 import { LessonVideo } from "../LessonVideo/LessonVideo";
 import { LessonReview } from "@/features/Academy";
 import CustomLink from "@/shared/ui/Link/Link";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 import styles from "./LessonPersonal.module.scss";
 
 interface LessonPersonalProps {
@@ -51,6 +52,31 @@ export const LessonPersonal: FC<LessonPersonalProps> = (props) => {
                             {data?.description}
                         </p>
                         <LessonVideo className={styles.lessonVideo} videoUrl={data?.url} />
+                        {data?.files && data.files.length > 0 && (
+                            <div className={styles.filesSection}>
+                                <h3 className={styles.filesTitle}>Материалы к уроку</h3>
+                                <ul className={styles.filesList}>
+                                    {data.files.map((file) => {
+                                        const url = getMediaContent(file.contentUrl);
+                                        const fileName = file.contentUrl.split("/").pop() || "Файл";
+                                        return url ? (
+                                            <li key={file.id} className={styles.filesItem}>
+                                                <a
+                                                    href={url}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    download
+                                                    className={styles.filesLink}
+                                                >
+                                                    {"📎 "}
+                                                    {fileName}
+                                                </a>
+                                            </li>
+                                        ) : null;
+                                    })}
+                                </ul>
+                            </div>
+                        )}
                     </>
                 )}
                 <div className={styles.buttons}>


### PR DESCRIPTION
## Проблема

Файлы, прикреплённые к уроку через админку, не отображались на странице урока — блок оставался пустым.

## Причина

1. Бэкенд возвращает `files: ImageResultDto[]` в ответе `GET /api/v3/video-course/element/{id}` — это было реализовано, но фронтенд его игнорировал.
2. Тип `GetLesson` не содержал поле `files`.
3. Компонент `LessonPersonal.tsx` не рендерил файлы.

## Исправление

- Добавлено `files: Image[]` в интерфейс `GetLesson`
- Добавлена секция «Материалы к уроку» в `LessonPersonal.tsx` — список ссылок для скачивания, отображается только если файлы есть
- Добавлены стили для блока файлов

## Затронутые файлы

- `src/entities/Academy/model/types/academy.ts`
- `src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx`
- `src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.module.scss`