### PR TITLE
fix: баллун карты — недостающие CSS-классы (баг #29)

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
@@ -1,5 +1,27 @@
+.wrapper {
+    width: 100%;
+    height: 100%;
+    position: relative;
+}
+
 .loading {
     display: none;
+}
+
+.balloonWrapper {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    padding: 4px;
+    cursor: pointer;
+    min-width: 200px;
+}
+
+.text {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    overflow: hidden;
 }
 
 .map {


### PR DESCRIPTION
## Проблема

При клике на маркер карты вакансий (`/ru/vacancies`) — balloon отображался сломанным: не было изображения, нарушена вёрстка.

## Причина

В `OffersMap.tsx` HTML-строка `balloonContent` использует CSS-модульные классы:
- `styles.balloonWrapper`
- `styles.text`
- `styles.wrapper` (JSX)

Но ни один из этих классов не был определён в `OffersMap.module.scss`. CSS Modules для несуществующих ключей возвращает `undefined`, поэтому в DOM рендерилось `class="undefined"` — flex-вёрстка не применялась.

## Исправление

Добавлены три недостающих CSS-класса в `OffersMap.module.scss`:
- `.wrapper` — обёртка карты (relative, 100%)
- `.balloonWrapper` — flex-контейнер balloon (изображение + текст)
- `.text` — колонка текста внутри balloon