### PR TITLE
fix: «Дней осталось» показывалось пустым у сборов без даты окончания (row 77)

### DIFF
--- a/src/entities/Donation/model/types/donationSchema.ts
+++ b/src/entities/Donation/model/types/donationSchema.ts
@@ -22,7 +22,7 @@ export interface GetDonations {
     name: string | null;
     shortDescription: string | null;
     percentAmountCollect: number;
-    daysLeft: number;
+    daysLeft: number | null;
     isSuccess: boolean;
     isClose: boolean;
     isCanEdit: boolean;
@@ -57,7 +57,7 @@ export type GetDonation = Omit<GetDonations, "shortDescription" | "isClose" | "o
     peopleSupportCount: number;
     percentAmountCollect: number;
     collectedAmount: number;
-    daysLeft: number;
+    daysLeft: number | null;
     amount: number | null;
     minAmount: number;
     latitude: number;

--- a/src/entities/Donation/ui/DonationCard/DonationCard.test.tsx
+++ b/src/entities/Donation/ui/DonationCard/DonationCard.test.tsx
@@ -1,0 +1,44 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DonationCard } from "./DonationCard";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const baseData = {
+    id: "1",
+    organizationName: "Организация",
+    percentAmountCollect: 10,
+    isSuccess: false,
+};
+
+/**
+ * Регресс-guard для row 77: сборы без указанной даты окончания (daysLeft=null
+ * у API) показывали заголовок «Осталось» с пустым значением вместо того,
+ * чтобы скрыть блок целиком.
+ */
+describe("DonationCard", () => {
+    it("не показывает «Осталось», если у сбора нет даты окончания (daysLeft=null)", () => {
+        render(
+            <MemoryRouter>
+                <DonationCard data={{ ...baseData, daysLeft: null }} locale="ru" />
+            </MemoryRouter>,
+        );
+
+        expect(screen.queryByText(/Осталось/)).not.toBeInTheDocument();
+    });
+
+    it("показывает «Осталось», если дата окончания задана", () => {
+        render(
+            <MemoryRouter>
+                <DonationCard data={{ ...baseData, daysLeft: 5 }} locale="ru" />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText(/Осталось/)).toBeInTheDocument();
+    });
+});

--- a/src/entities/Donation/ui/DonationCard/DonationCard.tsx
+++ b/src/entities/Donation/ui/DonationCard/DonationCard.tsx
@@ -19,7 +19,7 @@ export interface DonationCardType {
     title?: string | null;
     organizationName: string;
     description?: string | null;
-    daysLeft: number;
+    daysLeft: number | null;
     percentAmountCollect: number;
     isSuccess: boolean;
 }
@@ -89,14 +89,16 @@ export const DonationCard: FC<DonationCardProps> = memo((props: DonationCardProp
                                     %
                                 </span>
                             </div>
-                            <div className={styles.iconWrapper}>
-                                <img src={calendarIcon} alt="calendar" />
-                                <span>
-                                    {t("Осталось")}
-                                    {" "}
-                                    {daysLeft}
-                                </span>
-                            </div>
+                            {daysLeft !== null && (
+                                <div className={styles.iconWrapper}>
+                                    <img src={calendarIcon} alt="calendar" />
+                                    <span>
+                                        {t("Осталось")}
+                                        {" "}
+                                        {daysLeft}
+                                    </span>
+                                </div>
+                            )}
                         </>
                     )}
                 </div>

--- a/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.test.tsx
+++ b/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.test.tsx
@@ -70,4 +70,24 @@ describe("DonationWhenCard", () => {
 
         expect(screen.queryByText("donationPersonal.Средств собрано")).not.toBeInTheDocument();
     });
+
+    /**
+     * Регресс-guard для row 77: сборы без указанной даты окончания
+     * (daysLeft=null у API) показывали заголовок «Дней осталось» с пустым
+     * значением вместо того, чтобы скрыть блок целиком.
+     */
+    it("не показывает «Дней осталось», если у сбора нет даты окончания (daysLeft=null)", () => {
+        renderWithProviders(
+            <DonationWhenCard
+                dateStart="2026-01-01"
+                daysLeft={null}
+                percentAmountCollect={null}
+                collectedAmount={0}
+                amount={null}
+                isSuccess={false}
+            />,
+        );
+
+        expect(screen.queryByText("donationPersonal.Дней осталось")).not.toBeInTheDocument();
+    });
 });

--- a/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.tsx
+++ b/src/entities/Donation/ui/DonationWhenCard/DonationWhenCard.tsx
@@ -58,7 +58,7 @@ export const DonationWhenCard = memo((props: DonationWhenCardProps) => {
                 >
                     {donationDateStart()}
                 </InfoCardItem>
-                {(daysLeft && !isSuccess) && (
+                {(daysLeft !== null && !isSuccess) && (
                     <InfoCardItem
                         title={t("donationPersonal.Дней осталось")}
                         text={daysLeft}

--- a/src/entities/Donation/ui/HeaderDonationCard/HeaderDonationCard.test.tsx
+++ b/src/entities/Donation/ui/HeaderDonationCard/HeaderDonationCard.test.tsx
@@ -1,0 +1,53 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { HeaderDonationCard } from "./HeaderDonationCard";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+const baseProps = {
+    donationId: "1",
+    peopleSupportCount: 0,
+    percentAmountCollect: 0,
+    isSuccess: false,
+    canEdit: false,
+    canSupport: true,
+    status: "active" as const,
+    isVolunteer: true,
+};
+
+/**
+ * Регресс-guard для row 77: сборы без указанной даты окончания (daysLeft=null
+ * у API) показывали заголовок «Дней осталось» с пустым значением вместо
+ * того, чтобы скрыть блок целиком.
+ */
+describe("HeaderDonationCard", () => {
+    it("не показывает «Дней осталось», если у сбора нет даты окончания (daysLeft=null)", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <HeaderDonationCard {...baseProps} daysLeft={null} />
+            </MemoryRouter>,
+        );
+
+        expect(screen.queryByText(/Дней осталось/)).not.toBeInTheDocument();
+    });
+
+    it("показывает «Дней осталось», если дата окончания задана", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <HeaderDonationCard {...baseProps} daysLeft={5} />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText(/Дней осталось/)).toBeInTheDocument();
+    });
+});

--- a/src/entities/Donation/ui/HeaderDonationCard/HeaderDonationCard.tsx
+++ b/src/entities/Donation/ui/HeaderDonationCard/HeaderDonationCard.tsx
@@ -33,7 +33,7 @@ interface HeaderDonationCardProps {
     location?: string;
     peopleSupportCount: number;
     percentAmountCollect: number;
-    daysLeft: number;
+    daysLeft: number | null;
     isSuccess: boolean;
     imageBlock?: ReactNode;
     canEdit: boolean;
@@ -184,21 +184,23 @@ export const HeaderDonationCard = memo((props: HeaderDonationCardProps) => {
                                             %
                                         </span>
                                     </div>
-                                    <div className={styles.stats}>
-                                        <IconComponent
-                                            className={styles.icon}
-                                            icon={calendarIcon}
-                                        />
-                                        <span
-                                            className={cn(styles.ratingText, {
-                                                [styles.black]: !isImage,
-                                            })}
-                                        >
-                                            {t("donationPersonal.Дней осталось")}
-                                            {" "}
-                                            {daysLeft}
-                                        </span>
-                                    </div>
+                                    {daysLeft !== null && (
+                                        <div className={styles.stats}>
+                                            <IconComponent
+                                                className={styles.icon}
+                                                icon={calendarIcon}
+                                            />
+                                            <span
+                                                className={cn(styles.ratingText, {
+                                                    [styles.black]: !isImage,
+                                                })}
+                                            >
+                                                {t("donationPersonal.Дней осталось")}
+                                                {" "}
+                                                {daysLeft}
+                                            </span>
+                                        </div>
+                                    )}
                                 </>
                             )}
 


### PR DESCRIPTION
## Причина

`daysLeft` в ответе API (`fundraise/element/{id}`) — `number | null` (`null`, если у сбора нет заданной даты окончания). Проверил вживую на проде: единственный существующий сбор действительно возвращает `daysLeft: null`. Три места на фронте это не учитывали:

- `HeaderDonationCard.tsx` (шапка страницы сбора) — рендерил `«Дней осталось» {daysLeft}` безусловно (кроме `isSuccess`), пустое значение при `null`.
- `DonationCard.tsx` (карточка в списке `/donation-map`) — то же самое с `«Осталось» {daysLeft}`.
- `DonationWhenCard.tsx` — уже скрывал блок при `daysLeft=null` за счёт truthy-проверки `daysLeft && ...`, но та же проверка сломалась бы при `daysLeft=0` (последний день сбора) — React отрисовал бы буквальный `0` вместо скрытия блока. Поправил на явную проверку `!== null`.

Тип `daysLeft: number` в схеме исправлен на `number | null`, чтобы соответствовать реальному ответу API.

## Тесты

Добавлены/расширены регресс-тесты для всех трёх компонентов — «Дней осталось»/«Осталось» не должно рендериться при `daysLeft=null`. Регресс подтверждён revert/restore для `HeaderDonationCard` и `DonationCard` (падают без фикса с тем же текстом, что видел на проде).

Row 77 в таблице фиксов.