### PR TITLE
Шапка: воздух в правом кластере + бургер с ≤1280

### DIFF
--- a/src/widgets/MainHeader/MainHeader.module.scss
+++ b/src/widgets/MainHeader/MainHeader.module.scss
@@ -133,7 +133,7 @@
 .right {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 12px;
     flex-shrink: 0;
 
     .icons {
@@ -217,14 +217,14 @@
     display: none;
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1366px) {
     .header {
         padding: 0 12px;
-        gap: 10px;
+        gap: 12px;
     }
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1280px) {
     .wrapper {
         position: sticky;
         top: 0;


### PR DESCRIPTION
## Проблема
На средних ширинах (≈1200–1300px) в правой части шапки «Членство», переключатель языка и «Вход» слипались, а «Членство» почти касалось пункта «Международное волонтёрство». В зоне 1200–1280 десктоп-меню вообще было зажато (зазор nav↔Членство всего 10px — нет места под нормальные отступы).

## Решение (замерено вживую на 1280/1300/1366)
- Зазор правого кластера `.right` `gap` 8→**12px** — Членство/язык/Вход больше не прилипают (на всех ширинах).
- Порог переключения на мобильный бургер поднят **1200→1280**: бескомпромиссно-тесная зона 1200–1280 теперь показывает мобильный хедер, а не зажатый десктоп.
- Уплотнение десктопа (padding 12, gap 12) расширено до **≤1366**.

| Ширина | Результат |
|---|---|
| 1280 | мобильный бургер |
| 1300 | десктоп, все зазоры 12px |
| 1366 | десктоп, nav↔Членство 35px, флаг 12px |

## Файл
- `widgets/MainHeader/MainHeader.module.scss`