### PR TITLE
Исправить текст «Благотворительность» на странице предпочтений

### DIFF
--- a/src/features/ProfilePreferences/ui/CategoryCard/CategoryCard.module.scss
+++ b/src/features/ProfilePreferences/ui/CategoryCard/CategoryCard.module.scss
@@ -20,6 +20,11 @@
     transition: transform 0.3s ease;
     hyphens: auto;
     overflow-wrap: break-word;
+    word-break: break-word;
+    max-width: 100%;
+    min-width: 0;
+    padding: 0 8px;
+    box-sizing: border-box;
 }
 
 .title.selected {


### PR DESCRIPTION
## Проблема

Слово «Благотворительность» выходило за границы карточки 130px. `overflow-wrap: break-word` не срабатывал, потому что h4 во flex-контейнере имел `min-width: auto` (от содержимого) и мог занять ширину шире родителя.

## Решение

Добавлено в `.title` в `CategoryCard.module.scss`:
- `max-width: 100%`
- `min-width: 0` — обязательно для flex-дочернего элемента
- `word-break: break-word` — явный контроль переноса
- `padding: 0 8px; box-sizing: border-box` — отступы от краёв карточки