### PR TITLE
fix: индикатор загрузки обложки статьи (row 61)

### DIFF
--- a/src/features/ArticleForm/ui/UploadArticleCover/UploadArticleCover.module.scss
+++ b/src/features/ArticleForm/ui/UploadArticleCover/UploadArticleCover.module.scss
@@ -77,3 +77,10 @@
     max-width: 95px;
     height: 27px;
 }
+
+.loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}

--- a/src/features/ArticleForm/ui/UploadArticleCover/UploadArticleCover.test.tsx
+++ b/src/features/ArticleForm/ui/UploadArticleCover/UploadArticleCover.test.tsx
@@ -1,0 +1,43 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import {
+    render, screen, fireEvent, waitFor,
+} from "@testing-library/react";
+import { UploadArticleCover } from "./UploadArticleCover";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+let resolveUpload: (value: unknown) => void;
+vi.mock("@/shared/hooks/files/useUploadFile", () => ({
+    default: vi.fn(() => new Promise((resolve) => {
+        resolveUpload = resolve;
+    })),
+}));
+
+/**
+ * Регресс-guard для row 61: загрузка обложки статьи не показывала никакой
+ * индикации в процессе запроса — выглядело так, будто клик "не сработал".
+ */
+describe("UploadArticleCover — индикация загрузки", () => {
+    it("показывает лоадер, пока идёт загрузка обложки, и скрывает после завершения", async () => {
+        const onUpload = vi.fn();
+        const { container } = render(<UploadArticleCover id="cover" onUpload={onUpload} />);
+
+        const input = container.querySelector("input[type=file]") as HTMLInputElement;
+        const file = new File(["content"], "cover.png", { type: "image/png" });
+
+        fireEvent.change(input, { target: { files: [file] } });
+
+        expect(await screen.findByRole("progressbar")).toBeInTheDocument();
+
+        resolveUpload({ id: "1", contentUrl: "url", thumbnails: {} });
+
+        await waitFor(() => {
+            expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+        });
+        expect(onUpload).toHaveBeenCalled();
+    });
+});

--- a/src/features/ArticleForm/ui/UploadArticleCover/UploadArticleCover.tsx
+++ b/src/features/ArticleForm/ui/UploadArticleCover/UploadArticleCover.tsx
@@ -1,11 +1,12 @@
 import React, {
-    ChangeEvent, FC, useCallback,
+    ChangeEvent, FC, useCallback, useState,
 } from "react";
 
 import { useTranslation } from "react-i18next";
 import cameraIcon from "@/shared/assets/icons/photo-camera.svg";
 import Button from "@/shared/ui/Button/Button";
 import InputFile from "@/shared/ui/InputFile/InputFile";
+import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 
 import styles from "./UploadArticleCover.module.scss";
 import { Image } from "@/types/media";
@@ -23,12 +24,17 @@ export const UploadArticleCover: FC<UploadArticleCoverProps> = (
 ) => {
     const { id, onUpload, img } = props;
     const { t } = useTranslation("volunteer");
+    // Загрузка обложки может занимать заметное время (row 61 — "долго
+    // грузится, ощущение что не сработало"), а раньше в течение всего
+    // запроса не было никакой обратной связи.
+    const [isUploading, setIsUploading] = useState(false);
 
     const handleUpload = useCallback(
         async (e: ChangeEvent<HTMLInputElement>) => {
             const fileList = e.target.files;
             if (fileList && fileList.length > 0) {
                 const file = fileList[0];
+                setIsUploading(true);
                 await uploadFile(file.name, file)
                     .then((result) => {
                         if (result) {
@@ -41,6 +47,9 @@ export const UploadArticleCover: FC<UploadArticleCoverProps> = (
                     })
                     .catch(() => {
                         onUpload?.(null);
+                    })
+                    .finally(() => {
+                        setIsUploading(false);
                     });
             }
         },
@@ -56,51 +65,61 @@ export const UploadArticleCover: FC<UploadArticleCoverProps> = (
             {img && (
                 <div className={styles.imageWrapper}>
                     <img src={getMediaContent(img.contentUrl)} alt="uploaded" className={styles.imageCover} />
-                    <div className={styles.containerButtons}>
-                        <InputFile
-                            id="upload image"
-                            onChange={handleUpload}
-                            wrapperClassName={styles.inputButton}
-                            uploadedImageClassName={styles.hiddenImg}
-                            labelClassName={styles.inputButton}
-                            labelChildren={(
-                                <div
-                                    className={styles.buttons}
-                                >
-                                    {t("volunteer-create-article.Изменить")}
-                                </div>
-                            )}
-                        />
-                        <Button
-                            className={styles.buttons}
-                            color="BLUE"
-                            size="SMALL"
-                            variant="OUTLINE"
-                            onClick={handleDelete}
-                        >
-                            {t("volunteer-create-article.Удалить")}
-                        </Button>
-                    </div>
+                    {isUploading ? (
+                        <MiniLoader className={styles.loader} />
+                    ) : (
+                        <div className={styles.containerButtons}>
+                            <InputFile
+                                id="upload image"
+                                onChange={handleUpload}
+                                wrapperClassName={styles.inputButton}
+                                uploadedImageClassName={styles.hiddenImg}
+                                labelClassName={styles.inputButton}
+                                labelChildren={(
+                                    <div
+                                        className={styles.buttons}
+                                    >
+                                        {t("volunteer-create-article.Изменить")}
+                                    </div>
+                                )}
+                            />
+                            <Button
+                                className={styles.buttons}
+                                color="BLUE"
+                                size="SMALL"
+                                variant="OUTLINE"
+                                onClick={handleDelete}
+                            >
+                                {t("volunteer-create-article.Удалить")}
+                            </Button>
+                        </div>
+                    )}
                 </div>
             )}
             {!img
             && (
-                <InputFile
-                    onChange={handleUpload}
-                    imageURL={img}
-                    id={id}
-                    uploadedImageClassName={styles.hiddenImg}
-                    labelClassName={styles.btn}
-                    labelChildren={(
-                        <div className={styles.innerWrapper}>
-                            <img
-                                src={cameraIcon}
-                                alt="add item"
-                            />
-                            <span className={styles.text}>{t("volunteer-create-article.Добавить фото обложки")}</span>
-                        </div>
-                    )}
-                />
+                isUploading ? (
+                    <div className={styles.btn}>
+                        <MiniLoader className={styles.loader} />
+                    </div>
+                ) : (
+                    <InputFile
+                        onChange={handleUpload}
+                        imageURL={img}
+                        id={id}
+                        uploadedImageClassName={styles.hiddenImg}
+                        labelClassName={styles.btn}
+                        labelChildren={(
+                            <div className={styles.innerWrapper}>
+                                <img
+                                    src={cameraIcon}
+                                    alt="add item"
+                                />
+                                <span className={styles.text}>{t("volunteer-create-article.Добавить фото обложки")}</span>
+                            </div>
+                        )}
+                    />
+                )
             )}
         </div>
     );


### PR DESCRIPTION
## Причина

`UploadArticleCover.tsx` (создание статьи блога, `features/ArticleForm`) во время загрузки обложки не показывал никакой обратной связи — запрос на `/api/v1/media_objects` может занимать заметное время, и всё это время интерфейс выглядит так, будто клик по загрузке ничего не сделал.

## Фикс

Добавлено состояние `isUploading` — на время запроса вместо кнопки загрузки/превью показывается `MiniLoader`.

## Тесты

`UploadArticleCover.test.tsx` — мокает `uploadFile` управляемым промисом, проверяет что лоадер появляется сразу после выбора файла и исчезает после завершения запроса. Регресс подтверждён revert/restore.