### PR TITLE
fix: исправить ID для фильтров «Предоставляется» на странице поиска

### DIFF
--- a/src/pages/OffersMapPage/lib/offersFilterAdapter.ts
+++ b/src/pages/OffersMapPage/lib/offersFilterAdapter.ts
@@ -61,14 +61,13 @@ export const offersFilterApiAdapter = (
 
     provided.forEach((value) => {
         if (value === "food") {
-            queryParams.foodIds = [1, 3]; // Параметры с "Полный пансион" и "Завтра включен"
+            queryParams.foodIds = [1, 2, 3];
         }
         if (value === "housing") {
-            queryParams.houseIds = [5, 1]; // Параметры с "Отдельный дом" и "Комната"
+            queryParams.houseIds = [1, 2, 3, 4, 5];
         }
         if (value === "paidTravel") {
-            queryParams.transferIds = [2, 1]; // Параметры с "Полная оплата проезда"
-            // и "Частичная компенсация затрат"
+            queryParams.transferIds = [1, 2, 3, 4];
         }
     });
 


### PR DESCRIPTION
## Проблема

Фильтры «Проживание», «Питание», «Проезд» на странице поиска показывали значительно меньше проектов, чем должны.

Причина: в `offersFilterAdapter.ts` были захардкожены неверные и неполные ID из словарей БД.

| Фильтр | Старые ID | Результатов | Правильные ID | Результатов |
|---|---|---|---|---|
| Проживание | `[5, 1]` | 62 | `[1, 2, 3, 4, 5]` | 503 |
| Проезд | `[2, 1]` | 23 | `[1, 2, 3, 4]` | 105 |
| Питание | `[1, 3]` | 421 | `[1, 2, 3]` | 434 |

Комментарии к старому коду также были неверными (ID не соответствовали названиям в БД).

## Решение

Каждый переключатель теперь включает **все** варианты соответствующего справочника.

Словари (проверено на staging через `doctrine:query:sql`):
- House: 1=Отдельный дом, 2=Комната, 3=Койко-место, 4=Палатка, 5=Место под палатку
- Food: 1=Полный пансион, 2=Завтрак включён, 3=Продукты
- Transfer: 1=Полная оплата, 2=Компенсация стоимости, 3=Частичная компенсация, 4=Заброска из пункта сбора

## Связанные задачи

Баг #31 из таблицы ошибок.

## Тест-план

- [ ] Открыть поиск проектов (goodsurfing.org/ru/offers-map)
- [ ] Включить фильтр «Проживание» → нажать «Применить» → должно быть заметно больше результатов (~500 на staging)
- [ ] Проверить аналогично «Питание» и «Проезд»
- [ ] Убедиться, что комбинирование фильтров работает корректно