### PR TITLE
Шапка: «Членство» в правый CTA-кластер + фикс адаптива

### DIFF
--- a/src/widgets/MainHeader/MainHeader.module.scss
+++ b/src/widgets/MainHeader/MainHeader.module.scss
@@ -159,6 +159,30 @@
     white-space: nowrap;
 }
 
+.membershipCta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 40px;
+    padding: 0 14px;
+    background-color: #02CC9B;
+    border: 1px solid #02CC9B;
+    color: var(--color-white);
+    font-size: 13.5px;
+    font-weight: 600;
+    border-radius: 10px;
+    text-decoration: none;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+        background-color: #00B589;
+        border-color: #00B589;
+        color: var(--color-white);
+    }
+}
+
 .membershipWrapper {
     display: inline-flex;
 }
@@ -193,18 +217,14 @@
     display: none;
 }
 
-@media (max-width: 1080px) {
-    .wrapper {
-        max-width: 980px;
-    }
-
+@media (max-width: 1280px) {
     .header {
-        padding: 0 8px 0 16px;
-        gap: 8px;
+        padding: 0 12px;
+        gap: 10px;
     }
 }
 
-@media (max-width: 992px) {
+@media (max-width: 1200px) {
     .wrapper {
         position: sticky;
         top: 0;

--- a/src/widgets/MainHeader/MainHeader.tsx
+++ b/src/widgets/MainHeader/MainHeader.tsx
@@ -11,6 +11,7 @@ import MobileHeader from "@/widgets/MobileHeader/ui/MobileHeader/MobileHeader";
 import logotypeIcon from "@/shared/assets/icons/logo-black.svg";
 import {
     getMainPageUrl,
+    getMembershipPageUrl,
     getMessengerPageUrl,
     getSignInPageUrl,
 } from "@/shared/config/routes/AppUrls";
@@ -71,6 +72,12 @@ const MainHeader: FC<MainHeaderProps> = ({ variant = "floating" }) => {
                     <MainHeaderNav />
                 </div>
                 <div className={styles.right}>
+                    <LocaleLink
+                        to={getMembershipPageUrl(locale)}
+                        className={styles.membershipCta}
+                    >
+                        {t("main.welcome.header.membership", "Членство")}
+                    </LocaleLink>
                     <ChangeLanguage localeApi={myProfile?.locale} profileData={myProfile} />
                     {(isAuth && myProfile) ? (
                         <>

--- a/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.module.scss
+++ b/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.module.scss
@@ -1,7 +1,7 @@
 .wrapper {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 2px;
     flex-wrap: nowrap;
     min-width: 0;
 }
@@ -10,12 +10,12 @@
     background-color: var(--text-primary-1);
     border: 1px solid var(--text-primary-1);
     border-radius: 10px;
-    font-size: 13.5px;
+    font-size: 13px;
     font-weight: 500;
     color: var(--bg-primary-1);
     line-height: 1;
     box-sizing: border-box;
-    padding: 8px 14px;
+    padding: 8px 12px;
     white-space: nowrap;
     transition: all 0.2s ease;
 
@@ -44,10 +44,10 @@
     text-decoration: none;
     display: inline-flex;
     align-items: center;
-    column-gap: 4px;
-    padding: 8px 10px;
+    column-gap: 3px;
+    padding: 8px 8px;
     border-radius: 10px;
-    font-size: 13.5px;
+    font-size: 13px;
     font-weight: 500;
     color: var(--accent-color);
     cursor: pointer;
@@ -133,23 +133,3 @@
     }
 }
 
-.btnMembership {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 8px 14px;
-    background-color: var(--color-green);
-    border: 1px solid var(--color-green);
-    color: var(--color-white);
-    font-size: 13.5px;
-    font-weight: 600;
-    border-radius: 10px;
-    text-decoration: none;
-    white-space: nowrap;
-    transition: background-color 0.2s ease, color 0.2s ease;
-
-    &:hover {
-        background-color: var(--color-white);
-        color: var(--color-green);
-    }
-}

--- a/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.tsx
+++ b/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.tsx
@@ -354,11 +354,6 @@ export const MainHeaderNav = () => {
                 </Link>
             </div>
             <div>
-                <Link className={styles.btnMembership} to={getMembershipPageUrl(locale)}>
-                    {t("main.welcome.header.membership", "Членство")}
-                </Link>
-            </div>
-            <div>
                 <Link className={styles.btnNav} to="https://expedition.goodsurfing.org/">
                     {t("main.welcome.header.expeditions", "Экспедиции")}
                 </Link>

--- a/src/widgets/MobileHeader/ui/MobileHeader/MobileHeader.module.scss
+++ b/src/widgets/MobileHeader/ui/MobileHeader/MobileHeader.module.scss
@@ -169,7 +169,7 @@
 
 .buttonMembership {
     width: 100%;
-    background-color: #4CAF50 !important;
+    background-color: #02CC9B !important;
     color: white !important;
     padding: 25px 20px;
     justify-content: start;
@@ -179,7 +179,7 @@
     font-weight: 600;
 
     &:hover {
-        background-color: #388E3C !important;
+        background-color: #00B589 !important;
     }
 }
 


### PR DESCRIPTION
## Что и зачем

Зелёная кнопка «Членство» стояла **в середине** ряда меню и ломала визуальный ряд, а на ширинах **992–1268px** десктоп-меню (7 пунктов) переполнялось и наезжало на логотип и правый блок — мобильный бургер при этом включался только при ≤992px.

## Изменения

- **«Членство» → правый CTA-кластер.** Кнопка вынесена из центрального меню в `.right`, рядом с переключателем языка и «Входом» — как и положено основному call-to-action.
- **Единый бренд-зелёный `#02CC9B`** (как announcement-баннер) для десктопной и мобильной кнопки. До этого было три разных оттенка: `#22E0A5` (десктоп), `#4CAF50` (мобайл), `#02CC9B` (баннер).
- **Адаптив:** порог переключения на мобильный бургер поднят с 992 до **1200px** — закрыта сломанная зона 992–1268px. Ряд меню слегка уплотнён (шрифт 13.5→13, паддинги/гэпы), чтобы на ≤1280px был запас по ширине.

## Проверено в браузере

| Ширина | Результат |
|---|---|
| 1440 / 1280 | десктоп, всё помещается, наездов нет (зазор ~10px) |
| 1100 | чистый мобильный бургер (раньше — переполнение) |
| 375 | мобильное меню ок, «Членство» — зелёный CTA `#02CC9B` |

Цвет мобильной кнопки подтверждён инструментом: `rgb(2, 204, 155)`.

## Файлы
- `widgets/MainHeader/MainHeader.tsx` / `.module.scss`
- `widgets/MainHeader/MainHeaderNav/MainHeaderNav.tsx` / `.module.scss`
- `widgets/MobileHeader/ui/MobileHeader/MobileHeader.module.scss`