### PR TITLE
fix: корректный поиск при пагинации в фильтре проектов

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -66,11 +66,21 @@ export const OffersSearchFilter = () => {
     } = offerFilterForm;
 
     const isSyncingRef = useRef(false);
+    const currentSearchRef = useRef<string>("");
 
     useEffect(() => {
-        const watchData = watch();
-        const preparedData = offersFilterApiAdapter(watchData);
-        fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: currentPage });
+        if (currentSearchRef.current) {
+            fetchOffers({
+                sort: OfferSort.UpdatedDesc,
+                search: currentSearchRef.current,
+                limit: OFFERS_PER_PAGE,
+                page: currentPage,
+            });
+        } else {
+            const watchData = watch();
+            const preparedData = offersFilterApiAdapter(watchData);
+            fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: currentPage });
+        }
     }, [currentPage]);
 
     useEffect(() => {
@@ -111,6 +121,7 @@ export const OffersSearchFilter = () => {
     }, []);
 
     const onApplySearch = useCallback(async (search: string) => {
+        currentSearchRef.current = search;
         setSearchParams(new URLSearchParams());
         fetchOffers({
             sort: OfferSort.UpdatedDesc, search, limit: OFFERS_PER_PAGE, page: 1,
@@ -129,6 +140,7 @@ export const OffersSearchFilter = () => {
     }, [searchParams, onApplySearch]);
 
     const onApplyFilters = useCallback(handleSubmit(async (data: OffersFilterFields) => {
+        currentSearchRef.current = "";
         const preparedData = offersFilterApiAdapter(data);
         fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: 1 });
         fetchAllOffersMap({ ...preparedData });
@@ -136,6 +148,7 @@ export const OffersSearchFilter = () => {
     }), []);
 
     const onResetFilters = useCallback(async () => {
+        currentSearchRef.current = "";
         setSearchParams(new URLSearchParams());
         searchRef.current?.clearSearch();
         const preparedData = offersFilterApiAdapter(defaultValues);
@@ -158,8 +171,17 @@ export const OffersSearchFilter = () => {
 
                 debounceTimeoutRef.current = setTimeout(() => {
                     const preparedData = offersFilterApiAdapter(value as OffersFilterFields);
-                    fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: currentPage });
-                    fetchAllOffersMap({ ...preparedData });
+                    if (currentSearchRef.current) {
+                        fetchOffers({
+                            ...preparedData,
+                            search: currentSearchRef.current,
+                            limit: OFFERS_PER_PAGE,
+                            page: currentPage,
+                        });
+                    } else {
+                        fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: currentPage });
+                        fetchAllOffersMap({ ...preparedData });
+                    }
                 }, 300);
             }
         });


### PR DESCRIPTION
## Проблема

Пользователь вводит поисковый запрос (например, «работа с детьми») на странице поиска, но видит результаты из других категорий (например, «Археология»).

## Причина

В `onApplySearch` вызывается `reset(defaultValues)` + `onChangePage(1)`:
- `reset(defaultValues)` очищает форму (пустые categoryIds, resetit sort/showClosedOffers)
- `onChangePage(1)` — если текущая страница > 1, это меняет `currentPage`, что запускает `useEffect([currentPage])`
- useEffect читает форму (которая уже сброшена, без search) и вызывает `fetchOffers` без поискового запроса
- Последний fetch перетирает результаты поиска полным листингом
- Аналогично: `reset` мог изменить `offersSort.*` → sort-watch запускал fetch без search

## Решение

Добавлен `currentSearchRef` для хранения текущего поискового запроса:
- `onApplySearch` записывает запрос в ref
- `useEffect([currentPage])` — при активном поиске использует search из ref вместо формы
- Sort-watch — при активном поиске добавляет search к fetch
- `onApplyFilters` / `onResetFilters` — очищают ref (выход из режима поиска)