### PR TITLE
Сбор: фикс отображения собранных средств

### DIFF
--- a/src/entities/Donation/data/mockDonations.ts
+++ b/src/entities/Donation/data/mockDonations.ts
@@ -83,6 +83,7 @@ export const mockDonation: GetDonation = {
     description: "Полное описание",
     address: "Москва, Россия",
     amount: 1500,
+    collectedAmount: 0,
     minAmount: 1000,
     categories: [],
     galleryImages: [],

--- a/src/entities/Donation/model/types/donationSchema.ts
+++ b/src/entities/Donation/model/types/donationSchema.ts
@@ -56,8 +56,9 @@ export type GetDonation = Omit<GetDonations, "shortDescription" | "isClose" | "o
     startDate: string;
     peopleSupportCount: number;
     percentAmountCollect: number;
+    collectedAmount: number;
     daysLeft: number;
-    amount: number;
+    amount: number | null;
     minAmount: number;
     latitude: number;
     longitude: number;

--- a/src/entities/Donation/ui/DonationInfoCard/DonationInfoCard.tsx
+++ b/src/entities/Donation/ui/DonationInfoCard/DonationInfoCard.tsx
@@ -29,6 +29,7 @@ export const DonationInfoCard = memo((props: DonationInfoCardProps) => {
         <div className={cn(className)}>
             <DonationWhenCard
                 amount={donation.amount}
+                collectedAmount={donation.collectedAmount}
                 dateStart={donation.startDate}
                 daysLeft={donation.daysLeft}
                 percentAmountCollect={donation.percentAmountCollect}

--- a/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.tsx
+++ b/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.tsx
@@ -12,6 +12,7 @@ interface DonationWhenCardProps {
     dateStart: string | null;
     daysLeft: number | null;
     percentAmountCollect: number | null;
+    collectedAmount: number;
     amount: number | null;
     isSuccess: boolean;
 }
@@ -25,6 +26,7 @@ export const DonationWhenCard = memo((props: DonationWhenCardProps) => {
         daysLeft,
         amount,
         percentAmountCollect,
+        collectedAmount,
         isSuccess,
     } = props;
     const { t } = useTranslation("donation");
@@ -36,11 +38,16 @@ export const DonationWhenCard = memo((props: DonationWhenCardProps) => {
         return dateStart || emptyMessage;
     };
 
-    const showProgress = percentAmountCollect !== null && amount !== null;
-    const progressText = showProgress
-        ? `${fmt.format(Math.round((amount * percentAmountCollect) / 100))} ₽`
-            + ` / ${fmt.format(amount)} ₽ (${percentAmountCollect}%)`
-        : null;
+    const hasTargetAmount = amount !== null && amount > 0;
+    const showProgress = collectedAmount > 0 || hasTargetAmount;
+    const getProgressText = () => {
+        if (!showProgress) return null;
+        if (hasTargetAmount) {
+            return `${fmt.format(collectedAmount)} ₽ / ${fmt.format(amount)} ₽ (${percentAmountCollect ?? 0}%)`;
+        }
+        return `${fmt.format(collectedAmount)} ₽`;
+    };
+    const progressText = getProgressText();
 
     return (
         <div className={cn(className)} id="description">
@@ -67,7 +74,7 @@ export const DonationWhenCard = memo((props: DonationWhenCardProps) => {
                         className={styles.infoCard}
                     >
                         <DonationProgressBar
-                            value={percentAmountCollect as number}
+                            value={percentAmountCollect ?? 0}
                             isSuccess={isSuccess}
                         />
                     </InfoCardItem>


### PR DESCRIPTION
## Проблема
Баг #46: на странице сбора не отображалось, сколько средств уже собрано.

## Причина
`GetDonation` не содержал поля `collectedAmount`, хотя бэкенд его всегда возвращает. `amount` в API может быть `null` (когда хост не задал целевую сумму). В таком случае `showProgress = false` и блок «Средств собрано» вообще не рендерился.

Прогресс вычислялся как `amount * percentAmountCollect / 100` — при `amount = null` это 0 вместо реальной суммы.

## Изменения
- Добавлено поле `collectedAmount: number` в тип `GetDonation`
- `amount` исправлен на `number | null` (соответствует реальному ответу бэкенда)
- `DonationWhenCard` теперь принимает `collectedAmount` и использует его напрямую
- `showProgress = collectedAmount > 0 || hasTargetAmount` — показываем даже без цели
- Когда цель задана: «X ₽ / Y ₽ (Z%)»; когда цели нет: «X ₽»