### PR TITLE
test: регресс-тест для row 36 (реальная ошибка при смене пароля)

### DIFF
--- a/src/shared/lib/getErrorText.test.ts
+++ b/src/shared/lib/getErrorText.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { getErrorText } from "./getErrorText";
+
+/**
+ * Регресс-guard для row 36: при входе через ВК страница смены пароля
+ * выдавала заглушку «Произошла ошибка» вместо реальной причины (пароль
+ * короче 6 символов и т.п.). Фикс: getErrorText научился разбирать
+ * формат валидационных ошибок { errors: [...] } от бэкенда.
+ * PR gs-frontend#320.
+ */
+describe("getErrorText", () => {
+    it("извлекает текст из формата валидационных ошибок { errors: [...] }", () => {
+        const error = { data: { errors: ["Пароль слишком короткий"] } };
+
+        expect(getErrorText(error)).toBe("Пароль слишком короткий");
+    });
+
+    it("объединяет несколько ошибок через точку с пробелом", () => {
+        const error = { data: { errors: ["Ошибка 1", "Ошибка 2"] } };
+
+        expect(getErrorText(error)).toBe("Ошибка 1. Ошибка 2");
+    });
+
+    it("не подменяет заглушкой «Произошла ошибка», когда есть errors", () => {
+        const error = { data: { errors: ["Пароль слишком короткий"] } };
+
+        expect(getErrorText(error)).not.toBe("Произошла неизвестная ошибка.");
+    });
+});


### PR DESCRIPTION
## Что покрыто

`getErrorText` молча заменял валидационные ошибки бэка (формат `{ errors: [...] }`) на заглушку «Произошла неизвестная ошибка» — при входе через ВК страница смены пароля не объясняла, почему запрос отклонён (например, пароль короче 6 символов). Фикс (PR gs-frontend#320): `getErrorText` разбирает формат `{ errors: [...] }`.

Регресс-проверено: временно убирал ветку `errors` из `getErrorText`, все 3 теста падали (в т.ч. воспроизводили заглушку «Произошла неизвестная ошибка»), восстановил — снова зелёные.

## Test plan

- [x] `getErrorText.test.ts` — 3 теста, регресс-проверены
- [x] `npx tsc --noEmit` чисто
- [x] `eslint` чисто
- [ ] Проверить на стенде после деплоя