### PR TITLE
Сборы: дата донора показывалась с переставленными днём и месяцем

### DIFF
--- a/src/entities/Donation/ui/DonationDonorsCard/DonationDonorsCard.tsx
+++ b/src/entities/Donation/ui/DonationDonorsCard/DonationDonorsCard.tsx
@@ -74,7 +74,7 @@ export const DonationDonorsCard = memo((props: DonationDonorsCardProps) => {
                                     : donor.fullName || t("donationPersonal.Аноним")}
                             </span>
                             <span className={styles.donorDate}>
-                                {new Date(donor.createdAt).toLocaleDateString("ru-RU")}
+                                {donor.createdAt}
                             </span>
                         </div>
                         <span className={styles.amount}>


### PR DESCRIPTION
## Проблема (подтверждено на проде)
На странице сбора в списке доноров дата отображалась неверно. Проверил живой прод-API:
`GET /api/v3/donation/fundraise/{id}/list` возвращает `createdAt: "09.06.2026"` — **уже форматированную строку** `DD.MM.YYYY`.

А `DonationDonorsCard` оборачивал её в `new Date(donor.createdAt).toLocaleDateString("ru-RU")`. JS парсит `"09.06.2026"` как `MM.DD.YYYY` → **6 сентября**, поэтому дата показывалась с переставленными днём и месяцем (`09.06.2026` → `06.09.2026`). Для дней >12 (`new Date("15.06.2026")`) — вообще `Invalid Date`.

```
node: new Date("09.06.2026").toLocaleDateString("ru-RU") => "06.09.2026"  // день/месяц переставлены
```

## Решение
Выводим `donor.createdAt` как есть (строка уже в нужном формате `DD.MM.YYYY`).

## Файл
- `entities/Donation/ui/DonationDonorsCard/DonationDonorsCard.tsx`

Это часть пункта «Сборы: ошибки в отображении доноров и даты». Сама дата старта сбора (`DonationWhenCard`) выводится корректно — там `new Date()` нет.