### PR TITLE
Профиль организации: видео и фото галерея

### DIFF
--- a/src/features/Gallery/ui/HostGallery/HostGallery.tsx
+++ b/src/features/Gallery/ui/HostGallery/HostGallery.tsx
@@ -91,7 +91,10 @@ export const HostGallery: FC<HostGalleryProps> = (props) => {
                 uploadedImgs={imgs}
                 onUpload={handleOnUpload}
                 onDelete={handleOnDelete}
-                onError={() => {}}
+                onError={(error) => setToast({
+                    text: error ?? t("volunteer-gallery.Произошла ошибка с обновлением галереи"),
+                    type: HintType.Error,
+                })}
             />
         </div>
     );

--- a/src/features/VideoForm/ui/HostVideoForm/HostVideoForm.tsx
+++ b/src/features/VideoForm/ui/HostVideoForm/HostVideoForm.tsx
@@ -43,14 +43,16 @@ export const HostVideoForm: FC<HostVideoFormProps> = (props) => {
     const addVideo = useCallback(
         (newVideo: VideoFormImplementation) => {
             setToast(undefined);
+            const updatedVideos = [...videos, newVideo.video];
             updateHost({
                 id: host.id,
                 body: {
-                    videoGallery: [...videos, newVideo.video],
+                    videoGallery: updatedVideos,
                 },
             })
                 .unwrap()
                 .then(() => {
+                    setVideos(updatedVideos);
                     setToast({
                         text: t("hostVideo.Данные успешно изменены"),
                         type: HintType.Success,


### PR DESCRIPTION
## Баг #6 — Добавление ссылки на видео

`HostVideoForm.addVideo` не вызывал `setVideos` после успешного сохранения — новое видео появлялось только после перезагрузки страницы. `deleteVideo` делал это корректно.

**Фикс**: выносим `updatedVideos` в переменную до `updateHost`, в `.then()` вызываем `setVideos(updatedVideos)`.

## Баг #7 — Ошибка при загрузке фото

`HostGallery` передавал `onError={() => {}}` в `ImagesUploader` — ошибки загрузки (API 4xx/5xx, превышение 10 файлов, превышение 5 МБ) проглатывались без уведомления.

**Фикс**: показываем тост с текстом ошибки из `onError(error?)`.