### PR TITLE
fix: перенос текста сообщений в чате ломал слова посреди буквы (row 102, п.24)

### DIFF
--- a/src/widgets/Messenger/ui/Message/Message.module.scss
+++ b/src/widgets/Messenger/ui/Message/Message.module.scss
@@ -59,7 +59,10 @@
     font-weight: 500;
     color: var(--text-secondary-2);
     font-size: 0.875rem;
-    word-break: break-all;
+    // break-all резало слова посреди буквы вместо переноса по границе слова
+    // (row 102, п.24) — overflow-wrap переносит только слово, которое само
+    // по себе не помещается в строку, иначе перенос по обычным пробелам.
+    overflow-wrap: break-word;
     white-space: pre-line;
 }
 

--- a/src/widgets/Messenger/ui/Message/Message.wordBreak.test.ts
+++ b/src/widgets/Messenger/ui/Message/Message.wordBreak.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 102, п.24: текст сообщений в чате переносился
+ * через word-break: break-all — резало слова посреди буквы, читать было
+ * невозможно. overflow-wrap: break-word переносит по границе слова,
+ * ломая само слово только если оно не помещается в строку целиком.
+ */
+describe("Message — перенос текста сообщения", () => {
+    it(".text использует overflow-wrap: break-word, а не word-break: break-all", () => {
+        const scss = readFileSync(join(__dirname, "Message.module.scss"), "utf-8");
+        const textBlock = scss.match(/\.text\s*{[^}]*}/)?.[0] ?? "";
+
+        expect(textBlock).toMatch(/overflow-wrap:\s*break-word/);
+        expect(textBlock).not.toMatch(/word-break:\s*break-all/);
+    });
+});


### PR DESCRIPTION
## Причина

`Message.module.scss` `.text` использовал `word-break: break-all` — любой длинный текст переносился в произвольном месте, ломая слова посреди буквы (row 102, п.24 из фидбэк-документа: "читать невозможно").

## Фикс

`overflow-wrap: break-word` — перенос по обычным границам слов, слово ломается только если само по себе не помещается в строку целиком.

## Тесты

`Message.wordBreak.test.ts` (SCSS source-guard) — подтверждён revert/restore.

Row 102 в таблице фиксов (часть — см. следующий комментарий про остальные пункты 22/23/25/30, они уже были закрыты более ранними коммитами).