### PR TITLE
test: регресс-тесты для rows 54/50/49/46/41 (текст, чат, сбор, удаление вакансии)

### DIFF
--- a/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.test.tsx
+++ b/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.test.tsx
@@ -1,0 +1,73 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test-utils";
+import { DonationWhenCard } from "./DonationWhenCard";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const fmt = new Intl.NumberFormat("ru-RU");
+
+const getProgressTextNode = () => screen.getByText(
+    (content, node) => node?.className === "text" && content.includes("₽"),
+);
+
+/**
+ * Регресс-guard для row 46: на странице сбора не отображалось, сколько
+ * средств уже собрано. Причина: GetDonation не содержал collectedAmount
+ * — сумма вычислялась из amount*percent, а при amount=null (цель не
+ * задана) прогресс не показывался вообще. Фикс: collectedAmount берётся
+ * напрямую из API, прогресс показывается при collectedAmount > 0 даже
+ * без целевой суммы.
+ */
+describe("DonationWhenCard", () => {
+    it("показывает собранную сумму, даже если целевая сумма (amount) не задана", () => {
+        renderWithProviders(
+            <DonationWhenCard
+                dateStart="2026-01-01"
+                daysLeft={10}
+                percentAmountCollect={null}
+                collectedAmount={5000}
+                amount={null}
+                isSuccess={false}
+            />,
+        );
+
+        expect(getProgressTextNode().textContent).toBe(`${fmt.format(5000)} ₽`);
+    });
+
+    it("показывает прогресс «собрано / цель (%)», когда целевая сумма задана", () => {
+        renderWithProviders(
+            <DonationWhenCard
+                dateStart="2026-01-01"
+                daysLeft={10}
+                percentAmountCollect={50}
+                collectedAmount={7500}
+                amount={10000}
+                isSuccess={false}
+            />,
+        );
+
+        expect(getProgressTextNode().textContent).toBe(
+            `${fmt.format(7500)} ₽ / ${fmt.format(10000)} ₽ (50%)`,
+        );
+    });
+
+    it("не показывает блок прогресса, если ничего не собрано и цель не задана", () => {
+        renderWithProviders(
+            <DonationWhenCard
+                dateStart="2026-01-01"
+                daysLeft={10}
+                percentAmountCollect={null}
+                collectedAmount={0}
+                amount={null}
+                isSuccess={false}
+            />,
+        );
+
+        expect(screen.queryByText("donationPersonal.Средств собрано")).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/HostOffersPage/ui/HostOffersPage/HostOffersPage.regression.test.ts
+++ b/src/pages/HostOffersPage/ui/HostOffersPage/HostOffersPage.regression.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 41: сообщение об ошибке удаления вакансии не
+ * объясняло причину («Вакансию удалить нельзя»), и старая ошибка не
+ * сбрасывалась при повторной попытке удалить другую вакансию. Фикс:
+ * внятный текст «Нельзя удалить вакансию, по которой есть заявки» +
+ * setDeleteOfferError(false) в начале handleDeleteClick.
+ *
+ * Страница слишком тяжёлая для полного рендер-теста (4 RTK Query хука,
+ * пагинация, список офферов) — проверяем исходник и переводы.
+ */
+describe("HostOffersPage delete error (regress-guard)", () => {
+    it("текст ошибки объясняет причину, а не просто 'нельзя'", () => {
+        const ruHost = JSON.parse(
+            readFileSync(join(__dirname, "../../../../../public/locales/ru/host.json"), "utf-8"),
+        );
+
+        expect(ruHost.hostOffers["Вакансию удалить нельзя"]).toBe(
+            "Нельзя удалить вакансию, по которой есть заявки",
+        );
+    });
+
+    it("handleDeleteClick сбрасывает предыдущую ошибку перед выбором новой вакансии", () => {
+        const source = readFileSync(join(__dirname, "HostOffersPage.tsx"), "utf-8");
+        const handler = source.split("const handleDeleteClick")[1]?.split("};")[0] ?? "";
+
+        expect(handler).toMatch(/setDeleteOfferError\(false\)/);
+    });
+});

--- a/src/widgets/BenefitsContainer/ui/BenefitsContainer/Benefits.data.test.tsx
+++ b/src/widgets/BenefitsContainer/ui/BenefitsContainer/Benefits.data.test.tsx
@@ -1,0 +1,24 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useBenefitsData } from "./Benefits.data";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * Регресс-guard для row 54: первый пункт «Наши преимущества» на главной
+ * назывался «Бесплатно» (устаревший, вводящий в заблуждение текст —
+ * членство на GoodSurfing платное). Заменён на «Прямой контакт».
+ * PR gs-frontend#331.
+ */
+describe("useBenefitsData", () => {
+    it("первый пункт называется «Прямой контакт», а не «Бесплатно»", () => {
+        const { result } = renderHook(() => useBenefitsData());
+
+        expect(result.current[0].title).toBe("Прямой контакт");
+        expect(result.current.map((b) => b.title)).not.toContain("Бесплатно");
+    });
+});

--- a/src/widgets/Messenger/ui/Chat/Chat.tsx
+++ b/src/widgets/Messenger/ui/Chat/Chat.tsx
@@ -40,6 +40,7 @@ import {
 import { Modal } from "@/shared/ui/Modal/Modal";
 
 import { applicationOfferAdapter } from "../../lib/applicationOfferAdapter";
+import { getEffectiveCompanion } from "./getEffectiveCompanion";
 import { ChatFormFields } from "../../model/types/chatForm";
 import { Message } from "../Message/Message";
 import { SendMessage } from "../SendMessage/SendMessage";
@@ -202,7 +203,7 @@ export const Chat: FC<ChatProps> = (props) => {
         const processMessages = async () => {
             let currentDate = "";
             const today = new Date().toDateString();
-            const effectiveCompanion = companionData ?? chatData?.otherParticipants?.[0];
+            const effectiveCompanion = getEffectiveCompanion(companionData, chatData);
 
             const elements = await Promise.all(
                 messages.map(async (message) => {
@@ -457,8 +458,8 @@ export const Chat: FC<ChatProps> = (props) => {
                         />
                         <span className={styles.userName}>
                             {getFullName(
-                                (companionData ?? chatData?.otherParticipants?.[0])?.firstName,
-                                (companionData ?? chatData?.otherParticipants?.[0])?.lastName,
+                                getEffectiveCompanion(companionData, chatData)?.firstName,
+                                getEffectiveCompanion(companionData, chatData)?.lastName,
                             )}
                         </span>
                     </div>

--- a/src/widgets/Messenger/ui/Chat/getEffectiveCompanion.test.ts
+++ b/src/widgets/Messenger/ui/Chat/getEffectiveCompanion.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { ChatType } from "@/entities/Messenger";
+import { ProfileById } from "@/entities/Profile";
+import { getEffectiveCompanion } from "./getEffectiveCompanion";
+
+const chatData = {
+    otherParticipants: [{ id: "1", firstName: "Иван", lastName: "Иванов" }],
+} as unknown as ChatType;
+
+const companionData = {
+    id: "1",
+    firstName: "Пётр",
+    lastName: "Петров",
+} as unknown as ProfileById;
+
+/**
+ * Регресс-guard для rows 49/50: до загрузки companionData (отдельный
+ * ленивый запрос) в чате показывалось «Анонимный пользователь» и не было
+ * аватара. Фикс: chatData.otherParticipants[0] используется как фолбэк.
+ * PR gs-frontend#321.
+ */
+describe("getEffectiveCompanion", () => {
+    it("возвращает companionData, когда он уже загружен", () => {
+        expect(getEffectiveCompanion(companionData, chatData)).toBe(companionData);
+    });
+
+    it("падает обратно на chatData.otherParticipants[0], пока companionData не загружен", () => {
+        expect(getEffectiveCompanion(undefined, chatData)).toBe(chatData.otherParticipants[0]);
+    });
+
+    it("возвращает undefined, если нет ни companionData, ни chatData", () => {
+        expect(getEffectiveCompanion(undefined, undefined)).toBeUndefined();
+    });
+});

--- a/src/widgets/Messenger/ui/Chat/getEffectiveCompanion.ts
+++ b/src/widgets/Messenger/ui/Chat/getEffectiveCompanion.ts
@@ -1,0 +1,9 @@
+import { Profile, ProfileById } from "@/entities/Profile";
+import { ChatType } from "@/entities/Messenger";
+
+export function getEffectiveCompanion(
+    companionData: ProfileById | undefined,
+    chatData: ChatType | undefined,
+): ProfileById | Profile | undefined {
+    return companionData ?? chatData?.otherParticipants?.[0];
+}


### PR DESCRIPTION
## Что покрыто

- **row 54**: `useBenefitsData` — первый пункт «Наши преимущества» назывался «Бесплатно» (устаревший текст, вводящий в заблуждение — членство платное), заменён на «Прямой контакт».
- **rows 49/50**: `Chat` — до загрузки `companionData` (отдельный ленивый запрос) показывалось «Анонимный пользователь» без аватара. Вынес фолбэк-логику (`companionData ?? chatData?.otherParticipants?.[0]`) в чистую функцию `getEffectiveCompanion` — `Chat.tsx` слишком тяжёлый для полного рендер-теста (517 строк, сокеты, RTK Query).
- **row 46**: `DonationWhenCard` — на странице сбора не отображалось, сколько средств собрано, если целевая сумма (`amount`) не задана.
- **row 41**: `HostOffersPage` — сообщение об ошибке удаления вакансии не объясняло причину («Вакансию удалить нельзя» → «Нельзя удалить вакансию, по которой есть заявки»), и старая ошибка не сбрасывалась при повторной попытке. Покрыто source-guard тестом (страница слишком тяжёлая: 4 RTK Query хука).

Все тесты регресс-проверены: временно откатывал каждый фикс, убеждался, что тест падает, восстанавливал — тест снова зелёный.

## Test plan

- [x] 9 новых тестов в 4 файлах, все регресс-проверены
- [x] `npx tsc --noEmit` чисто
- [x] `eslint` чисто
- [ ] Проверить на стенде после деплоя