### PR TITLE
Сборы: неверная дата окончания при редактировании (парсинг d-m-Y)

### DIFF
--- a/src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx
+++ b/src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx
@@ -39,7 +39,7 @@ import {
     FUNDRAISE_DESCRIPTION_FORM,
     FUNDRAISE_WHERE_FORM,
 } from "@/shared/constants/localstorage";
-import { formattingDate } from "@/shared/lib/formatDate";
+import { formattingDate, parseDateApi } from "@/shared/lib/formatDate";
 import { getErrorText } from "@/shared/lib/getErrorText";
 import { AddButton } from "@/shared/ui/AddButton/AddButton";
 import Button from "@/shared/ui/Button/Button";
@@ -236,7 +236,7 @@ const FundraiseStepPage = () => {
         }
 
         if (donationWhen) {
-            setEndDate(donationWhen.endDate ? new Date(donationWhen.endDate) : undefined);
+            setEndDate(parseDateApi(donationWhen.endDate));
             setIsUntilAmountCollected(Boolean(donationWhen.isUntilAmountCollected));
         }
     }, [step, donationWhen]);

--- a/src/shared/lib/formatDate.ts
+++ b/src/shared/lib/formatDate.ts
@@ -90,7 +90,8 @@ export const parseDate = (dateString: string | null | undefined) => {
 export const parseDateApi = (dateStr: string | null | undefined): Date | undefined => {
     if (!dateStr) return undefined;
 
-    const parts = dateStr.split(".");
+    // API отдаёт даты как d.m.Y и d-m-Y — поддерживаем оба разделителя.
+    const parts = dateStr.split(/[.\-/]/);
     if (parts.length !== 3) return undefined;
 
     const [day, month, year] = parts.map(Number);


### PR DESCRIPTION
## Проблема (подтверждено форматом API + парсингом JS)
Эндпоинт `GET fundraise/when/{id}` отдаёт `endDate` в формате `d-m-Y` (бэкенд `Constant::DATE_FORMAT_2`), например `"09-06-2026"`. Форма редактирования сбора (`FundraiseStepPage`, шаг «когда») парсила её через `new Date(donationWhen.endDate)`:

```
node: new Date("09-06-2026") => Sun Sep 06 2026   // 9 июня прочитано как 6 сентября
node: new Date("15-06-2026") => Invalid Date       // день >12 → невалидная дата
```

→ хост при редактировании сбора видел неверную/пустую дату окончания в пикере.

## Решение
- `parseDateApi` теперь принимает оба разделителя API-дат (`.` и `-`): `split(/[.\-/]/)`.
- `FundraiseStepPage` использует `parseDateApi(donationWhen.endDate)` вместо `new Date(...)`.

Парсинг дат вакансий (формат `d.m.Y`, точки) уже шёл через `parseDateApi` и не затронут — регэксп по-прежнему корректно делит по точке (проверено).

## Файлы
- `shared/lib/formatDate.ts`
- `pages/FundraiseStepPage/ui/FundraiseStepPage.tsx`

Связано с пунктом «Сборы: ошибки в отображении ... даты» (вместе с PR #334 по дате доноров).