### PR TITLE
fix: унифицирован порядок Имя/Фамилия в getFullName (row 103)

### DIFF
--- a/src/shared/lib/getFullName.test.tsx
+++ b/src/shared/lib/getFullName.test.tsx
@@ -1,0 +1,33 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { renderHook } from "@testing-library/react";
+import { getFullName, useGetFullName } from "./getFullName";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * Регресс-guard для row 103: getFullName() (для не-React adapter'ов) и
+ * getFullName() из useGetFullName() (для компонентов) раньше отдавали ФИО в
+ * противоположном порядке — «Фамилия Имя» vs «Имя Фамилия» — из-за чего
+ * одинаковые данные выглядели по-разному на разных страницах (блог/видео/
+ * новости/админ-таблицы vs отзывы/чат/команда).
+ */
+describe("getFullName — порядок Имя/Фамилия", () => {
+    it("стандалон-функция отдаёт «Имя Фамилия»", () => {
+        expect(getFullName("Иван", "Иванов")).toBe("Иван Иванов");
+    });
+
+    it("хук отдаёт «Имя Фамилия»", () => {
+        const { result } = renderHook(() => useGetFullName());
+        expect(result.current.getFullName("Иван", "Иванов")).toBe("Иван Иванов");
+    });
+
+    it("стандалон-функция и хук согласованы для одних и тех же данных", () => {
+        const { result } = renderHook(() => useGetFullName());
+
+        expect(getFullName("Пётр", "Петров")).toBe(result.current.getFullName("Пётр", "Петров"));
+    });
+});

--- a/src/shared/lib/getFullName.tsx
+++ b/src/shared/lib/getFullName.tsx
@@ -27,7 +27,11 @@ export const getFullName = (
 ) => {
     if (!firstName && !lastName) return "Не указан";
 
-    const renderFullName = `${lastName || ""} ${firstName || ""}`.trim();
+    // Порядок «Имя Фамилия» — как в useGetFullName() выше. Раньше здесь был
+    // обратный порядок «Фамилия Имя», из-за чего одно и то же ФИО выглядело
+    // по-разному в зависимости от того, через хук или эту функцию рендерилось
+    // (row 103 — блог/видео/новости/админ-таблицы vs отзывы/чат/команда).
+    const renderFullName = `${firstName || ""} ${lastName || ""}`.trim();
     return (renderFullName);
 };
 


### PR DESCRIPTION
## Причина

В `src/shared/lib/getFullName.tsx` было две функции с одинаковым именем `getFullName`, но противоположным порядком аргументов:
- `useGetFullName()` (хук, для React-компонентов) — `Имя Фамилия`
- отдельный экспорт `getFullName` (для не-React adapter'ов вроде `blogAdapter.ts`, `newsAdapter.ts`, `videoAdapter.ts`, `admin*Adapter.ts` — им нельзя вызывать хук) — `Фамилия Имя`

Импортировались вперемешку в 48 местах — отзывы/чат/команда/личный кабинет показывали «Имя Фамилия», а блог/видео/новости/админ-таблицы — «Фамилия Имя». Одни и те же ФИО выглядели по-разному в зависимости от страницы.

## Фикс

Унифицировал стандалон-функцию на порядок `Имя Фамилия` (как в хуке) — этот порядок уже использовался в большинстве мест (27 против 22). Фолбэк-тексты при отсутствии имени/фамилии не трогал (`"Не указан"` у стандалон-функции vs переводимое `t("Анонимный пользователь")` у хука) — это разный копирайт для разных контекстов (админка vs пользовательский UI), не то, о чём row 103.

## Тесты

`getFullName.test.tsx` — проверяет, что обе функции отдают одинаковый порядок для одних и тех же данных. Регресс подтверждён revert/restore: без фикса тест падает (`'Петров Пётр'` вместо `'Пётр Петров'`).

Row 103 в таблице фиксов.