### PR TITLE
Пачка мелких фиксов: категории, sticky-хедер, CSS-фолбэк

### DIFF
--- a/src/entities/Video/lib/videoAdapter.ts
+++ b/src/entities/Video/lib/videoAdapter.ts
@@ -35,7 +35,7 @@ export const videoCardAdapter = (video: GetVideos[]): VideoCardType[] => video.m
         date: created,
         comments: reviewCount,
         likes: likeCount,
-        tag: { name: category?.name ?? "", color: category?.color ?? "var(--text-primary-1" },
+        tag: { name: category?.name ?? "", color: category?.color ?? "var(--text-primary-1)" },
     };
 });
 

--- a/src/pages/DonationPersonalPage/ui/DonationPersonalPage/DonationPersonalPage.module.scss
+++ b/src/pages/DonationPersonalPage/ui/DonationPersonalPage/DonationPersonalPage.module.scss
@@ -5,7 +5,7 @@
 }
 
 .content {
-    padding: 36px 50px 50px 50px;
+    padding: 92px 50px 50px 50px;
     min-height: 500px;
     width: 100%;
     max-width: 1920px;

--- a/src/pages/HostPersonalPage/ui/HostPersonalPage/HostPersonalPage.module.scss
+++ b/src/pages/HostPersonalPage/ui/HostPersonalPage/HostPersonalPage.module.scss
@@ -14,8 +14,7 @@
 
 .navMenu {
     position: sticky;
-    // top: 5.563rem;
-    top: 91px;
+    top: 6.5rem;
     z-index: 8;
 }
 

--- a/src/widgets/CategoriesWidget/ui/Category/Category.module.scss
+++ b/src/widgets/CategoriesWidget/ui/Category/Category.module.scss
@@ -27,8 +27,7 @@
     font-weight: 500;
     line-height: 1.4rem;
     color: white;
-    // word-break: break-word;
-    hyphens: auto;
+    word-break: break-word;
     overflow-wrap: break-word;
 }
 

--- a/src/widgets/CategoriesWidget/ui/Category/Category.tsx
+++ b/src/widgets/CategoriesWidget/ui/Category/Category.tsx
@@ -63,7 +63,7 @@ export const Category: FC<CategoryProps> = memo((props: CategoryProps) => {
             onClick={navigateTo}
         >
             <div>
-                <span className={styles.title}>{title}</span>
+                <span lang={locale} className={styles.title}>{title}</span>
                 <br />
                 <span className={styles.vacancy}>
                     {vacancyNumber}


### PR DESCRIPTION
## Что внутри
- **П9**: перенос названий категорий на /categories (убран `hyphens:auto`, добавлен `lang`) — та же причина, что чинили в CategoryCard (#319), но пропустили в CategoriesWidget/Category
- **П7,29 (частично)**: наложение шапки на HostPersonalPage (sticky top не довели до 6.5rem при фиксе c2ce9312) и DonationPersonalPage (content padding не подняли)
- Битый CSS-фолбэк в videoAdapter (`var(--text-primary-1` без закрывающей скобки)

## Test plan
- [x] tsc --noEmit чисто
- [ ] Проверить на проде: /categories (перенос слов), /host-personal/{id} и /donation/{id} (нет наложения при скролле)