### PR TITLE
Починить бургер-меню на мобильных устройствах

### DIFF
--- a/src/widgets/MainHeader/MainHeader.module.scss
+++ b/src/widgets/MainHeader/MainHeader.module.scss
@@ -187,6 +187,7 @@
         width: 100%;
         max-width: 100%;
         background: var(--color-white);
+        pointer-events: auto;
     }
 
     .header {
@@ -196,5 +197,6 @@
     .mobile {
         display: block;
         padding: 16px 20px;
+        pointer-events: auto;
     }
 }

--- a/src/widgets/MobileHeader/ui/MobileHeader/MobileHeader.module.scss
+++ b/src/widgets/MobileHeader/ui/MobileHeader/MobileHeader.module.scss
@@ -16,6 +16,7 @@
 	height: 30px;
 
 	cursor: pointer;
+	touch-action: manipulation;
 
 	span {
 		position: absolute;


### PR DESCRIPTION
## Проблема

На мобильном breakpoint (≤992px) обёртка `.wrapper` в MainHeader имеет `pointer-events: none` (нужно для плавающей капсулы на десктопе), но это правило не переопределялось для мобильного варианта. В результате клики по бургер-меню не регистрировались.

## Решение

- `MainHeader.module.scss`: добавлено `pointer-events: auto` для `.wrapper` и `.mobile` в медиа-запросе ≤992px
- `MobileHeader.module.scss`: добавлен `touch-action: manipulation` на бургер — убирает 300ms задержку перед кликом в мобильных браузерах (включая Яндекс.Браузер)