### PR TITLE
Исправлена опечатка firsName → firstName в типах и компонентах (П25)

### DIFF
--- a/src/entities/Academy/model/types/academy.ts
+++ b/src/entities/Academy/model/types/academy.ts
@@ -46,7 +46,7 @@ export interface Courses {
     videoCount: number;
     image: Image;
     author: {
-        firsName: string;
+        firstName: string;
         lastName: string;
     }
 }
@@ -82,7 +82,7 @@ export interface GetCourse {
     courseProgressNumber: number[];
     image: Image;
     author: {
-        firsName: string;
+        firstName: string;
         lastName: string;
     };
     experts: GetExpert[];

--- a/src/entities/Admin/lib/adminCourseAdapter.ts
+++ b/src/entities/Admin/lib/adminCourseAdapter.ts
@@ -31,7 +31,7 @@ export const adminCourseAdapter = (
 
     const expertsTemp: AdminExpertFields[] = experts.map((expert) => ({
         id: expert.id,
-        firstName: expert.firsName,
+        firstName: expert.firstName,
         lastName: expert.lastName,
         image: expert.image,
         city: expert.city,

--- a/src/entities/Admin/model/types/adminCourseSchema.ts
+++ b/src/entities/Admin/model/types/adminCourseSchema.ts
@@ -117,7 +117,7 @@ export type GetAdminLesson = CreateAdminLesson & {
 
 export interface GetAdminCourseExpert {
     id: string;
-    firsName: string;
+    firstName: string;
     lastName: string;
     project: string;
     country: string;

--- a/src/entities/News/model/types/newsSchema.ts
+++ b/src/entities/News/model/types/newsSchema.ts
@@ -32,7 +32,7 @@ export interface GetNewsListResponse {
 export type GetNews = GetNewsList & {
     author: {
         id: string;
-        firsName: string | null;
+        firstName: string | null;
         lastName: string | null;
         image: Image | null;
     }

--- a/src/entities/Video/model/types/videoSchema.ts
+++ b/src/entities/Video/model/types/videoSchema.ts
@@ -51,7 +51,7 @@ export type GetVideo = Omit<GetVideos, "category"> & {
     categoryResult: CategoryNews;
     author: {
         id: string;
-        firsName: string;
+        firstName: string;
         lastName: string;
         image: Image;
     }

--- a/src/widgets/Academy/ui/CoursePersonal/CoursePersonal/CoursePersonal.tsx
+++ b/src/widgets/Academy/ui/CoursePersonal/CoursePersonal/CoursePersonal.tsx
@@ -47,7 +47,7 @@ export const CoursePersonal: FC<CoursePersonalProps> = (props) => {
     const seoImage = getMediaContent(data.image?.contentUrl);
     const seoKeywords = [
         data.name,
-        data.author?.firsName,
+        data.author?.firstName,
         data.author?.lastName,
         t("seo.course.keywords"),
     ].filter(Boolean).join(", ");

--- a/src/widgets/Academy/ui/CoursePersonal/Header/Header.tsx
+++ b/src/widgets/Academy/ui/CoursePersonal/Header/Header.tsx
@@ -67,7 +67,7 @@ export const Header: FC<HeaderProps> = (props) => {
                     <span className={styles.author}>
                         Автор:
                         {" "}
-                        {getFullName(author.firsName, author.lastName)}
+                        {getFullName(author.firstName, author.lastName)}
                     </span>
                     <Button
                         className={styles.button}

--- a/src/widgets/Academy/ui/CoursesList/CoursesList.tsx
+++ b/src/widgets/Academy/ui/CoursesList/CoursesList.tsx
@@ -50,7 +50,7 @@ export const CoursesList: FC<CoursesListProps> = (props) => {
                     id,
                     title: name,
                     cover: getMediaContent(image.contentUrl),
-                    author: getFullName(author.firsName, author.lastName),
+                    author: getFullName(author.firstName, author.lastName),
                     description,
                     duration,
                     numberLessons: videoCount,

--- a/src/widgets/Video/ui/VideoPersonal/VideoPersonal.tsx
+++ b/src/widgets/Video/ui/VideoPersonal/VideoPersonal.tsx
@@ -159,7 +159,7 @@ export const VideoPersonal: FC<VideoPersonalProps> = (props) => {
                     className={styles.articleHeader}
                     title={data?.name ?? ""}
                     authorAvatar={getMediaContent(data?.author.image.thumbnails?.small)}
-                    authorName={getFullName(data?.author.firsName, data?.author.lastName)}
+                    authorName={getFullName(data?.author.firstName, data?.author.lastName)}
                     category={data?.categoryResult.name}
                     categoryColor={data?.categoryResult.color}
                     date={data?.created ?? ""}


### PR DESCRIPTION
## Проблема (П25 «Правки сайт ГС 2.0 от 23.06.2026»)

В API-типах поле `firstName` автора было написано с опечаткой — `firsName`. Из-за этого имя автора не передавалось в компоненты и не отображалось на страницах курсов, видео и новостей.

## Изменения

**Типы (5 файлов):**
- `entities/Academy/model/types/academy.ts` — 2 вхождения
- `entities/Video/model/types/videoSchema.ts`
- `entities/News/model/types/newsSchema.ts`
- `entities/Admin/model/types/adminCourseSchema.ts`

**Компоненты и адаптеры (5 файлов):**
- `widgets/Video/ui/VideoPersonal/VideoPersonal.tsx`
- `widgets/Academy/ui/CoursesList/CoursesList.tsx`
- `widgets/Academy/ui/CoursePersonal/Header/Header.tsx`
- `widgets/Academy/ui/CoursePersonal/CoursePersonal/CoursePersonal.tsx`
- `entities/Admin/lib/adminCourseAdapter.ts`