### PR TITLE
fix: непрочитанные чаты моргают и пропадают из списка (row 116)

### DIFF
--- a/src/entities/Chat/lib/useGetChatListData.test.tsx
+++ b/src/entities/Chat/lib/useGetChatListData.test.tsx
@@ -1,0 +1,84 @@
+import {
+    describe, it, expect, vi, beforeEach, afterEach,
+} from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useGetChatListData } from "./useGetChatListData";
+import { MessageType } from "@/entities/Messenger";
+
+/**
+ * Регресс-guard для row 116: непрочитанные чаты "моргали" и пропадали из
+ * видимой области списка при активной переписке. Причина — на КАЖДОЕ
+ * сообщение (в любом чате) дергался полный сетевой fetchChats() +
+ * пересортировка всего списка, вместо точечного обновления.
+ * applyIncomingMessage обновляет состояние локально, без сети.
+ */
+describe("useGetChatListData.applyIncomingMessage", () => {
+    const initialChats = [
+        { id: 1, lastMessage: undefined, otherParticipants: [], countUnreadMessages: 0 },
+        {
+            id: 2,
+            lastMessage: {
+                id: 1,
+                text: "привет",
+                attachments: [],
+                createdAt: "2026-07-01T10:00:00Z",
+                chat: "https://api.goodsurfing.org/api/v1/chats/2",
+                readByUserIds: [],
+                author: { id: "user-1" },
+            },
+            otherParticipants: [],
+            countUnreadMessages: 3,
+        },
+    ];
+
+    beforeEach(() => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            json: () => Promise.resolve(initialChats),
+        }));
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    const makeMessage = (chatId: number, id: number): MessageType => ({
+        id,
+        author: "user-1",
+        text: "hello",
+        attachments: [],
+        createdAt: "2026-07-09T10:00:00Z",
+        chat: `https://api.goodsurfing.org/api/v1/chats/${chatId}`,
+        readByUserIds: [],
+    });
+
+    it("обновляет lastMessage и увеличивает countUnreadMessages без сетевого запроса", async () => {
+        const { result } = renderHook(() => useGetChatListData("token", "mercure-token"));
+
+        await waitFor(() => expect(result.current.chatsList).toHaveLength(2));
+        const fetchCallsBefore = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+
+        act(() => {
+            result.current.applyIncomingMessage(makeMessage(2, 999));
+        });
+
+        const updatedChat = result.current.chatsList.find((c) => c.id === 2);
+        expect(updatedChat?.countUnreadMessages).toBe(4);
+        expect(updatedChat?.lastMessage?.id).toBe(999);
+
+        // Точечное обновление не должно было вызывать новый fetch
+        expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(fetchCallsBefore);
+    });
+
+    it("не меняет список для сообщения из чата, которого ещё нет локально", async () => {
+        const { result } = renderHook(() => useGetChatListData("token", "mercure-token"));
+
+        await waitFor(() => expect(result.current.chatsList).toHaveLength(2));
+
+        act(() => {
+            result.current.applyIncomingMessage(makeMessage(999, 1));
+        });
+
+        expect(result.current.chatsList).toHaveLength(2);
+        expect(result.current.chatsList.every((c) => c.id === 1 || c.id === 2)).toBe(true);
+    });
+});

--- a/src/entities/Chat/lib/useGetChatListData.test.tsx
+++ b/src/entities/Chat/lib/useGetChatListData.test.tsx
@@ -14,7 +14,9 @@ import { MessageType } from "@/entities/Messenger";
  */
 describe("useGetChatListData.applyIncomingMessage", () => {
     const initialChats = [
-        { id: 1, lastMessage: undefined, otherParticipants: [], countUnreadMessages: 0 },
+        {
+            id: 1, lastMessage: undefined, otherParticipants: [], countUnreadMessages: 0,
+        },
         {
             id: 2,
             lastMessage: {

--- a/src/entities/Chat/lib/useGetChatListData.tsx
+++ b/src/entities/Chat/lib/useGetChatListData.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { FormApplicationStatus } from "@/entities/Application";
 import {
-    ChatsList,
+    ChatsList, MessageType,
 } from "@/entities/Messenger";
 
 import { API_BASE_URL } from "@/shared/constants/api";
@@ -52,27 +52,29 @@ export const useGetChatListData = (
         fetchChats();
     }, [fetchChats]);
 
-    // useEffect(() => {
-    //     const unsubscribe = registerOnMessageCallback((updatedMessage: MessageType) => {
-    //         const tempUpdatedChatId = updatedMessage.chat.split("/").pop();
-    //         if (!tempUpdatedChatId) return;
+    // Точечно обновляет lastMessage/countUnreadMessages чата по SSE-событию,
+    // без полного сетевого рефетча всего списка (был источник "моргания" и
+    // схлопывания непрочитанных чатов при активной переписке — row 116).
+    // Если чата ещё нет в текущем списке (например, только что создан) —
+    // просто игнорируем событие, он появится при следующем обычном fetchChats.
+    const applyIncomingMessage = useCallback((updatedMessage: MessageType) => {
+        const tempUpdatedChatId = updatedMessage.chat?.split("/").pop();
+        if (!tempUpdatedChatId) return;
+        const updatedChatId = parseInt(tempUpdatedChatId, 10);
 
-    //         console.log("updatedMessage", updatedMessage);
-    //         const updatedChatId = parseInt(tempUpdatedChatId, 10);
+        setChatsList((prev) => prev.map((chat) => {
+            if (chat.id !== updatedChatId || !chat.lastMessage) return chat;
 
-    //         // setChatsList((prev) => prev.map((chat) => (chat.id === updatedChatId
-    //         //     ? {
-    //         //         ...chat,
-    //         //         lastMessage: updatedMessage,
-    //         //         countUnreadMessages: chat.countUnreadMessages + 1,
-    //         //     }
-    //         //     : chat)));
-    //     });
-
-    //     return () => {
-    //         unsubscribe();
-    //     };
-    // }, [registerOnMessageCallback]);
+            return {
+                ...chat,
+                // author у ChatsList.lastMessage — Profile, а в SSE-пейлоаде
+                // только id автора строкой; author нигде не рендерится в
+                // превью чата (см. UserCard), поэтому оставляем прежний.
+                lastMessage: { ...updatedMessage, author: chat.lastMessage.author },
+                countUnreadMessages: chat.countUnreadMessages + 1,
+            };
+        }));
+    }, []);
 
     const onChangeSearchValue = (value: string) => {
         setSearchValue(value);
@@ -89,5 +91,6 @@ export const useGetChatListData = (
         onChangeSearchValue,
         onChangeStatusValue,
         fetchChats,
+        applyIncomingMessage,
     };
 };

--- a/src/entities/Messenger/model/types/messenger.ts
+++ b/src/entities/Messenger/model/types/messenger.ts
@@ -11,7 +11,7 @@ export interface MessageType {
     text?: string;
     attachments: string[] | MediaObjectType[];
     createdAt: string;
-    // chat: string;
+    chat: string;
     applicationForm?: string;
     readByUserIds: string[];
 }

--- a/src/widgets/Messenger/ui/Chat/Chat.tsx
+++ b/src/widgets/Messenger/ui/Chat/Chat.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import cn from "classnames";
 import React, {
-    FC, Fragment, useCallback, useEffect, useState,
+    FC, Fragment, useCallback, useEffect, useRef, useState,
 } from "react";
 import { Controller, DefaultValues, useForm } from "react-hook-form";
 import InfiniteScroll from "react-infinite-scroll-component";
@@ -175,16 +175,23 @@ export const Chat: FC<ChatProps> = (props) => {
         // }
     }, [isChatCreate, offerId, getOfferData]);
 
+    // Ref, а не state: отмечаем последнее уже прочитанное сообщение конкретного
+    // чата, чтобы не дёргать readMessage/onReadMessage повторно на каждый
+    // ре-рендер messages (это вызывало каскад полных рефетчей списка чатов —
+    // "моргание" и схлопывание непрочитанных в списке, row 116).
+    const lastReadMessageIdRef = useRef<Record<string, number>>({});
+
     useEffect(() => {
-        if (messages) {
-            messages.forEach(async (message, index) => {
-                if (index === 0) {
-                    await readMessage({ message: `${API_BASE_URL}messages/${message.id}` });
-                    onReadMessage();
-                }
-            }, []);
-        }
-    }, [messages, onReadMessage, readMessage]);
+        if (!messages?.length || !id) return;
+        const latestMessage = messages[0];
+        if (lastReadMessageIdRef.current[id] === latestMessage.id) return;
+
+        lastReadMessageIdRef.current[id] = latestMessage.id;
+        (async () => {
+            await readMessage({ message: `${API_BASE_URL}messages/${latestMessage.id}` });
+            onReadMessage();
+        })();
+    }, [messages, id, onReadMessage, readMessage]);
 
     const onApplicationSubmit = useCallback(async (
         status: FormApplicationStatus,

--- a/src/widgets/Messenger/ui/MessengerList/MessengerList.regression.test.ts
+++ b/src/widgets/Messenger/ui/MessengerList/MessengerList.regression.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 116: непрочитанные чаты "моргали" и пропадали из
+ * видимой области при активной переписке — на каждое SSE-сообщение (в любом
+ * чате) дёргался полный fetchChats() (сеть + пересортировка всего списка).
+ * Колбэк на входящее сообщение должен использовать точечное обновление
+ * (applyIncomingMessage), а не fetchChats.
+ *
+ * Компонент слишком завязан на контекст (MessengerProvider, SSE) для
+ * полного рендер-теста — проверяем исходник.
+ */
+describe("MessengerList on-message wiring (regress-guard)", () => {
+    it("registerOnMessageCallback использует applyIncomingMessage, а не fetchChats", () => {
+        const source = readFileSync(join(__dirname, "MessengerList.tsx"), "utf-8");
+
+        const onMessageBlockMatch = source.match(
+            /registerOnMessageCallback\(\(msg\) => \{([\s\S]*?)\}\);/,
+        );
+        expect(onMessageBlockMatch).not.toBeNull();
+        expect(onMessageBlockMatch![1]).toMatch(/applyIncomingMessage/);
+        expect(onMessageBlockMatch![1]).not.toMatch(/fetchChats\(\)/);
+    });
+});

--- a/src/widgets/Messenger/ui/MessengerList/MessengerList.tsx
+++ b/src/widgets/Messenger/ui/MessengerList/MessengerList.tsx
@@ -33,6 +33,7 @@ export const MessengerList: FC<MessengerListProps> = (props: MessengerListProps)
         onChangeSearchValue,
         onChangeStatusValue,
         fetchChats,
+        applyIncomingMessage,
     } = useGetChatListData(token, mercureToken);
     const { registerMessageUpdateCallback, registerOnMessageCallback } = useMessenger();
 
@@ -45,11 +46,15 @@ export const MessengerList: FC<MessengerListProps> = (props: MessengerListProps)
         });
     }, [fetchChats, registerMessageUpdateCallback]);
 
+    // Точечное обновление вместо полного fetchChats на каждое сообщение —
+    // иначе список постоянно перезапрашивался и пересортировывался целиком,
+    // из-за чего непрочитанные чаты "моргали" и уезжали из видимой области
+    // (row 116).
     useEffect(() => {
-        registerOnMessageCallback(() => {
-            fetchChats();
+        registerOnMessageCallback((msg) => {
+            applyIncomingMessage(msg);
         });
-    }, [fetchChats, registerOnMessageCallback]);
+    }, [applyIncomingMessage, registerOnMessageCallback]);
 
     const handleTextChange = (text: string) => {
         onChangeSearchValue(text);


### PR DESCRIPTION
## Суть

Row 116 таблицы багов: непрочитанные чаты странно отображаются, видно только часть; после открытия одного из непрочитанных чатов список начинает моргать/обновляться, остальные непрочитанные чаты снова куда-то сворачиваются.

## Причина

Два независимых источника избыточных полных перерисовок списка:

1. `MessengerProvider` слушает SSE-топик на ВСЕ сообщения пользователя (`users/{id}/messages/{?chat}`), а `MessengerList` на каждое такое событие дёргал `fetchChats()` — полный сетевой запрос + пересортировка всего списка чатов, даже если сообщение пришло в чат, который сейчас не открыт.
2. В `Chat.tsx` эффект «пометить последнее сообщение прочитанным» перезапускался при любом изменении `messages` (в т.ч. повторно для уже прочитанного сообщения), каждый раз вызывая `onReadMessage()` → ещё один `fetchChats()` в списке.

В сумме — при активной переписке список чатов дёргал сеть и пересортировывался по несколько раз в секунду, из-за чего непрочитанные чаты визуально "уезжали" за пределы видимой области.

## Фикс

- `useGetChatListData`: добавлен `applyIncomingMessage` — точечно патчит `lastMessage`/`countUnreadMessages` нужного чата в локальном стейте без сети (реализация была начата и закомментирована ранее — просто доделал и включил).
- `MessengerList`: колбэк на новое сообщение использует `applyIncomingMessage` вместо `fetchChats()`.
- `Chat.tsx`: дедупликация пометки "прочитано" по id последнего обработанного сообщения на чат (через ref) — не перевызывается повторно для того же сообщения.

## Тесты

- `useGetChatListData.test.tsx` — обновление конкретного чата без сети, игнор сообщения из неизвестного чата.
- `MessengerList.regression.test.ts` — source-guard: колбэк на сообщение обязан использовать `applyIncomingMessage`, не `fetchChats`.

Регресс подтверждён revert/restore на обоих.

## Как проверялось

`npx tsc --noEmit` — 0 ошибок. `npx eslint` — чисто. Полный `vitest` — все тесты зелёные (1 несвязанный pre-existing fail из-за отсутствующего npm-модуля в чужом тесте, не трогал).

## Дальше

После мерджа — стейдж, затем прод (по стандартному пайплайну тегов).