### PR TITLE
fix: исправить toAbsoluteUrl — невалидный IRI при относительных URL

### DIFF
--- a/src/shared/lib/getMediaContent.ts
+++ b/src/shared/lib/getMediaContent.ts
@@ -8,7 +8,7 @@ const toAbsoluteUrl = (url: string): string => {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
     }
-    return `${BASE_URL}${url.startsWith("/") ? url.slice(1) : url}`;
+    return `${BASE_URL}${url.startsWith("/") ? url : `/${url}`}`;
 };
 
 export const getMediaContent = (


### PR DESCRIPTION
## Проблема

`toAbsoluteUrl` в `getMediaContent.ts` использовал `url.slice(1)` для отрезания ведущего `/`, что при `BASE_URL` без trailing slash давало невалидный IRI:

```
"/api/v1/media_objects/uuid" → "https://api.goodsurfing.orgapi/v1/media_objects/uuid"
```

Это приводило к CRITICAL ошибкам в логах Symfony: `Invalid IRI "https://api.goodsurfing.orgapi/v1/media_objects/..."`.

## Исправление

Инвертирована логика: если URL уже начинается на `/` — конкатенировать как есть; иначе добавить `/`.

```ts
// До (баг):
return `${BASE_URL}${url.startsWith("/") ? url.slice(1) : url}`;

// После (фикс):
return `${BASE_URL}${url.startsWith("/") ? url : `/${url}`}`;
```