### PR TITLE
test: регресс-тесты для rows 69/70 (бейджи вакансии: onlyVerified, receptionPlace)

### DIFF
--- a/src/entities/Offer/ui/OfferConditionsCard/OfferConditionsCard.test.tsx
+++ b/src/entities/Offer/ui/OfferConditionsCard/OfferConditionsCard.test.tsx
@@ -1,0 +1,53 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test-utils";
+import { OfferConditionsCard } from "./OfferConditionsCard";
+import { OfferFinishingTouches } from "../../model/types/offerFinishingTouches";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/features/OfferFinishingTouches/model/data/extraConditionsData", () => ({
+    useExtraConditionsData: () => ({ extraConditionsData: [] }),
+}));
+
+const baseFinishingTouches: OfferFinishingTouches = {
+    additionalConditions: [],
+    helloText: "",
+    roles: "",
+    questionnaireUrl: "",
+    questions: [],
+    onlyVerified: false,
+};
+
+/**
+ * Регресс-guard для row 69: бейдж «Принимать заявки только от проверенных
+ * участников» (finishingTouches.onlyVerified) раньше не выводился на
+ * публичной странице вакансии — блок скрывался целиком, если
+ * additionalConditions был пуст, даже при onlyVerified=true.
+ * Фикс: PR gs-frontend#349 (v0.1.26).
+ */
+describe("OfferConditionsCard", () => {
+    it("показывает бейдж onlyVerified, даже если additionalConditions пуст", () => {
+        renderWithProviders(
+            <OfferConditionsCard
+                finishingTouches={{ ...baseFinishingTouches, onlyVerified: true }}
+            />,
+        );
+
+        expect(
+            screen.getByText("finishingTouches.Принимать заявки только от проверенных участников"),
+        ).toBeInTheDocument();
+    });
+
+    it("не рендерит карточку, если additionalConditions пуст и onlyVerified=false", () => {
+        const { container } = renderWithProviders(
+            <OfferConditionsCard finishingTouches={baseFinishingTouches} />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/src/entities/Offer/ui/OfferWhoNeedsCard/OfferWhoNeedsCard.test.tsx
+++ b/src/entities/Offer/ui/OfferWhoNeedsCard/OfferWhoNeedsCard.test.tsx
@@ -1,0 +1,57 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test-utils";
+import { OfferWhoNeedsCard } from "./OfferWhoNeedsCard";
+import { OfferWhoNeeds } from "../../model/types/offerWhoNeeds";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const baseWhoNeeds: OfferWhoNeeds = {
+    genders: [],
+    ageMax: 99,
+    ageMin: 18,
+    needAllLanguages: false,
+    languages: [],
+    volunteerPlaceCount: 1,
+    receptionPlace: "any",
+    additionalInfo: "",
+};
+
+/**
+ * Регресс-guard для row 70: бейдж «только иностранцев» / «только из моей
+ * страны» (whoNeeds.receptionPlace) раньше не выводился на публичной
+ * странице вакансии волонтёру. Фикс: PR gs-frontend#349 (v0.1.26).
+ */
+describe("OfferWhoNeedsCard", () => {
+    it("показывает бейдж «Только иностранцев» при receptionPlace=foreigners", () => {
+        renderWithProviders(
+            <OfferWhoNeedsCard
+                whoNeeds={{ ...baseWhoNeeds, receptionPlace: "foreigners" }}
+            />,
+        );
+
+        expect(screen.getByText("whoNeeds.Только иностранцев")).toBeInTheDocument();
+    });
+
+    it("показывает бейдж «Только из моей страны» при receptionPlace=compatriot", () => {
+        renderWithProviders(
+            <OfferWhoNeedsCard
+                whoNeeds={{ ...baseWhoNeeds, receptionPlace: "compatriot" }}
+            />,
+        );
+
+        expect(screen.getByText("whoNeeds.Только из моей страны")).toBeInTheDocument();
+    });
+
+    it("не показывает бейдж при receptionPlace=any", () => {
+        renderWithProviders(
+            <OfferWhoNeedsCard whoNeeds={baseWhoNeeds} />,
+        );
+
+        expect(screen.queryByText(/whoNeeds\.Только/)).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Что покрыто

- **row 69**: `OfferConditionsCard` — бейдж «Принимать заявки только от проверенных участников» (`onlyVerified`) раньше не выводился, если `additionalConditions` был пуст (блок скрывался целиком).
- **row 70**: `OfferWhoNeedsCard` — бейдж «Только иностранцев» / «Только из моей страны» (`receptionPlace`) не выводился на публичной странице вакансии.

Оба фикса — часть исторического PR gs-frontend#349 (v0.1.26), уже задеплоенного на прод. Тесты регресс-проверены: временно откатывал каждый фикс, убеждался, что тест падает, восстанавливал — тест снова зелёный.

## Test plan

- [x] `OfferConditionsCard.test.tsx` — 2 теста, проверен на регрессию
- [x] `OfferWhoNeedsCard.test.tsx` — 3 теста, проверен на регрессию
- [x] `npx tsc --noEmit` чисто
- [x] `eslint` чисто
- [ ] Проверить на стенде после деплоя