### PR TITLE
fix: убрать блокировку профиля организации с inactive-флагом

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,7 +17,7 @@ env:
   REGISTRY: ${{ vars.PROD_REGISTRY }}
   IMAGE: gs-frontend
   VITE_API_BASE_URL: https://api-prod.goodsurfing.org
-  VITE_MAIN_URL: https://prod.goodsurfing.org
+  VITE_MAIN_URL: https://goodsurfing.org
   VITE_VKID_CLIENT_ID: "6499153"
 
 jobs:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   REGISTRY: ${{ vars.PROD_REGISTRY }}
   IMAGE: gs-frontend
-  VITE_API_BASE_URL: https://api-prod.goodsurfing.org
+  VITE_API_BASE_URL: https://api.goodsurfing.org
   VITE_MAIN_URL: https://goodsurfing.org
   VITE_VKID_CLIENT_ID: "54505769"
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,7 @@ env:
   IMAGE: gs-frontend
   VITE_API_BASE_URL: https://api-prod.goodsurfing.org
   VITE_MAIN_URL: https://goodsurfing.org
-  VITE_VKID_CLIENT_ID: "6499153"
+  VITE_VKID_CLIENT_ID: "54505769"
 
 jobs:
   build-and-deploy:

--- a/src/entities/Academy/model/types/academy.ts
+++ b/src/entities/Academy/model/types/academy.ts
@@ -154,7 +154,7 @@ export interface GetLesson {
     averageRating: number;
     image: Image;
     isCanReview: boolean;
-    files: Image[];
+    files?: Image[];
     course: {
         id: string;
         name: string;

--- a/src/entities/Academy/model/types/academy.ts
+++ b/src/entities/Academy/model/types/academy.ts
@@ -154,6 +154,7 @@ export interface GetLesson {
     averageRating: number;
     image: Image;
     isCanReview: boolean;
+    files: Image[];
     course: {
         id: string;
         name: string;

--- a/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
+++ b/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
@@ -65,13 +65,13 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
         useEffect(() => {
             if (reviewsData?.data) {
                 setReviews((prev) => {
-                    if (page === 1) {
+                    if (reviewsData.pagination.page === 1) {
                         return [...reviewsData.data];
                     }
                     return [...prev, ...reviewsData.data];
                 });
             }
-        }, [reviewsData, page]);
+        }, [reviewsData]);
 
         const handleSendReview = useCallback(async () => {
             if (!canReview || !commentInput.trim() || rating === null) return;

--- a/src/features/Academy/ui/LessonReview/LessonReview.tsx
+++ b/src/features/Academy/ui/LessonReview/LessonReview.tsx
@@ -57,13 +57,13 @@ export const LessonReview: FC<LessonReviewProps> = (props) => {
     useEffect(() => {
         if (reviewsData?.data) {
             setReviews((prev) => {
-                if (page === 1) {
+                if (reviewsData.pagination.page === 1) {
                     return [...reviewsData.data];
                 }
                 return [...prev, ...reviewsData.data];
             });
         }
-    }, [reviewsData, page]);
+    }, [reviewsData]);
 
     const handleSendReview = useCallback(async () => {
         if (!canReview || !commentInput.trim() || rating === null) return;

--- a/src/features/Admin/ui/AdminSkillForm/AdminSkillForm.tsx
+++ b/src/features/Admin/ui/AdminSkillForm/AdminSkillForm.tsx
@@ -126,8 +126,7 @@ export const AdminSkillForm: FC<AdminSkillFormProps> = (props) => {
                                     onChange={onChange}
                                     error={!!errors.imagePath}
                                     accept={{
-                                        "image/jpeg": [".jpeg", ".jpg"],
-                                        "image/png": [".png"],
+                                        "image/svg+xml": [".svg"],
                                     }}
                                 />
                             )}

--- a/src/pages/HostPersonalPage/ui/HostPersonalPage/HostPersonalPage.tsx
+++ b/src/pages/HostPersonalPage/ui/HostPersonalPage/HostPersonalPage.tsx
@@ -36,10 +36,6 @@ export const HostPersonalPage = () => {
     const navigate = useNavigate();
     const { isAuth, myProfile } = useAuth();
 
-    const isOwner = !!myProfile && myProfile.id === hostData?.owner.id;
-
-    const isHostUnavailable = hostData && !hostData.active && !isOwner;
-
     const handleEditClick = () => {
         navigate(getHostInfoUrl(locale));
     };
@@ -80,18 +76,6 @@ export const HostPersonalPage = () => {
                 <MainHeader variant="static" />
                 <div className={styles.content}>
                     <Text textSize="primary" text={t("personalHost.Произошла ошибка")} />
-                </div>
-                <Footer />
-            </div>
-        );
-    }
-
-    if (isHostUnavailable) {
-        return (
-            <div className={styles.wrapper}>
-                <MainHeader variant="static" />
-                <div className={styles.content}>
-                    <Text textSize="primary" text={t("personalHost.Организация недоступна")} />
                 </div>
                 <Footer />
             </div>

--- a/src/pages/OfferPersonalPage/ui/OfferPersonalPage/OfferPersonalPage.tsx
+++ b/src/pages/OfferPersonalPage/ui/OfferPersonalPage/OfferPersonalPage.tsx
@@ -50,7 +50,7 @@ export const OfferPersonalPage = () => {
     if (!id || isError) {
         return (
             <div className={styles.wrapper}>
-                <MainHeader />
+                <MainHeader variant="static" />
                 <div className={styles.content}>
                     <Text
                         className={styles.error}

--- a/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.module.scss
+++ b/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.module.scss
@@ -37,6 +37,47 @@
     margin: 40px auto;
 }
 
+.filesSection {
+    margin-top: 32px;
+    margin-bottom: 8px;
+}
+
+.filesTitle {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.filesList {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.filesItem {
+    display: flex;
+    align-items: center;
+}
+
+.filesLink {
+    color: var(--text-primary-1);
+    text-decoration: none;
+    font-size: 15px;
+    padding: 8px 16px;
+    border: 1px solid var(--border-primary-1, #e0e0e0);
+    border-radius: 8px;
+    transition: background-color 0.2s ease;
+    word-break: break-all;
+
+    &:hover {
+        background-color: var(--bg-secondary-1, #f5f5f5);
+        text-decoration: underline;
+    }
+}
+
 .buttons {
     width: 100%;
     display: flex;

--- a/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx
+++ b/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx
@@ -52,31 +52,34 @@ export const LessonPersonal: FC<LessonPersonalProps> = (props) => {
                             {data?.description}
                         </p>
                         <LessonVideo className={styles.lessonVideo} videoUrl={data?.url} />
-                        {data?.files && data.files.length > 0 && (
-                            <div className={styles.filesSection}>
-                                <h3 className={styles.filesTitle}>Материалы к уроку</h3>
-                                <ul className={styles.filesList}>
-                                    {data.files.map((file) => {
-                                        const url = getMediaContent(file.contentUrl);
-                                        const fileName = file.contentUrl.split("/").pop() || "Файл";
-                                        return url ? (
-                                            <li key={file.id} className={styles.filesItem}>
-                                                <a
-                                                    href={url}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    download
-                                                    className={styles.filesLink}
-                                                >
-                                                    {"📎 "}
-                                                    {fileName}
-                                                </a>
-                                            </li>
-                                        ) : null;
-                                    })}
-                                </ul>
-                            </div>
-                        )}
+                        {(() => {
+                            const validFiles = (data?.files ?? []).filter((f) => f.contentUrl);
+                            if (!validFiles.length) return null;
+                            return (
+                                <div className={styles.filesSection}>
+                                    <h3 className={styles.filesTitle}>Материалы к уроку</h3>
+                                    <ul className={styles.filesList}>
+                                        {validFiles.map((file) => {
+                                            const url = getMediaContent(file.contentUrl);
+                                            const fileName = file.contentUrl.split("/").pop() || "Файл";
+                                            return (
+                                                <li key={file.id} className={styles.filesItem}>
+                                                    <a
+                                                        href={url}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className={styles.filesLink}
+                                                    >
+                                                        {"📎 "}
+                                                        {fileName}
+                                                    </a>
+                                                </li>
+                                            );
+                                        })}
+                                    </ul>
+                                </div>
+                            );
+                        })()}
                     </>
                 )}
                 <div className={styles.buttons}>

--- a/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx
+++ b/src/widgets/Academy/ui/LessonPersonal/ui/LessonPersonal/LessonPersonal.tsx
@@ -7,6 +7,7 @@ import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 import { LessonVideo } from "../LessonVideo/LessonVideo";
 import { LessonReview } from "@/features/Academy";
 import CustomLink from "@/shared/ui/Link/Link";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 import styles from "./LessonPersonal.module.scss";
 
 interface LessonPersonalProps {
@@ -51,6 +52,31 @@ export const LessonPersonal: FC<LessonPersonalProps> = (props) => {
                             {data?.description}
                         </p>
                         <LessonVideo className={styles.lessonVideo} videoUrl={data?.url} />
+                        {data?.files && data.files.length > 0 && (
+                            <div className={styles.filesSection}>
+                                <h3 className={styles.filesTitle}>Материалы к уроку</h3>
+                                <ul className={styles.filesList}>
+                                    {data.files.map((file) => {
+                                        const url = getMediaContent(file.contentUrl);
+                                        const fileName = file.contentUrl.split("/").pop() || "Файл";
+                                        return url ? (
+                                            <li key={file.id} className={styles.filesItem}>
+                                                <a
+                                                    href={url}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    download
+                                                    className={styles.filesLink}
+                                                >
+                                                    {"📎 "}
+                                                    {fileName}
+                                                </a>
+                                            </li>
+                                        ) : null;
+                                    })}
+                                </ul>
+                            </div>
+                        )}
                     </>
                 )}
                 <div className={styles.buttons}>

--- a/src/widgets/OffersMap/ui/OfferPlacemark/OfferPlacemark.tsx
+++ b/src/widgets/OffersMap/ui/OfferPlacemark/OfferPlacemark.tsx
@@ -19,12 +19,13 @@ interface OfferPlacemarkProps {
     geometry: number[];
     name: string;
     categoryColor?: string;
+    imageUrl?: string;
     locale: string;
 }
 
 export const OfferPlacemark: FC<OfferPlacemarkProps> = memo((props: OfferPlacemarkProps) => {
     const {
-        id, categoryColor, name, geometry, locale,
+        id, categoryColor, name, geometry, locale, imageUrl,
     } = props;
 
     const navigate = useNavigate();
@@ -106,7 +107,9 @@ export const OfferPlacemark: FC<OfferPlacemarkProps> = memo((props: OfferPlacema
             options={{
                 iconLayout: "default#imageWithContent",
                 iconContentLayout: ymaps?.templateLayoutFactory?.createClass?.(
-                    `<div style="background-color: ${categoryColor || "var(--accent-color)"};" class="${styles.customPlacemarkIcon}"></div>`,
+                    imageUrl
+                        ? `<div style="background: url('${imageUrl}') center/cover no-repeat;" class="${styles.customPlacemarkIcon}"></div>`
+                        : `<div style="background-color: ${categoryColor || "var(--accent-color)"};" class="${styles.customPlacemarkIcon}"></div>`,
                 ),
                 hideIconOnBalloonOpen: false,
                 openEmptyBalloon: false,

--- a/src/widgets/OffersMap/ui/OffersPlacemarkList/OffersPlacemarkList.tsx
+++ b/src/widgets/OffersMap/ui/OffersPlacemarkList/OffersPlacemarkList.tsx
@@ -18,7 +18,7 @@ export const OffersPlacemarkList: FC<OffersPlacemarkListProps> = (props) => {
 
     const offersPlacemarkList = useMemo(
         () => data.map(({
-            id, name, categories, latitude, longitude,
+            id, name, categories, latitude, longitude, image,
         }) => {
             if (typeof latitude === "number" && typeof longitude === "number") {
                 return (
@@ -28,6 +28,7 @@ export const OffersPlacemarkList: FC<OffersPlacemarkListProps> = (props) => {
                         geometry={[latitude, longitude]}
                         locale={locale}
                         categoryColor={categories[0]?.color}
+                        imageUrl={image?.contentUrl}
                         key={id}
                     />
                 );


### PR DESCRIPTION
## Суть

Страница профиля хоста (`/host-personal/:id`) блокировалась для всех пользователей, кроме владельца, если у организации `isActive=false`.

Проблема в том, что `isActive` отражает статус членства организации (выставляется в `true` при создании через фронт), а не видимость страницы публично. Новые организации, не купившие членство, имеют `isActive=false` по умолчанию — и их профиль был недоступен чужим пользователям.

## Что изменено

- Убрана переменная `isOwner` (больше не нужна)
- Убрана переменная `isHostUnavailable` и блок рендера «Организация недоступна»
- Страница теперь открывается публично для любой организации

## Связанная задача

Строка 32 таблицы багов прод-переезда.