### PR TITLE
test: регресс-тесты для rows 79/80/76/75 (навигация, страница успеха сбора, фото обложки)

### DIFF
--- a/src/pages/DonationPaySuccessPage/ui/DonationPaySuccessPage/DonationPaySuccessPage.test.tsx
+++ b/src/pages/DonationPaySuccessPage/ui/DonationPaySuccessPage/DonationPaySuccessPage.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import DonationPaySuccessPage from "./DonationPaySuccessPage";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+// MainPageLayout — общий каркас (шапка/футер), не предмет этого теста, а его
+// собственная шапка тянет за собой Auth/i18n-контекст. Мокаем, чтобы
+// проверять только контент карточки успеха.
+vi.mock("@/widgets/MainPageLayout", () => ({
+    MainPageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+/**
+ * Регресс-guard для row 76: страница успешной оплаты пожертвования — это
+ * отдельный компонент DonationPaySuccessPage (коммит f32865c7), НЕ
+ * переиспользующий членский PaymentSuccessPage. Раньше был баг, что после
+ * оплаты сбора показывался текст про членство — фиксируем корректный текст,
+ * чтобы при будущем рефакторинге компоненты снова случайно не схлопнули.
+ */
+describe("DonationPaySuccessPage", () => {
+    it("показывает текст про пожертвование, а не про членство", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <DonationPaySuccessPage />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText(/Спасибо за пожертвование/i)).toBeInTheDocument();
+        expect(screen.queryByText(/членств/i)).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx
+++ b/src/pages/FundraiseStepPage/ui/FundraiseStepPage.tsx
@@ -51,6 +51,8 @@ import Input from "@/shared/ui/Input/Input";
 import Switch from "@/shared/ui/Switch/Switch";
 import Textarea from "@/shared/ui/Textarea/Textarea";
 
+import { getMissingCoverImageToast } from "./getMissingCoverImageToast";
+
 import styles from "./FundraiseStepPage.module.scss";
 
 const FundraiseStepPage = () => {
@@ -402,14 +404,9 @@ const FundraiseStepPage = () => {
             return;
         }
 
-        if (!data.coverImage?.id) {
-            setToast({
-                text: t("hostFundraiseDescription.imageNotUploaded", {
-                    defaultValue: "Дождитесь загрузки фото обложки перед сохранением",
-                    ns: "host",
-                }),
-                type: HintType.Error,
-            });
+        const missingCoverImageToast = getMissingCoverImageToast(data.coverImage, t);
+        if (missingCoverImageToast) {
+            setToast(missingCoverImageToast);
             return;
         }
 
@@ -422,7 +419,7 @@ const FundraiseStepPage = () => {
                     name: data.title,
                     shortDescription: data.shortDescription,
                     description: data.fullDescription,
-                    imageId: data.coverImage.id,
+                    imageId: data.coverImage?.id as string,
                     galleryImageIds,
                     categoryIds: data.category,
                 },

--- a/src/pages/FundraiseStepPage/ui/getMissingCoverImageToast.test.ts
+++ b/src/pages/FundraiseStepPage/ui/getMissingCoverImageToast.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { HintType } from "@/shared/ui/HintPopup/HintPopup.interface";
+import { getMissingCoverImageToast } from "./getMissingCoverImageToast";
+
+const t = (key: string, opts?: Record<string, unknown>) => (opts?.defaultValue as string) ?? key;
+
+/**
+ * Регресс-guard для row 75: сохранение описания сбора раньше молча
+ * прерывалось (return без обратной связи), если фото обложки ещё не
+ * загрузилось — пользователь не понимал, почему "Сохранить" не работает.
+ */
+describe("getMissingCoverImageToast", () => {
+    it("возвращает тост с ошибкой, если coverImage не задан", () => {
+        const toast = getMissingCoverImageToast(undefined, t);
+
+        expect(toast).toEqual({
+            text: "Дождитесь загрузки фото обложки перед сохранением",
+            type: HintType.Error,
+        });
+    });
+
+    it("возвращает тост с ошибкой, если coverImage.id отсутствует", () => {
+        const toast = getMissingCoverImageToast({}, t);
+
+        expect(toast).toEqual({
+            text: "Дождитесь загрузки фото обложки перед сохранением",
+            type: HintType.Error,
+        });
+    });
+
+    it("возвращает null, если coverImage.id уже есть", () => {
+        const toast = getMissingCoverImageToast({ id: "cover-1" }, t);
+
+        expect(toast).toBeNull();
+    });
+});

--- a/src/pages/FundraiseStepPage/ui/getMissingCoverImageToast.ts
+++ b/src/pages/FundraiseStepPage/ui/getMissingCoverImageToast.ts
@@ -1,0 +1,26 @@
+import { HintType } from "@/shared/ui/HintPopup/HintPopup.interface";
+
+type TFunction = (key: string, opts?: Record<string, unknown>) => string;
+
+/**
+ * Регресс-фикс PR gs-frontend#349 (v0.1.26): onSubmitDescription молча
+ * выходил (return без обратной связи), если coverImage.id ещё не пришёл
+ * (фото грузится/не загрузилось) — пользователь жал "Сохранить", ничего не
+ * происходило. Теперь вместо тихого отказа — явный тост с ошибкой.
+ */
+export function getMissingCoverImageToast(
+    coverImage: { id?: string } | null | undefined,
+    t: TFunction,
+): { text: string; type: HintType } | null {
+    if (coverImage?.id) {
+        return null;
+    }
+
+    return {
+        text: t("hostFundraiseDescription.imageNotUploaded", {
+            defaultValue: "Дождитесь загрузки фото обложки перед сохранением",
+            ns: "host",
+        }),
+        type: HintType.Error,
+    };
+}

--- a/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.test.tsx
+++ b/src/widgets/MainHeader/MainHeaderNav/MainHeaderNav.test.tsx
@@ -1,0 +1,44 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { MainHeaderNav } from "./MainHeaderNav";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+/**
+ * Регресс-тест для rows 79/80 (навигация): пункты меню «Экспедиции» и
+ * «Международное волонтёрство» ведут на отдельные поддомены проекта
+ * (expedition.goodsurfing.org, international.goodsurfing.org).
+ */
+describe("MainHeaderNav", () => {
+    it("пункт меню \"Экспедиции\" ведёт на expedition.goodsurfing.org", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <MainHeaderNav />
+            </MemoryRouter>,
+        );
+
+        const link = screen.getByText("Экспедиции").closest("a");
+        expect(link).toHaveAttribute("href", "https://expedition.goodsurfing.org/");
+    });
+
+    it("пункт меню \"Международное волонтёрство\" ведёт на international.goodsurfing.org", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <MainHeaderNav />
+            </MemoryRouter>,
+        );
+
+        const link = screen.getByText("Международное волонтёрство").closest("a");
+        expect(link).toHaveAttribute("href", "https://international.goodsurfing.org/");
+    });
+});


### PR DESCRIPTION
## Что покрыто

- **rows 79/80**: пункты меню «Экспедиции» / «Международное волонтёрство» в `MainHeaderNav` ведут на `expedition.goodsurfing.org` / `international.goodsurfing.org`, а не были случайно схлопнуты в общий роут.
- **row 76**: `DonationPaySuccessPage` показывает текст про пожертвование, а не переиспользует членский текст успеха оплаты.
- **row 75**: `FundraiseStepPage.onSubmitDescription` раньше молча ничего не делал (return без обратной связи), если фото обложки сбора ещё не загрузилось. Вынес проверку в чистую функцию `getMissingCoverImageToast` (без изменения поведения) для тестируемости — теперь явно проверяется, что показывается тост с ошибкой.

Все тесты регресс-проверены: временно ломал каждый фикс, убеждался, что тест падает, восстанавливал — тест снова зелёный.

## Test plan

- [x] `getMissingCoverImageToast.test.ts` — 3 теста, проверен на регрессию
- [x] `MainHeaderNav.test.tsx` — 2 теста, проверен на регрессию
- [x] `DonationPaySuccessPage.test.tsx` — 1 тест, проверен на регрессию
- [x] `npx tsc --noEmit` чисто
- [x] `eslint` чисто
- [ ] Проверить на стенде после деплоя