### PR TITLE
chore(prod): фронт на apex api.goodsurfing.org

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   REGISTRY: ${{ vars.PROD_REGISTRY }}
   IMAGE: gs-frontend
-  VITE_API_BASE_URL: https://api-prod.goodsurfing.org
+  VITE_API_BASE_URL: https://api.goodsurfing.org
   VITE_MAIN_URL: https://goodsurfing.org
   VITE_VKID_CLIENT_ID: "54505769"
 


### PR DESCRIPTION
Прод-фронт собирался с `VITE_API_BASE_URL=https://api-prod.goodsurfing.org`. Технический алиас `api-prod.goodsurfing.org` выводится из эксплуатации — переключаем сборку прод-образа на apex `https://api.goodsurfing.org` (apex-cutover сделан 2026-06-02, домен живой).

Часть перевода прода на apex-only (вместе с правками Traefik/MERCURE_PUBLIC_URL/CORS на VM и в gs-infra). Без редеплоя фронта прод продолжит ходить на api-prod.