### PR TITLE
Сбор: фикс ошибки при выборе «пока не будет собрана сумма»

### DIFF
--- a/src/entities/Donation/model/types/donationSchema.ts
+++ b/src/entities/Donation/model/types/donationSchema.ts
@@ -110,7 +110,9 @@ export type GetDonationWhen = Pick<GetDonation, "id"> & {
     isUntilAmountCollected: boolean;
 };
 
-export type UpdateDonationWhen = Omit<GetDonationWhen, | "id">;
+export type UpdateDonationWhen = Omit<GetDonationWhen, "id" | "endDate"> & {
+    endDate: string | null;
+};
 
 export interface UpdateDonationWhenRequest {
     id: string;

--- a/src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx
+++ b/src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx
@@ -331,7 +331,7 @@ const FundraiseStepPage = () => {
             await updateDonationWhen({
                 id,
                 body: {
-                    endDate: formattingDate(endDate) || "",
+                    endDate: isUntilAmountCollected ? null : (formattingDate(endDate) || null),
                     isUntilAmountCollected,
                 },
             }).unwrap();


### PR DESCRIPTION
## Проблема
Баг #45: при включении тумблера «Принимаю пожертвования до тех пор, пока минимальная сумма не будет собрана» при сохранении шага «когда» возникала ошибка.

## Причина
Фронтенд отправлял `endDate: ""` (пустую строку). Бэкенд валидировал поле через `Assert\NotBlank`, что отклоняло пустую строку с ошибкой 422.

## Фронтенд
При `isUntilAmountCollected = true` теперь отправляем `endDate: null` вместо `""`.
Тип `UpdateDonationWhen.endDate` обновлён до `string | null`.