### PR TITLE
fix: кнопка активации членства в admin-панели (баг #22)

### DIFF
--- a/src/entities/Admin/api/adminApi.ts
+++ b/src/entities/Admin/api/adminApi.ts
@@ -464,6 +464,13 @@ export const adminApi = createApi({
             }),
             invalidatesTags: ["user"],
         }),
+        activateUserMembership: build.mutation<void, string>({
+            query: (userId) => ({
+                url: `user/activate-membership/${userId}`,
+                method: "POST",
+            }),
+            invalidatesTags: ["user"],
+        }),
         deleteUser: build.mutation<void, string>({
             query: (userId) => ({
                 url: `user/${userId}`,
@@ -936,6 +943,7 @@ export const {
     useGetPublicTransfersQuery,
     useLazyGetUsersQuery,
     useUpdateAdminUserMutation,
+    useActivateUserMembershipMutation,
     useDeleteUserMutation,
     useToggleAdminUserActiveMutation,
     useGetUserByIdQuery,

--- a/src/entities/Admin/index.ts
+++ b/src/entities/Admin/index.ts
@@ -91,6 +91,7 @@ export {
     useLazyGetTransfersQuery, useGetPublicFoodsQuery,
     useLazyGetUsersQuery,
     useUpdateAdminUserMutation,
+    useActivateUserMembershipMutation,
     useDeleteUserMutation,
     useToggleAdminUserActiveMutation,
     useGetUserByIdQuery,

--- a/src/features/Admin/ui/AdminUserSettings/AdminUserSettings.tsx
+++ b/src/features/Admin/ui/AdminUserSettings/AdminUserSettings.tsx
@@ -7,8 +7,11 @@ import { ConfirmActionModal } from "@/shared/ui/ConfirmActionModal/ConfirmAction
 import { AdminUpdateAchievement } from "../AdminUpdateAchievement/AdminUpdateAchievement";
 import {
     adminUpdateUserAdapter,
-    AdminUser, useDeleteUserMutation,
-    useGetPublicAchievementsQuery, useToggleAdminUserActiveMutation,
+    AdminUser,
+    useActivateUserMembershipMutation,
+    useDeleteUserMutation,
+    useGetPublicAchievementsQuery,
+    useToggleAdminUserActiveMutation,
     useUpdateAdminUserMutation,
 } from "@/entities/Admin";
 import { getFullName } from "@/shared/lib/getFullName";
@@ -40,6 +43,8 @@ export const AdminUserSettings: FC<AdminUserSettingsProps> = (props) => {
     const [toggleAdminUserActive,
         { isLoading: isTogglingActive }] = useToggleAdminUserActiveMutation();
     const [deleteUser, { isLoading: isDeleting }] = useDeleteUserMutation();
+    const [activateMembership,
+        { isLoading: isActivatingMembership }] = useActivateUserMembershipMutation();
 
     const openDeleteModal = () => setIsDeleteModalOpen(true);
     const closeDeleteModal = () => setIsDeleteModalOpen(false);
@@ -89,12 +94,22 @@ export const AdminUserSettings: FC<AdminUserSettingsProps> = (props) => {
     const openMembershipModal = () => setIsMembershipModalOpen(true);
     const closeMembershipModal = () => setIsMembershipModalOpen(false);
 
-    const handleConfirmMembership = () => {
-        setToast({
-            text: "Активация членства: не реализовано",
-            type: HintType.Error,
-        });
-        closeMembershipModal();
+    const handleConfirmMembership = async () => {
+        setToast(undefined);
+        try {
+            await activateMembership(userId).unwrap();
+            setToast({
+                text: `Членство для "${userName}" активировано`,
+                type: HintType.Success,
+            });
+        } catch {
+            setToast({
+                text: "Не удалось активировать членство",
+                type: HintType.Error,
+            });
+        } finally {
+            closeMembershipModal();
+        }
     };
 
     const openAchievementModal = () => setIsAchievementModalOpen(true);
@@ -185,6 +200,7 @@ export const AdminUserSettings: FC<AdminUserSettingsProps> = (props) => {
                 size="SMALL"
                 variant="FILL"
                 onClick={openMembershipModal}
+                disabled={isActivatingMembership}
             >
                 Активировать членство
             </Button>
@@ -235,6 +251,7 @@ export const AdminUserSettings: FC<AdminUserSettingsProps> = (props) => {
                 onClose={closeMembershipModal}
                 confirmTextButton="Активировать"
                 cancelTextButton="Отмена"
+                isLoading={isActivatingMembership}
             />
             <AdminUpdateAchievement
                 achievements={achievementsData ?? []}


### PR DESCRIPTION
## Изменения

Реализована кнопка «Активировать членство» в `AdminUserSettings`:
- Добавлена мутация `useActivateUserMembershipMutation` в `adminApi.ts`
- `handleConfirmMembership` теперь вызывает `POST /admin/v3/user/activate-membership/{id}`
- Показывает toast с результатом (успех/ошибка)
- Кнопка заблокирована во время загрузки

Зависит от: gs-backend PR #206 (уже смержен).