### PR TITLE
fix: молчаливый возврат со страницы оплаты при активном членстве (row 95)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ localhost+1.pem
 Agents.md
 .claude/
 scripts/
+playwright-report/
+test-results/
+e2e/.auth/

--- a/e2e/tests/payment.spec.ts
+++ b/e2e/tests/payment.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect, request } from '@playwright/test';
+import { API_URL, IAP_TOKEN } from '../config';
+
+/**
+ * Живая проверка полного платёжного пути на стейдже (row 95, row 106-соседние
+ * пункты про членство) — не мок, реальный тестовый платёж через ЮКасса
+ * (staging сконфигурирован на YOOKASSA_SECRET_KEY=test_..., деньги не
+ * списываются, "demo store will receive the payment").
+ *
+ * ВАЖНО про архитектуру теста: регистрация/логин/чекаут/вебхук/проверка
+ * членства идут напрямую через API-контекст (`api`), а не через открытие
+ * SPA на staging.goodsurfing.org. Причина — IAP-bypass токен нужно слать
+ * заголовком (Authorization или X-Forwarded-Authorization), а любой
+ * нестандартный заголовок на кросс-origin запрос (staging.goodsurfing.org →
+ * api-staging.goodsurfing.org) заставляет браузер слать CORS-preflight
+ * (OPTIONS), который сам перехватывается IAP и не проходит — реальные
+ * авторизованные запросы SPA с любым из этих заголовков падают с CORS-
+ * ошибкой ещё до попытки авторизации. `request.newContext()` — обычный
+ * HTTP-клиент Playwright, не браузерный fetch, на него CORS не действует,
+ * поэтому весь путь до реального чекаута идёт через него. Браузер (`page`)
+ * используется только для навигации на сам чекаут ЮКассы (yoomoney.ru —
+ * сторонний домен, IAP там нет вообще).
+ *
+ * ВАЖНО про вебхук: staging закрыт Yandex IAP на уровне инфраструктуры
+ * (перед Traefik), и это гейтит ВООБЩЕ ВСЕ входящие запросы на
+ * api-staging.goodsurfing.org — включая вебхук ЮКасса. Реальные серверы
+ * ЮКассы не могут пройти IAP и получают 302 на страницу логина Яндекса
+ * вместо ответа от Symfony. Проверено напрямую: POST на
+ * /api/v1/payments/yookassa/notification без IAP-bypass-заголовка → 302 на
+ * /auth/login, не 200. Значит на стейдже членство НИКОГДА не активируется
+ * автоматически после оплаты — тест поэтому вручную реплеит нотификацию с
+ * IAP-bypass, эмулируя то, что сделали бы реальные серверы ЮКассы, если бы
+ * могли достучаться. Сама бизнес-логика вебхука (верификация через переспрос
+ * ЮКасса API, идемпотентность, активация Membership) от этого не мокается —
+ * только обходится инфраструктурная блокировка доставки.
+ *
+ * Оба ограничения — системные особенности стейджа, не баги тестируемого кода.
+ */
+test.describe('Оплата членства — полный путь на стейдже', () => {
+    test('чекаут → тестовая оплата ЮКасса → (replay вебхука) → членство ACTIVE', async ({ page }) => {
+        const api = await request.newContext({
+            baseURL: API_URL,
+            extraHTTPHeaders: IAP_TOKEN ? { 'X-Forwarded-Authorization': `Bearer ${IAP_TOKEN}` } : {},
+            ignoreHTTPSErrors: true,
+        });
+
+        // Свежий одноразовый пользователь — чтобы не зависеть от состояния
+        // членства общих e2e-фикстур (vol@test.com и т.д.) между прогонами.
+        const email = `e2e-payment-${Date.now()}@test.local`;
+        const password = 'E2ePayment2026!';
+
+        const registerResp = await api.post('/api/v1/users', {
+            data: {
+                email, plainPassword: password, locale: 'ru', isActive: true,
+            },
+        });
+        expect(registerResp.ok(), await registerResp.text()).toBeTruthy();
+
+        // /api/v1/token требует is_verified=true, а реального письма в e2e
+        // нет — подтверждаем через служебный тест-эндпоинт (тот же гейт
+        // E2E_TESTING_ENABLED, что у /api/test/reset).
+        const verifyResp = await api.post('/api/test/verify-email', { data: { email } });
+        expect(verifyResp.ok(), await verifyResp.text()).toBeTruthy();
+
+        const loginResp = await api.post('/api/v1/token', { data: { email, password } });
+        expect(loginResp.ok(), await loginResp.text()).toBeTruthy();
+        const { accessToken } = await loginResp.json();
+        const authHeader = { Authorization: `Bearer ${accessToken}` };
+
+        // Тот же запрос, что PaymentPage.tsx делает через
+        // useCheckoutMembershipMutation() — воспроизводим напрямую, минуя SPA.
+        const checkoutResp = await api.post('/api/v1/membership/checkout', {
+            data: { tariffCode: 'volunteer_990' },
+            headers: authHeader,
+        });
+        expect(checkoutResp.ok(), await checkoutResp.text()).toBeTruthy();
+        const { paymentUrl } = await checkoutResp.json();
+        expect(paymentUrl).toBeTruthy();
+
+        // playwright.config.ts шлёт Authorization: Bearer <IAP-токен> глобально
+        // для всех запросов контекста (нужно для обхода IAP на staging) — но
+        // тот же заголовок летит и на сторонние домены. yoomoney.ru не ждёт
+        // Authorization на кросс-origin запросах к своим статикам и роняет
+        // CORS-preflight на них (страница остаётся пустой). Чекаут ЮKassa не
+        // за IAP, так что заголовок здесь не нужен — снимаем его перед переходом.
+        await page.context().setExtraHTTPHeaders({});
+        await page.goto(paymentUrl);
+        await page.waitForURL(/yoomoney\.ru\/checkout/, { timeout: 15_000 });
+        await expect(page.locator('[data-qa="notification-informer"]')).toBeVisible({ timeout: 10_000 });
+
+        const orderId = new URL(page.url()).searchParams.get('orderId');
+        expect(orderId).toBeTruthy();
+
+        // Виджет ЮKassa на этот заказ выдаёт тестовый кошелёк test.wallet —
+        // выбираем его как способ оплаты и подтверждаем.
+        await page.locator('[data-qa="pay-wallet"]').click();
+        await page.locator('[data-qa="confirm-payment-button"]').click();
+        await page.waitForURL(/checkout\/payments\/v2\/success/, { timeout: 15_000 });
+
+        // Реальная доставка вебхука на стейдж заблокирована IAP (см. коммент
+        // в начале файла) — реплеим её сами тем же способом, каким это
+        // делают все остальные ручные проверки на стейдже в этой сессии.
+        const notifyResp = await api.post('/api/v1/payments/yookassa/notification', {
+            data: {
+                type: 'notification',
+                event: 'payment.succeeded',
+                object: { id: orderId, status: 'succeeded' },
+            },
+        });
+        expect(notifyResp.ok(), await notifyResp.text()).toBeTruthy();
+
+        const membershipResp = await api.get('/api/v1/membership/current', { headers: authHeader });
+        const membership = await membershipResp.json();
+        expect(membership.status).toBe('ACTIVE');
+        expect(membership.tariff?.code).toBe('volunteer_990');
+
+        await api.dispose();
+    });
+});

--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.regression.test.ts
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.regression.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 95 ("Не работает модуль оплаты" — пункт 15
+ * "Правки сайт ГС 2.0 от 23.06.2026": "После нажатия на любую из кнопок
+ * оплаты, просто возвращает в начало страницы").
+ *
+ * Бэкенд-чекаут (POST /api/v1/membership/checkout) при живой проверке на
+ * стейдже отдаёт валидный paymentUrl без ошибок — сам чекаут исправен.
+ * Но при HTTP 409 (у пользователя уже есть ACTIVE членство) фронт молча
+ * делал navigate() на страницу членства без единого сообщения — именно
+ * это выглядит как "нажал на оплату — ничего не произошло, вернуло в
+ * начало". Теперь показывается явное сообщение через errorMessage.
+ *
+ * Компонент слишком завязан на роутинг/auth/RTK Query для полного
+ * рендер-теста — проверяем исходник.
+ */
+describe("PaymentPage 409-handling (regress-guard)", () => {
+    it("на 409 показывает сообщение вместо молчаливого navigate", () => {
+        const source = readFileSync(join(__dirname, "PaymentPage.tsx"), "utf-8");
+
+        const catchBlockMatch = source.match(
+            /err\.status === 409\) \{([\s\S]*?)\}/,
+        );
+        expect(catchBlockMatch).not.toBeNull();
+        expect(catchBlockMatch![1]).toMatch(/setErrorMessage/);
+        expect(catchBlockMatch![1]).not.toMatch(/navigate\(/);
+    });
+});

--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
@@ -50,7 +50,10 @@ const PaymentPage: React.FC = () => {
             })
             .catch((err: unknown) => {
                 if (isFetchError(err) && err.status === 409) {
-                    navigate(getMembershipPageUrl(locale));
+                    // Раньше здесь был молчаливый переход на страницу членства
+                    // без сообщения — выглядело так, будто клик по оплате
+                    // "просто возвращает на начало страницы" (row 95).
+                    setErrorMessage("У вас уже есть активное членство.");
                     return;
                 }
 


### PR DESCRIPTION
## Суть

Row 95 таблицы багов / пункт 15 "Правки сайт ГС 2.0 от 23.06.2026": "Страница членства. Модуль оплаты не работает. После нажатия на любую из кнопок оплаты, просто возвращает в начало страницы".

## Что реально происходит

Бэкенд-чекаут (`POST /api/v1/membership/checkout`) — проверил вживую на стейдже:
- Чистый аккаунт (нет членства) → 201, валидный `paymentUrl`, реальный переход на YooKassa/YooMoney checkout работает.
- Аккаунт с уже ACTIVE членством → 409 (`MembershipAlreadyActiveException`, ожидаемое поведение бэка).

Фронт на 409 молча делал `navigate()` на страницу членства — без единого сообщения. Для пользователя это выглядит ровно как "нажал на оплату — ничего не произошло, вернуло на начало".

## Фикс

На 409 теперь показывается явное сообщение "У вас уже есть активное членство." через уже существующий UI ошибки (с кнопкой "Вернуться на страницу членства"), вместо тихого редиректа.

## Тест

Source-guard `PaymentPage.regression.test.ts` — 409-ветка должна вызывать `setErrorMessage`, а не `navigate`. Регресс подтверждён revert/restore.

## Как проверялось

Живьём на стейдже (`npm start` + IAP bypass, реальные тестовые аккаунты):
- Аккаунт без членства → реальный переход браузера на `yoomoney.ru/checkout/...`.
- Аккаунт с активным членством (активировано через admin-эндпоинт) → страница показывает "Ошибка: У вас уже есть активное членство." с кнопкой возврата, вместо молчаливого редиректа.

## Дальше

После мерджа — стейдж, затем прод.