### PR TITLE
test: регресс-тесты для rows 56/57/58/60/65/66 (профиль, навыки, отзывы, тип НКО)

### DIFF
--- a/src/entities/Admin/lib/adminAdapters.test.ts
+++ b/src/entities/Admin/lib/adminAdapters.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { AdminOrganization } from "../model/types/adminSchema";
+import { adminOrganizationAdapter } from "./adminAdapters";
+
+const baseOrganization: AdminOrganization = {
+    id: "1",
+    name: "Организация",
+    isActive: true,
+    address: "",
+    type: "НКО",
+    otherType: "",
+    image: null,
+    website: "",
+    description: "",
+    shortDescription: "",
+    vk: "",
+    facebook: "",
+    instagram: "",
+    telegram: "",
+    countVacancies: 0,
+    countApplications: 0,
+};
+
+/**
+ * Регресс-guard для row 66: тип организации «НКО» не был известен
+ * adminAdapters — в админке любая организация с type="НКО" сваливалась
+ * в "Другое". PR gs-frontend#330.
+ */
+describe("adminOrganizationAdapter", () => {
+    it("распознаёт тип организации «НКО», а не сваливает его в «Другое»", () => {
+        const result = adminOrganizationAdapter(baseOrganization);
+
+        expect(result.type?.organizationType).toBe("НКО");
+        expect(result.type?.otherOrganizationType).toBe("");
+    });
+});

--- a/src/features/HostDescription/lib/hostDescriptionAdapter.test.ts
+++ b/src/features/HostDescription/lib/hostDescriptionAdapter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { Host } from "@/entities/Host";
+import { hostDescriptionFormAdapter } from "./hostDescriptionAdapter";
+
+const baseHost: Host = {
+    id: "1",
+    name: "Организация",
+    active: true,
+    address: "",
+    type: "НКО",
+    otherType: "",
+    website: "",
+    description: "",
+    shortDescription: "",
+    vk: "",
+    facebook: "",
+    instagram: "",
+    telegram: "",
+    team: [],
+    vacancies: [],
+    owner: {} as Host["owner"],
+    videoGallery: [],
+    galleryImages: [],
+    feedbacksCount: 0,
+};
+
+/**
+ * Регресс-guard для row 66: тип организации «НКО» не был известен
+ * hostDescriptionAdapter — при чтении с бэка любая организация с
+ * type="НКО" сваливалась в "Другое". PR gs-frontend#330.
+ */
+describe("hostDescriptionFormAdapter", () => {
+    it("распознаёт тип организации «НКО», а не сваливает его в «Другое»", () => {
+        const result = hostDescriptionFormAdapter(baseHost);
+
+        expect(result.type?.organizationType).toBe("НКО");
+        expect(result.type?.otherOrganizationType).toBe("");
+    });
+});

--- a/src/features/ProfileInfo/ui/ProfileInfoForm/ProfileInfoForm.test.tsx
+++ b/src/features/ProfileInfo/ui/ProfileInfoForm/ProfileInfoForm.test.tsx
@@ -1,0 +1,88 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { Profile } from "@/entities/Profile";
+import { ProfileInfoForm } from "./ProfileInfoForm";
+
+const navigateMock = vi.fn();
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key: string, opts?: string | { defaultValue?: string }) => {
+            if (typeof opts === "string") {
+                return opts;
+            }
+            return opts?.defaultValue ?? key;
+        },
+    }),
+    initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual("react-router-dom");
+    return { ...actual, useNavigate: () => navigateMock };
+});
+
+const profile: Profile = {
+    id: "1",
+    email: "a@a.ru",
+    locale: "ru",
+    firstName: "Иван",
+    lastName: "Иванов",
+    gender: null,
+    birthDate: null,
+    country: null,
+    city: null,
+    phone: null,
+    image: null,
+    aboutMe: null,
+    vk: null,
+    facebook: null,
+    instagram: null,
+    telegram: null,
+    hostId: null,
+    volunteer: null,
+    videoGallery: [],
+    galleryImages: [],
+    favoriteCategories: [],
+    isActive: true,
+    isVerified: false,
+};
+
+/**
+ * Регресс-guard для rows 56/57: /profile/info раньше открывался в
+ * read-only режиме (нужно было нажать «Редактировать»), и не было кнопки
+ * перехода к следующему шагу («Дальше» → предпочтения). Фикс: PR
+ * gs-frontend#331.
+ */
+describe("ProfileInfoForm", () => {
+    it("row 56: форма открывается сразу в режиме редактирования", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <ProfileInfoForm profile={profile} />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByRole("button", { name: "info.Отмена" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "info.Сохранить" })).toBeEnabled();
+    });
+
+    it("row 57: кнопка «Дальше» ведёт к предпочтениям профиля", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <ProfileInfoForm profile={profile} />
+            </MemoryRouter>,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Дальше" }));
+
+        expect(navigateMock).toHaveBeenCalledWith(expect.stringContaining("preferences"));
+    });
+});

--- a/src/features/VolunteerSkills/ui/VolunteerLanguage/VolunteerLanguage.regression.test.ts
+++ b/src/features/VolunteerSkills/ui/VolunteerLanguage/VolunteerLanguage.regression.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 58: крестик удаления языка/навыка был слишком
+ * мелким и малоконтрастным (14px, text-secondary-2) — фикс увеличил его
+ * до 18px, сменил цвет на text-primary-2 и добавил hover-подсветку
+ * (error-color). PR gs-frontend#331.
+ */
+describe("VolunteerLanguage delete icon (SCSS regрess-guard)", () => {
+    it("крестик удаления остаётся крупным (18px) и не откатывается на старый цвет", () => {
+        const scssPath = join(__dirname, "VolunteerLanguage.module.scss");
+        const scss = readFileSync(scssPath, "utf-8");
+        const deleteIconBlock = scss.split(".deleteIcon")[1]?.split("}")[0] ?? "";
+
+        expect(deleteIconBlock).toMatch(/width:\s*18px/);
+        expect(deleteIconBlock).toMatch(/height:\s*18px/);
+        expect(deleteIconBlock).toMatch(/fill:\s*var\(--text-primary-2\)/);
+        expect(deleteIconBlock).toMatch(/&:hover/);
+    });
+});

--- a/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.regression.test.ts
+++ b/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.regression.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 65: у бейджа «member» на карточке волонтёра не
+ * было подсказки, что означает эта иконка. Фикс: обёрнут в MUI Tooltip с
+ * текстом «Верифицированный гудсёрфер». PR gs-frontend#331.
+ *
+ * Компонент слишком тяжёлый для полного рендер-теста (ProfileById,
+ * AchievementModal, медали и т.д.) — проверяем исходник, что Tooltip
+ * не потерялся при рефакторинге.
+ */
+describe("VolunteerHeaderCard member badge tooltip (source regress-guard)", () => {
+    it("иконка member обёрнута в Tooltip с текстом «Верифицированный гудсёрфер»", () => {
+        const tsxPath = join(__dirname, "VolunteerHeaderCard.tsx");
+        const source = readFileSync(tsxPath, "utf-8");
+
+        expect(source).toMatch(/import\s*{\s*Tooltip\s*}\s*from\s*"@mui\/material"/);
+
+        const memberIconBlock = source.split("alt=\"member\"")[0]?.slice(-400) ?? "";
+        expect(memberIconBlock).toMatch(/<Tooltip/);
+        expect(memberIconBlock).toMatch(/Верифицированный гудсёрфер/);
+    });
+});

--- a/src/shared/hooks/useGetTypeOrganization.test.tsx
+++ b/src/shared/hooks/useGetTypeOrganization.test.tsx
@@ -1,0 +1,28 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGetTypeOrganization } from "./useGetTypeOrganization";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * Регресс-guard для row 66: в форме создания/редактирования организации
+ * не было пункта «НКО» (union OrganizationType, список hostTypes,
+ * getTranslate). PR gs-frontend#330.
+ */
+describe("useGetTypeOrganization", () => {
+    it("список типов организации содержит «НКО»", () => {
+        const { result } = renderHook(() => useGetTypeOrganization());
+
+        expect(result.current.hostTypes.map((t) => t.value)).toContain("НКО");
+    });
+
+    it("getTranslate переводит «НКО», а не возвращает значение как есть по умолчанию", () => {
+        const { result } = renderHook(() => useGetTypeOrganization());
+
+        expect(result.current.getTranslate("НКО")).toBe("hostDescription.НКО");
+    });
+});

--- a/src/shared/ui/ModalReview/ModalReview.test.tsx
+++ b/src/shared/ui/ModalReview/ModalReview.test.tsx
@@ -1,0 +1,53 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test-utils";
+import { ModalReview } from "./ModalReview";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key: string, fallback?: string) => fallback ?? key,
+    }),
+}));
+
+/**
+ * Регресс-guard для row 60: было неочевидно, что отзыв сохраняется
+ * только при выставленных звёздах — кнопка «Оставить отзыв» просто не
+ * реагировала на клик без объяснения причины. Фикс: подсказка
+ * «Поставьте оценку, чтобы оставить отзыв» под текстовым полем, пока
+ * звёзды не выставлены. PR gs-frontend#331.
+ */
+describe("ModalReview", () => {
+    it("показывает подсказку про оценку, пока звёзды не выставлены", () => {
+        renderWithProviders(
+            <ModalReview
+                isOpen
+                onClose={() => {}}
+                titleText="Отзыв"
+                sendReview={() => {}}
+                value={{ stars: undefined, text: "" }}
+                onChange={() => {}}
+            />,
+        );
+
+        expect(screen.getByText("Поставьте оценку, чтобы оставить отзыв")).toBeInTheDocument();
+    });
+
+    it("не показывает подсказку, когда звёзды уже выставлены", () => {
+        renderWithProviders(
+            <ModalReview
+                isOpen
+                onClose={() => {}}
+                titleText="Отзыв"
+                sendReview={() => {}}
+                value={{ stars: 5, text: "" }}
+                onChange={() => {}}
+            />,
+        );
+
+        expect(
+            screen.queryByText("Поставьте оценку, чтобы оставить отзыв"),
+        ).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Что покрыто

- **rows 56/57** (PR gs-frontend#331): `ProfileInfoForm` — `/profile/info` теперь сразу открывается в режиме редактирования (без нужды жать «Редактировать») и есть кнопка «Дальше» к предпочтениям.
- **row 58** (PR gs-frontend#331): `VolunteerLanguage` — крестик удаления языка/навыка увеличен (14px→18px), контрастнее, hover-подсветка.
- **row 60** (PR gs-frontend#331): `ModalReview` — подсказка «Поставьте оценку, чтобы оставить отзыв», пока звёзды не выставлены.
- **row 65** (PR gs-frontend#331): `VolunteerHeaderCard` — бейдж «member» обёрнут в MUI Tooltip с текстом «Верифицированный гудсёрфер».
- **row 66** (PR gs-frontend#330): `hostDescriptionAdapter` / `adminAdapters` / `useGetTypeOrganization` — тип организации «НКО» теперь распознаётся, а не сваливается в «Другое».

Row 58/65 покрыты через source-guard тесты (SCSS/TSX регекс-проверки) — компоненты слишком тяжёлые для полного рендера (медали, аватары, ProfileById и т.д.), паттерн такой же, как раньше для `Category.test.tsx`/`stickyHeaderOffset.test.ts`.

Все тесты регресс-проверены: временно откатывал каждый фикс, убеждался, что тест падает, восстанавливал — тест снова зелёный.

## Test plan

- [x] 10 новых тестов в 7 файлах, все регресс-проверены
- [x] `npx tsc --noEmit` чисто
- [x] `eslint` чисто
- [ ] Проверить на стенде после деплоя