### PR TITLE
Показывать реальную ошибку API при смене пароля

### DIFF
--- a/src/pages/ProfileResetPasswordPage/ui/ProfileResetPasswordForm/ProfileResetPasswordForm.tsx
+++ b/src/pages/ProfileResetPasswordPage/ui/ProfileResetPasswordForm/ProfileResetPasswordForm.tsx
@@ -11,6 +11,7 @@ import HintPopup from "@/shared/ui/HintPopup/HintPopup";
 import { HintType } from "@/shared/ui/HintPopup/HintPopup.interface";
 import Input from "@/shared/ui/Input/Input";
 import { useChangePasswordMutation, useChangePasswordWithoutOldPasswordMutation, useGetProfilePasswordIsChangeQuery } from "@/entities/Profile";
+import { getErrorText } from "@/shared/lib/getErrorText";
 
 import styles from "./ProfileResetPasswordForm.module.scss";
 import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
@@ -70,7 +71,7 @@ const ProfileResetPasswordForm: FC = () => {
                 reset();
             } catch (error) {
                 setToast({
-                    text: t("password.Произошла ошибка"),
+                    text: getErrorText(error),
                     type: HintType.Error,
                 });
             }

--- a/src/shared/lib/getErrorText.tsx
+++ b/src/shared/lib/getErrorText.tsx
@@ -13,6 +13,14 @@ export const getErrorText = (error: unknown): string => {
             if ("title" in data) {
                 return String(data.title);
             }
+            // Validation errors: { errors: ["msg1", "msg2", ...] }
+            if ("errors" in data && Array.isArray(data.errors) && data.errors.length > 0) {
+                return data.errors.join(". ");
+            }
+            // { error: "msg" }
+            if ("error" in data) {
+                return String(data.error);
+            }
             // JWT 401 errors return { code, message } without detail/title
             if ("message" in data) {
                 return String(data.message);


### PR DESCRIPTION
## Проблема

При входе через VK (и в других случаях) страница смены пароля показывала «Произошла ошибка» без объяснения.

## Причины

1. `catch` блок использовал статическую строку вместо ошибки из API
2. `getErrorText` не обрабатывал формат `{"errors": ["..."]}`, который возвращает бэкенд при ошибках валидации

## Решение

- `getErrorText.tsx`: добавлена поддержка `errors[]` и `error` полей
- `ProfileResetPasswordForm.tsx`: catch использует `getErrorText(error)` вместо заглушки

## Связанный PR

Бэкенд: gs-backend#208 (Assert\Length(min: 6))