### PR TITLE
test: покрыть пакет фиксов rows 105/100/99/94

### DIFF
--- a/src/pages/FindJobPage/ui/Header/Header.test.tsx
+++ b/src/pages/FindJobPage/ui/Header/Header.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { Header } from "./Header";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+/**
+ * Регресс-тест для PR gs-frontend#349 (v0.1.26): кнопка "Найти работу" на
+ * /find-job вела на /offers-map?category=paid_work — фильтр на offers-map
+ * принимает только числовые ID категорий (Number("paid_work")=NaN,
+ * отбрасывалось). Должна вести на реальный numeric ID категории "Оплачиваемая
+ * работа" (13).
+ */
+describe("FindJobPage Header", () => {
+    it('кнопка "Найти работу" ведёт на числовой ID категории, а не на строковый слаг', () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <Header />
+            </MemoryRouter>,
+        );
+
+        const link = screen.getByText("Найти работу").closest("a");
+        expect(link).toHaveAttribute("href", "/ru/offers-map?category=13");
+        expect(link?.getAttribute("href")).not.toContain("paid_work");
+    });
+});

--- a/src/pages/MembershipPage/ui/WhyMembership/WhyMembership.test.tsx
+++ b/src/pages/MembershipPage/ui/WhyMembership/WhyMembership.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WhyMembership } from "./WhyMembership";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+/**
+ * Регресс-тест: WhyMembership ссылался на несуществующий публичный путь
+ * /images/membership/community.jpg (404 на странице членства). Картинка
+ * должна подключаться бандл-импортом (резолвится сборщиком в реальный
+ * хэшированный ассет), а не хардкодиться строкой на public-путь.
+ */
+describe("WhyMembership", () => {
+    it("рендерит картинку с валидным резолвнутым src (не пустым и не старым битым путём)", () => {
+        render(<WhyMembership />);
+
+        const image = screen.getByAltText("Волонтёры Гудсёрфинга");
+        const src = image.getAttribute("src");
+
+        expect(src).toBeTruthy();
+        expect(src).not.toBe("/images/membership/community.jpg");
+    });
+});

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { setupStore } from "./store";
+import { userActions } from "@/entities/User";
+import { setRegisterUserData } from "./reducers/registerSlice";
+
+/**
+ * Регресс-тест для PR gs-frontend#342 + хотфиксы v0.1.22/23 (#346, баг П27):
+ * logout должен полностью сбрасывать RTK Query-кэш всех api-слайсов и
+ * slice-данные (profile/gallery/admin/...), чтобы данные предыдущего
+ * пользователя не "смешивались" со следующим при смене аккаунта.
+ *
+ * Но ТОЛЬКО когда до этого была активная сессия (authData) — authMiddleware
+ * дёргает logout() и на 401 у гостя (например, гостевой /profile), и полный
+ * сброс в этом случае обнулял бы кэш при активной подписке, роняя форму
+ * входа в вечный спиннер.
+ */
+describe("rootReducer — сброс стейта при logout", () => {
+    it("полностью сбрасывает кэш RTK Query при выходе из активной сессии", () => {
+        const store = setupStore();
+
+        // initAuthData поднимает _inited в true — так же, как при загрузке
+        // приложения с уже залогиненным пользователем.
+        store.dispatch(userActions.initAuthData());
+        store.dispatch(userActions.setAuthData({
+            username: "vol@test.com",
+            token: "fake-jwt",
+            mercureToken: "fake-mercure",
+            rememberMe: true,
+            roles: ["ROLE_USER"],
+        }));
+
+        // Данные другого слайса (не user) — чтобы отличить "полный сброс стора"
+        // от обычной работы userReducer.logout, который и сам чистит authData
+        // независимо от полного сброса (см. вторую проверку ниже).
+        store.dispatch(setRegisterUserData({ id: "prev-user-id", email: "prev@test.com" }));
+
+        expect(store.getState().user.authData).toBeDefined();
+        expect(store.getState().user._inited).toBe(true);
+        expect(store.getState().register.id).toBe("prev-user-id");
+
+        store.dispatch(userActions.logout());
+
+        const state = store.getState();
+        expect(state.user.authData).toBeUndefined();
+        // Ключевая проверка регресса (баг П27, "данные смешиваются"): данные
+        // предыдущего юзера из другого слайса реально стёрлись, а не только
+        // authData в user-слайсе.
+        expect(state.register.id).toBe("");
+        expect(state.register.email).toBe("");
+        // _inited должен сохраниться, а не сброситься к initial (иначе роутер
+        // ловит "Cannot assign to read only property" и падает белым экраном —
+        // см. комментарий в store.ts).
+        expect(state.user._inited).toBe(true);
+    });
+
+    it("не трогает кэш при logout без активной сессии (гостевой 401)", () => {
+        const store = setupStore();
+
+        const stateBefore = store.getState();
+
+        store.dispatch(userActions.logout());
+
+        const stateAfter = store.getState();
+
+        // Ключевая проверка регресса: без предварительной authData полный
+        // сброс стейта не должен происходить — только обычная работа
+        // userSlice-редьюсера (authData как был undefined, так и остался).
+        expect(stateAfter.user.authData).toBeUndefined();
+        expect(stateAfter.register).toBe(stateBefore.register);
+        expect(stateAfter.profile).toBe(stateBefore.profile);
+    });
+});

--- a/src/widgets/Footer/ui/Footer.test.tsx
+++ b/src/widgets/Footer/ui/Footer.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { Footer } from "./Footer";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ myProfile: null }),
+}));
+
+vi.mock("@/widgets/ChangeLanguage", () => ({
+    ChangeLanguage: () => null,
+}));
+
+/**
+ * Регресс-тест для PR gs-frontend#344 (v0.1.21): половина ссылок в футере
+ * вела на старый неактуальный сайт (community.goodsurfing.org). Заменены на
+ * внутренние роуты через хелперы из AppUrls.
+ */
+describe("Footer", () => {
+    it("ссылки блога/видео/амбассадоров/академии ведут на внутренние роуты, а не на community.goodsurfing.org", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <Footer />
+            </MemoryRouter>,
+        );
+
+        const allLinks = screen.getAllByRole("link").map((el) => el.getAttribute("href"));
+
+        const externalCommunityLinks = allLinks.filter(
+            (href) => href?.includes("community.goodsurfing.org"),
+        );
+        expect(externalCommunityLinks).toHaveLength(0);
+
+        expect(allLinks).toContain("/ru/blog");
+        expect(allLinks).toContain("/ru/video");
+    });
+});


### PR DESCRIPTION
## Что

Регресс-тесты на 4 закрытых пункта таблицы фиксов (все frontend, объединены в один PR):

- **row 105** — logout полностью сбрасывает RTK Query кэш при активной сессии (PR #342 + #346)
- **row 100** — ссылки в футере ведут на внутренние роуты, не на community.goodsurfing.org (PR #344)
- **row 99** — кнопка "Найти работу" → `category=13`, не `paid_work` (PR #349)
- **row 94** — картинка WhyMembership через бандл-импорт (PR #345)

Только тесты, продовый код не менялся.

## Проверено
Каждый тест — временный откат соответствующего фикса → тест падает → возврат → тест зелёный. Все 4 файла (5 тестов) зелёные вместе.

Linear: GS-68

## Test plan
- [ ] После мержа — деплой на стейдж прошёл
- [ ] `npx vitest run` зелёный в CI