### PR TITLE
categories: убран неверный лейбл 'Заповедники и парки'

### DIFF
--- a/src/shared/data/categories/index.tsx
+++ b/src/shared/data/categories/index.tsx
@@ -31,7 +31,7 @@ export const useCategories = () => {
             image: reserveImage,
             value: "reserves_and_parks",
             color: "#C3A3E9",
-            text: t("category-offer.Заповедники и парки"),
+            text: t("category-offer.Заповедники и нац. парки"),
             path: "/offers-map?category=2",
         },
         {


### PR DESCRIPTION
Мёртвый код (tags массив нигде не используется), но неверная формулировка была на месте — убрал ловушку на будущее.