### PR TITLE
Фикс задвоения отзывов при пагинации в LessonReview

### DIFF
--- a/src/features/Academy/ui/LessonReview/LessonReview.tsx
+++ b/src/features/Academy/ui/LessonReview/LessonReview.tsx
@@ -57,13 +57,13 @@ export const LessonReview: FC<LessonReviewProps> = (props) => {
     useEffect(() => {
         if (reviewsData?.data) {
             setReviews((prev) => {
-                if (page === 1) {
+                if (reviewsData.pagination.page === 1) {
                     return [...reviewsData.data];
                 }
                 return [...prev, ...reviewsData.data];
             });
         }
-    }, [reviewsData, page]);
+    }, [reviewsData]);
 
     const handleSendReview = useCallback(async () => {
         if (!canReview || !commentInput.trim() || rating === null) return;


### PR DESCRIPTION
## Проблема

На странице урока академии при нажатии «Показать ещё» отзывы задваивались.

## Причина

Тот же stale-closure баг, что исправлен в OfferReviewsCard (#302):

```ts
useEffect(() => {
    if (reviewsData?.data) {
        setReviews((prev) => {
            if (page === 1) {          // ← page из state
                return [...reviewsData.data];
            }
            return [...prev, ...reviewsData.data];
        });
    }
}, [reviewsData, page]);   // ← оба в зависимостях
```

При клике «Показать ещё»: `page` → 2, эффект срабатывает немедленно со старым `reviewsData` (стр. 1) → данные стр. 1 добавляются повторно → задвоение.

## Фикс

```ts
useEffect(() => {
    if (reviewsData?.data) {
        setReviews((prev) => {
            if (reviewsData.pagination.page === 1) {
                return [...reviewsData.data];
            }
            return [...prev, ...reviewsData.data];
        });
    }
}, [reviewsData]);
```

`page` убран из зависимостей, номер страницы берётся из `reviewsData.pagination.page` — гарантированно соответствует пришедшим данным. Тип `GetReviewsLessonResponse.pagination: Pagination` — required, доступ безопасен.

## Проверка

- [x] Lint чистый
- [ ] Открыть урок с 5+ отзывами → нажать «Показать ещё» → убедиться, что дублей нет