### PR TITLE
fix(academy): фиксы по ревью блока файлов урока

### DIFF
--- a/src/entities/Academy/model/types/academy.ts
+++ b/src/entities/Academy/model/types/academy.ts
@@ -154,7 +154,7 @@ export interface GetLesson {
     averageRating: number;
     image: Image;
     isCanReview: boolean;
-    files: Image[];
+    files?: Image[];
     course: {
         id: string;
         name: string;

--- a/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx
+++ b/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx
@@ -52,31 +52,34 @@ export const LessonPersonal: FC<LessonPersonalProps> = (props) => {
                             {data?.description}
                         </p>
                         <LessonVideo className={styles.lessonVideo} videoUrl={data?.url} />
-                        {data?.files && data.files.length > 0 && (
-                            <div className={styles.filesSection}>
-                                <h3 className={styles.filesTitle}>Материалы к уроку</h3>
-                                <ul className={styles.filesList}>
-                                    {data.files.map((file) => {
-                                        const url = getMediaContent(file.contentUrl);
-                                        const fileName = file.contentUrl.split("/").pop() || "Файл";
-                                        return url ? (
-                                            <li key={file.id} className={styles.filesItem}>
-                                                <a
-                                                    href={url}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    download
-                                                    className={styles.filesLink}
-                                                >
-                                                    {"📎 "}
-                                                    {fileName}
-                                                </a>
-                                            </li>
-                                        ) : null;
-                                    })}
-                                </ul>
-                            </div>
-                        )}
+                        {(() => {
+                            const validFiles = (data?.files ?? []).filter((f) => f.contentUrl);
+                            if (!validFiles.length) return null;
+                            return (
+                                <div className={styles.filesSection}>
+                                    <h3 className={styles.filesTitle}>Материалы к уроку</h3>
+                                    <ul className={styles.filesList}>
+                                        {validFiles.map((file) => {
+                                            const url = getMediaContent(file.contentUrl);
+                                            const fileName = file.contentUrl.split("/").pop() || "Файл";
+                                            return (
+                                                <li key={file.id} className={styles.filesItem}>
+                                                    <a
+                                                        href={url}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className={styles.filesLink}
+                                                    >
+                                                        {"📎 "}
+                                                        {fileName}
+                                                    </a>
+                                                </li>
+                                            );
+                                        })}
+                                    </ul>
+                                </div>
+                            );
+                        })()}
                     </>
                 )}
                 <div className={styles.buttons}>


### PR DESCRIPTION
## Контекст

Дополнение к PR #298 по итогам code review.

## Найденные нарушения

### 1. Orphaned heading при пустых contentUrl (CONFIRMED)
Гард `data.files.length > 0` пропускал массив с файлами, у которых S3-запись отсутствует (`contentUrl = ""`). `getMediaContent("")` → `undefined`, все `<li>` рендерились как `null`, но заголовок «Материалы к уроку» уже отображался. Исправлено фильтрацией массива до рендера: секция показывается только если есть хотя бы один файл с непустым `contentUrl`.

### 2. download-атрибут игнорируется для cross-origin URL (CONFIRMED)
Файлы хранятся на `goodsurfing-public.storage.yandexcloud.net` — другой origin относительно фронтенда. Браузеры принудительно игнорируют `download` для cross-origin ссылок. Атрибут удалён, файлы открываются во вкладке через `target="_blank"`.

### 3. files?: Image[] — опциональное поле (TYPE SAFETY)
Поле сделано опциональным, чтобы корректно работать с тёплым RTK-кэшем от старой версии API (до добавления `files`).

## Затронутые файлы
- `src/entities/Academy/model/types/academy.ts`
- `src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx`