### PR TITLE
test: покрыть пакет фиксов rows 89/87/85/84/83/82

### DIFF
--- a/src/pages/HostPersonalPage/ui/HostPersonalPage/stickyHeaderOffset.test.ts
+++ b/src/pages/HostPersonalPage/ui/HostPersonalPage/stickyHeaderOffset.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-тест для PR gs-frontend#348 (v0.1.25): фиксированная шапка меню
+ * наезжала на sticky-подменю при скролле на нескольких страницах.
+ * offer/host/volunteer-personal починили раньше (c2ce9312, 23.06), здесь
+ * докатили ещё 2 пропущенные страницы — HostPersonalPage (top 91px → 6.5rem)
+ * и DonationPersonalPage (content padding-top 36px → 92px).
+ */
+describe("Наложение шапки при скролле — sticky-офсеты", () => {
+    it("HostPersonalPage: .navMenu top = 6.5rem, а не старые 91px", () => {
+        const scss = readFileSync(
+            join(__dirname, "HostPersonalPage.module.scss"),
+            "utf-8",
+        );
+
+        const navMenuBlock = scss.match(/\.navMenu\s*{[^}]*}/)?.[0] ?? "";
+        expect(navMenuBlock).toMatch(/top:\s*6\.5rem/);
+        expect(navMenuBlock).not.toMatch(/top:\s*91px/);
+    });
+
+    it("DonationPersonalPage: .content padding-top = 92px, а не старые 36px", () => {
+        const scss = readFileSync(
+            join(
+                __dirname,
+                "../../../DonationPersonalPage/ui/DonationPersonalPage/DonationPersonalPage.module.scss",
+            ),
+            "utf-8",
+        );
+
+        const contentBlock = scss.match(/\.content\s*{[^}]*}/)?.[0] ?? "";
+        expect(contentBlock).toMatch(/padding:\s*92px/);
+        expect(contentBlock).not.toMatch(/padding:\s*36px/);
+    });
+});

--- a/src/pages/OfferPersonalPage/ui/OfferPersonalCard/OfferPersonalCard.tsx
+++ b/src/pages/OfferPersonalPage/ui/OfferPersonalCard/OfferPersonalCard.tsx
@@ -15,7 +15,7 @@ interface OfferPersonalCardProps {
     isVolunteer: boolean;
 }
 
-function galleryUrls(images: Image[]): string[] {
+export function galleryUrls(images: Image[]): string[] {
     return images.map((img) => img.thumbnails?.large
         ?? img.thumbnails?.medium
         ?? img.contentUrl).filter(Boolean) as string[];

--- a/src/pages/OfferPersonalPage/ui/OfferPersonalCard/galleryUrls.test.ts
+++ b/src/pages/OfferPersonalPage/ui/OfferPersonalCard/galleryUrls.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { galleryUrls } from "./OfferPersonalCard";
+import { Image } from "@/types/media";
+
+/**
+ * Регресс-тест для PR gs-frontend#337/#338 (коммит c2ce9312): галерея вакансии
+ * отдавала пустые/битые ссылки для старых (легаси) вакансий без thumbnails —
+ * нужен фолбэк large → medium → contentUrl.
+ */
+describe("galleryUrls", () => {
+    it("использует thumbnails.large, когда он есть", () => {
+        const image: Image = {
+            id: "1",
+            contentUrl: "https://cdn.example/original.jpg",
+            thumbnails: { large: "https://cdn.example/large.jpg", medium: "https://cdn.example/medium.jpg", small: "" },
+        };
+
+        expect(galleryUrls([image])).toEqual(["https://cdn.example/large.jpg"]);
+    });
+
+    it("падает на thumbnails.medium, если large отсутствует", () => {
+        // API в реальности иногда не отдаёт large для конкретного изображения,
+        // хотя тип объявляет поле обязательной строкой — имитируем это как на
+        // рантайме (нужен ?? , а не ||, отсюда и вылезла регрессия).
+        const image = {
+            id: "1",
+            contentUrl: "https://cdn.example/original.jpg",
+            thumbnails: { large: undefined, medium: "https://cdn.example/medium.jpg", small: "" },
+        } as unknown as Image;
+
+        expect(galleryUrls([image])).toEqual(["https://cdn.example/medium.jpg"]);
+    });
+
+    it("падает на contentUrl для легаси-вакансий без thumbnails", () => {
+        const image: Image = {
+            id: "1",
+            contentUrl: "https://cdn.example/legacy-original.jpg",
+        };
+
+        expect(galleryUrls([image])).toEqual(["https://cdn.example/legacy-original.jpg"]);
+    });
+
+    it("отфильтровывает изображения без вообще какого-либо валидного URL", () => {
+        const image: Image = { id: "1", contentUrl: "" };
+
+        expect(galleryUrls([image])).toEqual([]);
+    });
+});

--- a/src/shared/data/categories/useCategories.test.tsx
+++ b/src/shared/data/categories/useCategories.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCategories } from "./index";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key.replace("category-offer.", "") }),
+}));
+
+/**
+ * Регресс-тест для PR gs-frontend#350 (v0.1.27): в мёртвом коде-ловушке
+ * (массив tags) лейбл категории "Заповедники и нац. парки" был указан
+ * неверно как "Заповедники и парки" — расходился с реальным API. Живые
+ * страницы (/categories, /offers-map, карточки) уже показывали верный текст,
+ * но ловушка могла всплыть при будущем использовании tags/getTranslation.
+ */
+describe("useCategories", () => {
+    it('tags содержит правильный лейбл "Заповедники и нац. парки"', () => {
+        const { result } = renderHook(() => useCategories());
+
+        const reservesTag = result.current.tags.find((tag) => tag.value === "reserves_and_parks");
+        expect(reservesTag?.text).toBe("Заповедники и нац. парки");
+    });
+
+    it("getTranslation резолвит актуальный (API) лейбл категории верно", () => {
+        const { result } = renderHook(() => useCategories());
+
+        expect(result.current.getTranslation("Заповедники и нац. парки")).toBe("Заповедники и нац. парки");
+    });
+
+    it("getColorByCategory находит цвет по value, а не по устаревшему тексту", () => {
+        const { result } = renderHook(() => useCategories());
+
+        expect(result.current.getColorByCategory("reserves_and_parks")).toBe("#C3A3E9");
+    });
+});

--- a/src/widgets/CategoriesWidget/ui/Category/Category.test.tsx
+++ b/src/widgets/CategoriesWidget/ui/Category/Category.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { Category } from "./Category";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * Регресс-тест для PR gs-frontend#348 (v0.1.25): на /categories заголовки
+ * категорий переносились некорректно (были кракозябры вместо "не-" → "нес-")
+ * — в Category.module.scss был активен hyphens: auto без указания lang на
+ * элементе, из-за чего браузер не мог выбрать словарь переноса. Та же
+ * ошибка чинилась раньше в CategoryCard (PR #319), но здесь была пропущена.
+ */
+describe("Category", () => {
+    it("заголовок категории получает lang для корректного переноса", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <Category
+                    title="Заповедники и нац. парки"
+                    vacancyNumber={5}
+                    link="/offers-map?category=2"
+                    locale="ru"
+                />
+            </MemoryRouter>,
+        );
+
+        const title = screen.getByText("Заповедники и нац. парки");
+        expect(title).toHaveAttribute("lang", "ru");
+    });
+
+    it("SCSS больше не использует hyphens: auto без lang (регресс-ловушка)", () => {
+        const scssPath = join(__dirname, "Category.module.scss");
+        const scss = readFileSync(scssPath, "utf-8");
+
+        expect(scss).not.toMatch(/hyphens:\s*auto/);
+        expect(scss).toMatch(/word-break:\s*break-word/);
+    });
+});

--- a/src/widgets/OffersMap/ui/OffersList/OffersList.tsx
+++ b/src/widgets/OffersMap/ui/OffersList/OffersList.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { useLocale } from "@/app/providers/LocaleProvider";
 
 import { OfferApi } from "@/entities/Offer";
+import { getOfferImagePath } from "./getOfferImagePath";
 
 import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 import { Text } from "@/shared/ui/Text/Text";
@@ -84,7 +85,7 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
                         id: offer.id,
                         title: offer.title,
                         shortDescription: offer.shortDescription,
-                        imagePath: offer.image?.thumbnails?.medium ?? offer.image?.contentUrl,
+                        imagePath: getOfferImagePath(offer.image),
                         categories: offer.categories.map((cat) => cat.name),
                         address: offer.address,
                         acceptedApplicationsCount: offer.acceptedApplicationsCount,

--- a/src/widgets/OffersMap/ui/OffersList/getOfferImagePath.test.ts
+++ b/src/widgets/OffersMap/ui/OffersList/getOfferImagePath.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { getOfferImagePath } from "./getOfferImagePath";
+
+/**
+ * Регресс-тест для PR gs-frontend#337/#338 (коммит c2ce9312): картинки
+ * в списке /offers-map не отображались для старых (легаси) вакансий без
+ * thumbnails — нужен фолбэк на contentUrl оригинала.
+ */
+describe("getOfferImagePath", () => {
+    it("использует thumbnails.medium, когда он есть", () => {
+        const image = {
+            id: "1",
+            contentUrl: "https://cdn.example/original.jpg",
+            thumbnails: { large: "", medium: "https://cdn.example/medium.jpg", small: "" },
+        };
+
+        expect(getOfferImagePath(image)).toBe("https://cdn.example/medium.jpg");
+    });
+
+    it("падает на contentUrl для легаси-вакансий без thumbnails", () => {
+        const image = { id: "1", contentUrl: "https://cdn.example/legacy-original.jpg" };
+
+        expect(getOfferImagePath(image)).toBe("https://cdn.example/legacy-original.jpg");
+    });
+
+    it("возвращает undefined, если у вакансии вообще нет картинки", () => {
+        expect(getOfferImagePath(null)).toBeUndefined();
+        expect(getOfferImagePath(undefined)).toBeUndefined();
+    });
+});

--- a/src/widgets/OffersMap/ui/OffersList/getOfferImagePath.ts
+++ b/src/widgets/OffersMap/ui/OffersList/getOfferImagePath.ts
@@ -1,0 +1,10 @@
+import { Image } from "@/types/media";
+
+/**
+ * Картинка карточки вакансии в списке /offers-map: у старых вакансий (легаси)
+ * нет thumbnails, только contentUrl оригинала — используем его как fallback.
+ * Регресс-фикс PR gs-frontend#337/#338 (коммит c2ce9312).
+ */
+export function getOfferImagePath(image?: Image | null): string | undefined {
+    return image?.thumbnails?.medium ?? image?.contentUrl;
+}


### PR DESCRIPTION
## Что

Регресс-тесты на 6 закрытых пунктов таблицы фиксов (все frontend, один PR):

- **rows 85/84** — фолбэк-цепочка картинок для легаси-вакансий без thumbnails (PR #337/#338)
- **rows 82/83** — верный лейбл категории "Заповедники и нац. парки" (PR #350)
- **row 89** — lang-атрибут для корректного переноса заголовков категорий (PR #348)
- **row 87** — CSS-офсеты sticky-шапки на HostPersonalPage/DonationPersonalPage (PR #348)

Один небольшой рефакторинг: инлайн-логика фолбэка картинки в `OffersList` вынесена в отдельный экспортируемый хелпер `getOfferImagePath` для тестируемости — поведение не меняется.

## Проверено
Каждый тест — временный откат фикса → тест падает → возврат → тест зелёный. Все 5 файлов (14 тестов) зелёные вместе. `tsc --noEmit` чистый.

Linear: GS-69

## Test plan
- [ ] После мержа — деплой на стейдж прошёл
- [ ] `npx vitest run` зелёный в CI