### PR TITLE
Создание вакансии («Когда»): периоды добавляются снизу

### DIFF
--- a/src/features/Offer/OfferWhen/ui/OfferWhenPeriods/OfferWhenPeriods.tsx
+++ b/src/features/Offer/OfferWhen/ui/OfferWhenPeriods/OfferWhenPeriods.tsx
@@ -57,20 +57,6 @@ export const OfferWhenPeriods = memo(({ value, onChange }: OfferWhenPeriodsProps
     return (
         <Box className={styles.wrapper}>
             <Box className={styles.dateWrapper}>
-                <DateInputs
-                    onDateChange={handleTempPeriodChange}
-                    value={tempPeriod}
-                    close={(
-                        <CloseButton
-                            className={cn(
-                                styles.btn,
-                                { [styles.active]: !!(tempPeriod.start || tempPeriod.end) },
-                            )}
-                            onClick={resetTempPeriod}
-                        />
-                    )}
-                />
-
                 {value.map((dates, index) => (
                     <DateInputs
                         key={index}
@@ -84,6 +70,20 @@ export const OfferWhenPeriods = memo(({ value, onChange }: OfferWhenPeriodsProps
                         )}
                     />
                 ))}
+
+                <DateInputs
+                    onDateChange={handleTempPeriodChange}
+                    value={tempPeriod}
+                    close={(
+                        <CloseButton
+                            className={cn(
+                                styles.btn,
+                                { [styles.active]: !!(tempPeriod.start || tempPeriod.end) },
+                            )}
+                            onClick={resetTempPeriod}
+                        />
+                    )}
+                />
             </Box>
             <Box className={styles.add}>
                 <AddButton text={t("when.Добавить период")} onClick={onAddBtnClick} />


### PR DESCRIPTION
## Проблема
На шаге «Когда» создания вакансии поле для ввода нового периода стояло **над** списком уже добавленных периодов. Из-за этого новые периоды визуально появлялись сверху, что неинтуитивно.

## Решение
Переставил порядок рендера в `OfferWhenPeriods`: сначала список добавленных периодов, затем — пустое поле для нового периода (снизу). Форма читается сверху вниз, новые периоды добавляются в конец.

Логика добавления не менялась — `onAddBtnClick` как и раньше делает `onChange([...value, tempPeriod])` (push в конец).

## Файл
- `features/Offer/OfferWhen/ui/OfferWhenPeriods/OfferWhenPeriods.tsx`

> Живой репро требует входа хостом и прохода формы вакансии до вкладки «Когда»; изменение — чистая перестановка JSX, ESLint зелёный.