### PR TITLE
Фикс задвоения отзывов при пагинации

### DIFF
--- a/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
+++ b/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
@@ -65,13 +65,13 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
         useEffect(() => {
             if (reviewsData?.data) {
                 setReviews((prev) => {
-                    if (page === 1) {
+                    if (reviewsData.pagination.page === 1) {
                         return [...reviewsData.data];
                     }
                     return [...prev, ...reviewsData.data];
                 });
             }
-        }, [reviewsData, page]);
+        }, [reviewsData]);
 
         const handleSendReview = useCallback(async () => {
             if (!canReview || !commentInput.trim() || rating === null) return;


### PR DESCRIPTION
## Проблема

На странице оффера при нажатии «Показать ещё» отзывы задваивались.

## Причина

В `OfferReviewsCard` два `useEffect` работали неправильно в связке:

```ts
useEffect(() => {
    if (reviewsData?.data) {
        setReviews((prev) => {
            if (page === 1) {          // ← page из state
                return [...reviewsData.data];
            }
            return [...prev, ...reviewsData.data];
        });
    }
}, [reviewsData, page]);   // ← оба в зависимостях
```

При клике «Показать ещё»:
1. `page` становится 2 — эффект срабатывает **сразу**
2. `reviewsData` ещё содержит данные страницы 1
3. `page !== 1` → данные стр. 1 добавляются в список повторно (задвоение)
4. Приходит ответ стр. 2 → добавляется поверх уже задвоенных данных

## Фикс

Убрана зависимость от `page`; вместо стейта используется `reviewsData.pagination.page` из ответа API — он всегда соответствует пришедшим данным:

```ts
useEffect(() => {
    if (reviewsData?.data) {
        setReviews((prev) => {
            if (reviewsData.pagination.page === 1) {
                return [...reviewsData.data];
            }
            return [...prev, ...reviewsData.data];
        });
    }
}, [reviewsData]);   // page убран
```

## Проверка

- [x] Lint чистый (в изменённом файле)
- [ ] Открыть оффер с 5+ отзывами → нажать «Показать ещё» → убедиться, что дублей нет