### PR TITLE
Смена аккаунта: полный сброс стейта при выходе (П27)

### DIFF
--- a/src/entities/User/model/slice/userSlice.ts
+++ b/src/entities/User/model/slice/userSlice.ts
@@ -59,7 +59,7 @@ export const userSlice = createSlice({
         logout: (state) => {
             state.authData = undefined;
 
-            [localStorage].forEach((storage) => {
+            [localStorage, sessionStorage].forEach((storage) => {
                 storage.removeItem(USER_LOCALSTORAGE_KEY);
                 storage.removeItem(ROLES_LOCALSTORAGE_KEY);
                 storage.removeItem(TOKEN_LOCALSTORAGE_KEY);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -4,7 +4,7 @@ import { authApi } from "@/store/api/authApi";
 
 import { localeApi } from "./api/localeApi";
 
-import { userReducer } from "@/entities/User";
+import { userReducer, userActions } from "@/entities/User";
 
 import { profileApi, profileReducer } from "@/entities/Profile";
 
@@ -38,7 +38,7 @@ import { donationApi } from "@/entities/Donation";
 import { membershipApi } from "./api/membershipApi";
 import { donationPaymentApi } from "./api/donationPaymentApi";
 
-const rootReducer = combineReducers({
+const combinedReducer = combineReducers({
     register: registerReducer,
     profile: profileReducer,
     gallery: galleryReducer,
@@ -74,6 +74,22 @@ const rootReducer = combineReducers({
     [adminSystemApi.reducerPath]: adminSystemApi.reducer,
     [adminBannerMarketingApi.reducerPath]: adminBannerMarketingApi.reducer,
 });
+
+// При выходе из аккаунта сбрасываем весь стейт к initial: это очищает кэши RTK Query
+// всех api-слайсов и данные slice'ов (profile/gallery/admin/...), чтобы данные
+// предыдущего пользователя не «смешивались» после смены аккаунта (баг П27).
+// Флаг user._inited сохраняем — на нём держится рендер роутера (App.tsx),
+// сброс его в false дал бы белый экран.
+const rootReducer: typeof combinedReducer = (state, action) => {
+    if (action.type === userActions.logout.type) {
+        const inited = state?.user._inited ?? true;
+        const resetState = combinedReducer(undefined, action);
+        resetState.user._inited = inited;
+        return resetState;
+    }
+
+    return combinedReducer(state, action);
+};
 
 export const setupStore = () => configureStore({
     reducer: rootReducer,


### PR DESCRIPTION
## Проблема (П27 «Правки сайт ГС 2.0 от 23.06.2026»)

«Ошибка при смене аккаунта. Не до конца выходит из учётной записи. Страницы смешиваются.»

При `logout` (`userSlice`) очищался только Redux `authData` и часть ключей `localStorage`. Не сбрасывались:
- **кэш RTK Query** — в проекте **29 `createApi`-слайсов** (profileApi, hostApi, offerApi, chatApi, adminApi…), `resetApiState()` не вызывался нигде → данные предыдущего пользователя оставались в кэше и подмешивались после входа под другим аккаунтом;
- **`sessionStorage`** — `baseQuery.prepareHeaders` читает токен из `state → localStorage → sessionStorage` (фолбэк), а logout чистил только `localStorage`;
- data-слайсы `profile`/`gallery`/`register`.

## Решение

- **`store.ts`** — обёртка над `combinedReducer`: на `auth/logout` весь стейт сбрасывается к initial (`combinedReducer(undefined, action)`), что разом очищает кэши всех api-слайсов и data-слайсы. Флаг `user._inited` сохраняется — в `App.tsx` роутер рендерится по `{inited && <LangRouter/>}`, поэтому сброс `_inited` в `false` дал бы белый экран.
- **`userSlice.ts`** — `logout` чистит и `sessionStorage` (тот же набор ключей токена).