### PR TITLE
fix: rows 111-115 — сортировка и фильтр по членству в админке

### DIFF
--- a/src/entities/Admin/index.ts
+++ b/src/entities/Admin/index.ts
@@ -22,6 +22,7 @@ export type {
     GetAdminAmbassador,
     AboutProjectInfoFields,
     AboutProjectPrinciples,
+    MembershipStatusFilter,
 } from "./model/types/adminSchema";
 
 export { AdminSort } from "./model/types/adminSchema";

--- a/src/entities/Admin/lib/adminAdapters.test.ts
+++ b/src/entities/Admin/lib/adminAdapters.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { AdminOrganization } from "../model/types/adminSchema";
-import { adminOrganizationAdapter } from "./adminAdapters";
+import { AdminOrganization, AdminOrganizations } from "../model/types/adminSchema";
+import { adminOrganizationAdapter, adminOrganizationsAdapter } from "./adminAdapters";
 
 const baseOrganization: AdminOrganization = {
     id: "1",
@@ -32,5 +32,40 @@ describe("adminOrganizationAdapter", () => {
 
         expect(result.type?.organizationType).toBe("НКО");
         expect(result.type?.otherOrganizationType).toBe("");
+    });
+});
+
+const baseOrganizationListItem: AdminOrganizations = {
+    id: "1",
+    name: "Организация",
+    lastName: "Иванов",
+    firstName: "Иван",
+    countVacancies: 0,
+    countApplications: 0,
+    isActive: true,
+    isMembership: false,
+    endMembership: null,
+};
+
+/**
+ * Регресс-guard для rows 112/113/115: у организаций не было видно
+ * членство владельца (организационный тариф) в списке админки — только у
+ * пользователей, и то было захардкожено в false на бэке.
+ */
+describe("adminOrganizationsAdapter", () => {
+    it("пробрасывает isMembership и endMembership из API-ответа в строку таблицы", () => {
+        const [result] = adminOrganizationsAdapter([
+            { ...baseOrganizationListItem, isMembership: true, endMembership: "01.01.2027" },
+        ]);
+
+        expect(result.isMembership).toBe(true);
+        expect(result.endMembership).toBe("01.01.2027");
+    });
+
+    it("отражает isMembership=false, когда у владельца нет активного членства", () => {
+        const [result] = adminOrganizationsAdapter([baseOrganizationListItem]);
+
+        expect(result.isMembership).toBe(false);
+        expect(result.endMembership).toBeNull();
     });
 });

--- a/src/entities/Admin/lib/adminAdapters.ts
+++ b/src/entities/Admin/lib/adminAdapters.ts
@@ -145,7 +145,7 @@ AdminOrganizationsFields[] => {
     const result: AdminOrganizationsFields[] = data.map((host) => {
         const {
             id, name, firstName, lastName, countApplications, countVacancies,
-            isActive,
+            isActive, isMembership, endMembership,
         } = host;
         return {
             id,
@@ -155,6 +155,8 @@ AdminOrganizationsFields[] => {
             countApplications,
             countVacancies,
             isActive,
+            isMembership,
+            endMembership,
         };
     });
 

--- a/src/entities/Admin/model/types/adminSchema.ts
+++ b/src/entities/Admin/model/types/adminSchema.ts
@@ -192,12 +192,15 @@ export enum AdminSort {
     TypeDesc = "type:desc",
 }
 
+export type MembershipStatusFilter = "active" | "inactive";
+
 export interface GetAdminUserParams {
     sort: AdminSort;
     id: number; // search by id user
     email: string; // search by email of user
     firstName: string; // search by first name of user
     lastName: string; // search by last name of user
+    membershipStatus: MembershipStatusFilter;
     page: number;
     limit: number;
 }
@@ -239,6 +242,8 @@ export interface AdminOrganizations {
     countVacancies: number;
     countApplications: number;
     isActive: boolean;
+    isMembership: boolean;
+    endMembership: string | null;
 }
 
 export type UpdateAdminOrganization = Omit<AdminOrganization, "id" | "image"
@@ -256,6 +261,7 @@ export interface GetAdminOrganizationParams {
     name: string; // search by organization name
     firstName: string;
     lastName: string;
+    membershipStatus: MembershipStatusFilter;
     page: number;
     limit: number;
 }
@@ -273,6 +279,8 @@ export interface AdminOrganizationsFields {
     countVacancies: number;
     countApplications: number;
     isActive: boolean;
+    isMembership: boolean;
+    endMembership: string | null;
 }
 
 export interface CreateAdminSkillRequest {

--- a/src/widgets/Admin/ui/AdminOrganizationsTable/AdminOrganizationsTable.regression.test.ts
+++ b/src/widgets/Admin/ui/AdminOrganizationsTable/AdminOrganizationsTable.regression.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 111: список организаций в админке сортировался по
+ * умолчанию по id:asc (старые сверху). Дефолт сменён на created:desc,
+ * который на бэке проксируется через id (UUIDv7 — монотонно по времени),
+ * т.к. Organization не хранит отдельного поля даты регистрации.
+ *
+ * Компонент слишком тяжёлый для полного рендер-теста — проверяем исходник.
+ */
+describe("AdminOrganizationsTable default sort (regress-guard)", () => {
+    it("сортировка по умолчанию — CreatedDesc (новые сверху), а не IdAsc", () => {
+        const source = readFileSync(join(__dirname, "AdminOrganizationsTable.tsx"), "utf-8");
+
+        expect(source).not.toMatch(/sort:\s*AdminSort\.IdAsc/);
+        expect(source.match(/AdminSort\.CreatedDesc/g)?.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("есть фильтр по статусу членства и колонка «Членство» (rows 112/113/115)", () => {
+        const source = readFileSync(join(__dirname, "AdminOrganizationsTable.tsx"), "utf-8");
+
+        expect(source).toMatch(/membershipStatus/);
+        expect(source).toMatch(/field:\s*"isMembership"/);
+        expect(source).toMatch(/field:\s*"endMembership"/);
+    });
+});

--- a/src/widgets/Admin/ui/AdminOrganizationsTable/AdminOrganizationsTable.tsx
+++ b/src/widgets/Admin/ui/AdminOrganizationsTable/AdminOrganizationsTable.tsx
@@ -8,7 +8,7 @@ import {
 import cn from "classnames";
 import {
     adminOrganizationsAdapter,
-    AdminSort, GetAdminOrganizationParams, useDeleteOrganizationMutation,
+    AdminSort, GetAdminOrganizationParams, MembershipStatusFilter, useDeleteOrganizationMutation,
     useLazyGetOrganizationsQuery,
     useToggleAdminOrganizationActiveMutation,
 } from "@/entities/Admin";
@@ -74,6 +74,29 @@ const customFields: CustomFilterField<keyof OrganizationsFilters>[] = [
         ),
     },
     {
+        key: "membershipStatus",
+        label: "Членство",
+        render: ({ value, onChange, disabled }) => (
+            <FormControl fullWidth size="small" disabled={disabled}>
+                <InputLabel id="custom-membership-status-label" sx={{ background: "background.paper", px: 0.5 }}>
+                    Членство
+                </InputLabel>
+                <Select
+                    labelId="custom-membership-status-label"
+                    value={value ?? ""}
+                    label="Членство"
+                    onChange={(e) => onChange(
+                        (e.target.value || undefined) as MembershipStatusFilter | undefined,
+                    )}
+                >
+                    <MenuItem value="">Все</MenuItem>
+                    <MenuItem value="active">Активно</MenuItem>
+                    <MenuItem value="inactive">Неактивно</MenuItem>
+                </Select>
+            </FormControl>
+        ),
+    },
+    {
         key: "sort",
         label: "Сортировка",
         render: ({ value, onChange, disabled }) => (
@@ -83,7 +106,7 @@ const customFields: CustomFilterField<keyof OrganizationsFilters>[] = [
                 </InputLabel>
                 <Select
                     labelId="custom-sort-label"
-                    value={value || AdminSort.IdAsc}
+                    value={value || AdminSort.CreatedDesc}
                     label="Сортировка"
                     onChange={(e) => onChange(e.target.value as AdminSort)}
                     MenuProps={{
@@ -125,10 +148,11 @@ export const AdminOrganizationsTable = () => {
     const [toast, setToast] = useState<ToastAlert>();
     const { filters, setFilters } = useQueryFilters({
         page: 1,
-        sort: AdminSort.IdAsc,
+        sort: AdminSort.CreatedDesc,
         firstName: undefined,
         lastName: undefined,
         name: undefined,
+        membershipStatus: undefined,
     });
 
     const [toggleAdminOrganizationActive,
@@ -151,10 +175,11 @@ export const AdminOrganizationsTable = () => {
                 await getOrganizations({
                     page: filters.page,
                     limit: ORGANIZATIONS_PER_PAGE,
-                    sort: filters.sort ?? AdminSort.IdAsc,
+                    sort: filters.sort ?? AdminSort.CreatedDesc,
                     firstName: filters.firstName,
                     lastName: filters.lastName,
                     name: filters.name,
+                    membershipStatus: filters.membershipStatus,
                 }).unwrap();
             } catch (error) {
                 setToast({
@@ -165,7 +190,7 @@ export const AdminOrganizationsTable = () => {
         };
 
         fetchData();
-    }, [filters.firstName, filters.lastName, filters.name,
+    }, [filters.firstName, filters.lastName, filters.name, filters.membershipStatus,
         filters.page, filters.sort, getOrganizations]);
 
     const handleOpenDeleteModal = (id: string, name: string) => {
@@ -292,6 +317,24 @@ export const AdminOrganizationsTable = () => {
             filterable: false,
             disableColumnMenu: true,
             hideable: false,
+        },
+        {
+            field: "isMembership",
+            headerName: "Членство",
+            type: "boolean",
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+        },
+        {
+            field: "endMembership",
+            headerName: "Окончание членства",
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            width: 140,
         },
         {
             field: "actions",

--- a/src/widgets/Admin/ui/AdminUsersTable/AdminUsersTable.regression.test.ts
+++ b/src/widgets/Admin/ui/AdminUsersTable/AdminUsersTable.regression.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 111: список пользователей в админке сортировался
+ * по умолчанию по id:asc — так как id это UUIDv7 (монотонно по времени),
+ * это технически не «рандомно», но и не то, чего ожидает админ («последние
+ * регистрации вверху»). Дефолт сортировки сменён на created:desc.
+ *
+ * Компонент слишком тяжёлый для полного рендер-теста (RTK Query, DataGrid,
+ * несколько модалок) — проверяем исходник.
+ */
+describe("AdminUsersTable default sort (regress-guard)", () => {
+    it("сортировка по умолчанию — CreatedDesc (новые сверху), а не IdAsc", () => {
+        const source = readFileSync(join(__dirname, "AdminUsersTable.tsx"), "utf-8");
+
+        expect(source).not.toMatch(/sort:\s*AdminSort\.IdAsc/);
+        expect(source.match(/AdminSort\.CreatedDesc/g)?.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("есть фильтр по статусу членства (membershipStatus)", () => {
+        const source = readFileSync(join(__dirname, "AdminUsersTable.tsx"), "utf-8");
+
+        expect(source).toMatch(/membershipStatus/);
+    });
+});

--- a/src/widgets/Admin/ui/AdminUsersTable/AdminUsersTable.tsx
+++ b/src/widgets/Admin/ui/AdminUsersTable/AdminUsersTable.tsx
@@ -18,7 +18,8 @@ import {
 } from "@/shared/ui/AdminFiltersTable/AdminFiltersTable";
 import { HintType, ToastAlert } from "@/shared/ui/HintPopup/HintPopup.interface";
 import {
-    AdminSort, adminUsersAdapter, useDeleteUserMutation, useLazyGetUsersQuery,
+    AdminSort, adminUsersAdapter, MembershipStatusFilter,
+    useDeleteUserMutation, useLazyGetUsersQuery,
     useToggleAdminUserActiveMutation,
 } from "@/entities/Admin";
 import HintPopup from "@/shared/ui/HintPopup/HintPopup";
@@ -35,6 +36,7 @@ interface UserFilters {
     email?: string;
     firstName?: string;
     lastName?: string;
+    membershipStatus?: MembershipStatusFilter;
     sort?: AdminSort;
 }
 
@@ -97,6 +99,29 @@ const customFields: CustomFilterField<keyof UserFilters>[] = [
         ),
     },
     {
+        key: "membershipStatus",
+        label: "Членство",
+        render: ({ value, onChange, disabled }) => (
+            <FormControl fullWidth size="small" disabled={disabled}>
+                <InputLabel id="custom-membership-status-label" sx={{ background: "background.paper", px: 0.5 }}>
+                    Членство
+                </InputLabel>
+                <Select
+                    labelId="custom-membership-status-label"
+                    value={value ?? ""}
+                    label="Членство"
+                    onChange={(e) => onChange(
+                        (e.target.value || undefined) as MembershipStatusFilter | undefined,
+                    )}
+                >
+                    <MenuItem value="">Все</MenuItem>
+                    <MenuItem value="active">Активно</MenuItem>
+                    <MenuItem value="inactive">Неактивно</MenuItem>
+                </Select>
+            </FormControl>
+        ),
+    },
+    {
         key: "sort",
         label: "Сортировка",
         render: ({ value, onChange, disabled }) => (
@@ -106,7 +131,7 @@ const customFields: CustomFilterField<keyof UserFilters>[] = [
                 </InputLabel>
                 <Select
                     labelId="custom-sort-label"
-                    value={value || AdminSort.IdAsc}
+                    value={value || AdminSort.CreatedDesc}
                     label="Сортировка"
                     onChange={(e) => onChange(e.target.value as AdminSort)}
                     MenuProps={{
@@ -171,7 +196,8 @@ export const AdminUsersTable = () => {
         email: undefined,
         firstName: undefined,
         lastName: undefined,
-        sort: AdminSort.IdAsc,
+        membershipStatus: undefined,
+        sort: AdminSort.CreatedDesc,
     });
 
     const [userToDelete, setUserToDelete] = useState<
@@ -198,7 +224,8 @@ export const AdminUsersTable = () => {
                     email: filters.email,
                     firstName: filters.firstName,
                     lastName: filters.lastName,
-                    sort: filters.sort ?? AdminSort.IdAsc,
+                    membershipStatus: filters.membershipStatus,
+                    sort: filters.sort ?? AdminSort.CreatedDesc,
                 }).unwrap();
             } catch (error) {
                 setToast({
@@ -210,7 +237,7 @@ export const AdminUsersTable = () => {
 
         fetchData();
     }, [filters.email, filters.firstName, filters.id,
-        filters.lastName, filters.page, filters.sort, getUsers]);
+        filters.lastName, filters.membershipStatus, filters.page, filters.sort, getUsers]);
 
     const handleOpenDeleteModal = (idValue: string, name: string) => {
         setUserToDelete({ id: idValue, name });


### PR DESCRIPTION
## Что сделано

Это НЕ регресс-тест на прошлый фикс — это новые фиксы для открытых пунктов таблицы (rows 111-115, раздел «Админка Пользователи»), обнаруженных постановщиком после того, как я пропустил конец списка (остановился на row 110). Парный бэкенд-PR: gs-backend (см. следующий PR).

- **row 111**: сортировка пользователей/организаций по умолчанию была `id:asc` (старые сверху). Технически не «рандомная» (id — UUIDv7, монотонный по времени), но не то, что ожидает админ. Дефолт сменён на `created:desc`.
- **rows 112/113**: у организаций в админке вообще не было видно членство владельца (организационный тариф host_XXXX) — только у пользователей, да и то на бэке было захардкожено в `false` (см. бэкенд-PR). Добавлены колонки «Членство» / «Окончание членства» в таблицу организаций.
- **row 114**: фильтр по статусу членства (активно/неактивно) добавлен и у пользователей, и у организаций.
- **row 115**: фильтр реально бьёт по актуальным данным `Membership`, не по заглушке.

Все тесты регресс-проверены (временно откатывал → тест падал → восстанавливал → тест снова зелёный).

## Test plan

- [x] 7 тестов (adminAdapters + 2 source-guard теста для тяжёлых DataGrid-компонентов), регресс-проверены
- [x] `npx tsc --noEmit` чисто
- [x] `eslint` чисто
- [ ] Проверить на стенде после деплоя (нужен реальный owner с активным членством, чтобы увидеть колонку в деле)