### PR TITLE
feat: независимая пагинация колонок CRM, фильтр по вакансии, дата заявки (row 101)

### DIFF
--- a/src/entities/Application/model/types/application.ts
+++ b/src/entities/Application/model/types/application.ts
@@ -94,6 +94,7 @@ export interface Application {
     status: FormApplicationStatus;
     chatId: number | null;
     isHasReview: boolean;
+    createdAt: string | null;
 }
 
 export type GetFormApplication = Omit<FullFormApplication, "volunteer"> & {

--- a/src/entities/Application/ui/RequestCard/RequestCard.module.scss
+++ b/src/entities/Application/ui/RequestCard/RequestCard.module.scss
@@ -74,11 +74,19 @@
 
 .linkWrapper {
     margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
 }
 
 .link {
     text-decoration: none;
     color: var(--color-blue);
+}
+
+.applicationDate {
+    font-size: 0.75rem;
+    color: var(--text-primary-1);
 }
 
 .buttons {

--- a/src/entities/Application/ui/RequestCard/RequestCard.tsx
+++ b/src/entities/Application/ui/RequestCard/RequestCard.tsx
@@ -41,7 +41,7 @@ export const RequestCard = memo((props: RequestCardProps) => {
     } = props;
     const {
         volunteer, vacancy, status, startDate, endDate, chatId,
-        id, isHasReview,
+        id, isHasReview, createdAt,
     } = application;
 
     const { t } = useTranslation();
@@ -110,6 +110,13 @@ export const RequestCard = memo((props: RequestCardProps) => {
                 >
                     {vacancy.title}
                 </Link>
+                {createdAt && (
+                    <span className={styles.applicationDate}>
+                        {t("notes.Заявка получена")}
+                        {" "}
+                        {createdAt}
+                    </span>
+                )}
             </div>
             <div className={styles.buttons}>
                 {(showButtons && status === "accepted") && (

--- a/src/entities/Chat/api/chatApi.ts
+++ b/src/entities/Chat/api/chatApi.ts
@@ -27,6 +27,11 @@ interface UpdateFormApplicationStatus {
     status: FormApplicationStatus;
 }
 
+export interface GetHostApplicationsParams extends PaginationParams {
+    status?: FormApplicationStatus;
+    vacancyId?: number;
+}
+
 export const chatApi = createApi({
     reducerPath: "chatApi",
     baseQuery: baseQueryAcceptJson,
@@ -109,7 +114,8 @@ export const chatApi = createApi({
             }),
             providesTags: ["application"],
         }),
-        getMyHostApplications: build.query<GetHostFormApplicationResponse, PaginationParams>({
+        getMyHostApplications: build.query<
+        GetHostFormApplicationResponse, GetHostApplicationsParams>({
             query: (params) => ({
                 url: `${API_BASE_URL_V3}application/list-of-organization`,
                 method: "GET",

--- a/src/features/Notes/ui/NotesHostForm/NotesHostForm.module.scss
+++ b/src/features/Notes/ui/NotesHostForm/NotesHostForm.module.scss
@@ -9,4 +9,20 @@
 
 .notes {
     margin-top: 40px;
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+}
+
+@media (max-width: 756px) {
+    .notes {
+        grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    }
+}
+
+@media (max-width: 442px) {
+    .notes {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
 }

--- a/src/features/Notes/ui/NotesHostForm/NotesHostForm.tsx
+++ b/src/features/Notes/ui/NotesHostForm/NotesHostForm.tsx
@@ -1,13 +1,14 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
+import { DragDropContext, DropResult } from "react-beautiful-dnd";
 import { Controller, DefaultValues, useForm } from "react-hook-form";
-import { Pagination } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
-import { NotesWidget } from "@/widgets/NotesWidget";
+import { NotesContainer } from "@/widgets/NotesWidget";
+import { statusColors } from "@/widgets/NotesWidget/model/lib/statusColors";
 
 import {
-    FormApplicationStatus,
     Application,
+    FormApplicationStatus,
 } from "@/entities/Application";
 import { HostModalReview, useCreateVolunteerReviewMutation } from "@/entities/Review";
 import { getErrorText } from "@/shared/lib/getErrorText";
@@ -15,15 +16,53 @@ import {
     HintType,
     ToastAlert,
 } from "@/shared/ui/HintPopup/HintPopup.interface";
+import SelectField from "@/components/SelectField/SelectField";
 
 import { ReviewFields } from "../../model/types/notes";
 import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 import { useLocale } from "@/app/providers/LocaleProvider";
-import { useLazyGetMyHostApplicationsQuery, useUpdateApplicationFormStatusByIdWithoutTagsMutation } from "@/entities/Chat";
+import {
+    useGetMyHostApplicationsQuery,
+    useUpdateApplicationFormStatusByIdMutation,
+} from "@/entities/Chat";
+import { useGetMyHostQuery } from "@/entities/Host";
+import { useLazyGetHostAllOffersByIdQuery } from "@/entities/Offer";
 import styles from "./NotesHostForm.module.scss";
 import HintPopup from "@/shared/ui/HintPopup/HintPopup";
 
 const APPLICATIONS_PER_PAGE = 10;
+
+interface VacancyOption {
+    label: string;
+    value: number | undefined;
+}
+
+// Раньше все статусы тянулись одной общей страницей и раскладывались по 3
+// колонкам уже на фронте — счётчики и постраничность каждой колонки были
+// неверными (row 101). Теперь у каждой колонки своя независимая
+// пагинация и свой реальный total с бэкенда.
+const useApplicationsColumn = (status: FormApplicationStatus, vacancyId?: number) => {
+    const [page, setPage] = useState(1);
+
+    const { data, isFetching } = useGetMyHostApplicationsQuery({
+        status,
+        vacancyId,
+        limit: APPLICATIONS_PER_PAGE,
+        page,
+    });
+
+    return {
+        status,
+        notes: data?.data ?? [],
+        total: data?.pagination.total ?? 0,
+        totalPages: data?.pagination
+            ? Math.ceil(data.pagination.total / APPLICATIONS_PER_PAGE)
+            : 0,
+        page,
+        setPage,
+        isFetching,
+    };
+};
 
 export const NotesHostForm = () => {
     const defaultValues: DefaultValues<ReviewFields> = {
@@ -44,33 +83,40 @@ export const NotesHostForm = () => {
     const [selectedApplication,
         setSelectedApplication] = useState<Application | null>(null);
 
-    const [adaptedApplications, setAdaptedApplications] = useState<Application[]>([]);
-    const [page, setPage] = useState<number>(1);
-    const [getApplications,
-        { data: applicationData, isLoading }] = useLazyGetMyHostApplicationsQuery();
+    const [vacancyId, setVacancyId] = useState<number | undefined>(undefined);
+
+    const { data: myHost } = useGetMyHostQuery();
+    const [fetchVacancies, { data: vacanciesData }] = useLazyGetHostAllOffersByIdQuery();
+
+    React.useEffect(() => {
+        if (myHost?.id) {
+            fetchVacancies({
+                organizationId: myHost.id,
+                limit: 100,
+                page: 1,
+                statuses: ["active", "disabled"],
+            });
+        }
+    }, [myHost?.id, fetchVacancies]);
+
+    const vacancyOptions = useMemo<VacancyOption[]>(() => [
+        { label: t("hostNotes.Все вакансии"), value: undefined },
+        ...(vacanciesData?.data ?? []).map((vacancy) => ({
+            label: vacancy.title ?? t("hostNotes.Без названия"),
+            value: vacancy.id,
+        })),
+    ], [vacanciesData, t]);
+
+    const newColumn = useApplicationsColumn("new", vacancyId);
+    const acceptedColumn = useApplicationsColumn("accepted", vacancyId);
+    const canceledColumn = useApplicationsColumn("canceled", vacancyId);
+    const columns = [newColumn, acceptedColumn, canceledColumn];
+
     const [createVolunteerReview] = useCreateVolunteerReviewMutation();
-    const [updateApplicationStatus,
-        { isLoading: updateApplicationLoading },
-    ] = useUpdateApplicationFormStatusByIdWithoutTagsMutation();
+    const [updateApplicationStatus] = useUpdateApplicationFormStatusByIdMutation();
     const { locale } = useLocale();
 
-    const fetchApplications = useCallback(async (limit: number, pageItem: number) => {
-        await getApplications({ limit, page: pageItem });
-    }, [getApplications]);
-
-    useEffect(() => {
-        fetchApplications(APPLICATIONS_PER_PAGE, page);
-    }, [fetchApplications, page]);
-
-    useEffect(() => {
-        if (applicationData) {
-            setAdaptedApplications(applicationData.data);
-        }
-    }, [applicationData]);
-
-    const totalPageCount = applicationData ? Math.ceil(
-        applicationData.pagination.total / APPLICATIONS_PER_PAGE,
-    ) : 0;
+    const isLoading = columns.every((column) => column.isFetching && column.notes.length === 0);
 
     const onReviewClick = (application: Application) => {
         setSelectedApplication(application);
@@ -127,6 +173,16 @@ export const NotesHostForm = () => {
         }
     };
 
+    const onDragEnd = (result: DropResult) => {
+        const { destination, source, draggableId } = result;
+
+        if (!destination || destination.droppableId === source.droppableId) {
+            return;
+        }
+
+        handleUpdateStatus(Number(draggableId), destination.droppableId as FormApplicationStatus);
+    };
+
     if (isLoading) {
         return (
             <div><MiniLoader /></div>
@@ -136,21 +192,40 @@ export const NotesHostForm = () => {
     return (
         <div className={styles.wrapper}>
             {toastTop && <HintPopup text={toastTop.text} type={toastTop.type} />}
-            <NotesWidget
-                className={styles.notes}
-                notes={adaptedApplications}
-                variant="host"
-                onReviewClick={onReviewClick}
-                updateApplicationStatus={handleUpdateStatus}
-                isDragDisable={updateApplicationLoading || isLoading}
-                locale={locale}
+            <SelectField
+                isSearchable={false}
+                name="vacancyFilter"
+                label={t("hostNotes.Вакансия")}
+                options={vacancyOptions}
+                value={vacancyOptions.find((option) => option.value === vacancyId)}
+                onChange={(option) => {
+                    const selected = option as VacancyOption | null;
+                    setVacancyId(selected?.value);
+                    columns.forEach((column) => column.setPage(1));
+                }}
             />
-            <Pagination
-                count={totalPageCount}
-                page={page}
-                onChange={(_, newPage) => setPage(newPage)}
-                size="large"
-            />
+            <DragDropContext onDragEnd={onDragEnd}>
+                <div className={styles.notes}>
+                    {columns.map((column) => (
+                        <NotesContainer
+                            key={column.status}
+                            onReviewClick={onReviewClick}
+                            onAcceptClick={(appId) => handleUpdateStatus(appId, "accepted")}
+                            onCancelClick={(appId) => handleUpdateStatus(appId, "canceled")}
+                            status={column.status}
+                            notes={column.notes}
+                            total={column.total}
+                            page={column.page}
+                            totalPages={column.totalPages}
+                            onPageChange={column.setPage}
+                            color={statusColors[column.status]}
+                            variant="host"
+                            isDragDisable={false}
+                            locale={locale}
+                        />
+                    ))}
+                </div>
+            </DragDropContext>
             <Controller
                 name="review"
                 control={control}

--- a/src/widgets/NotesWidget/ui/NotesContainer/NotesContainer.module.scss
+++ b/src/widgets/NotesWidget/ui/NotesContainer/NotesContainer.module.scss
@@ -45,3 +45,9 @@
 .noteCard {
     margin-top: 14px;
 }
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    padding: 14px 0;
+}

--- a/src/widgets/NotesWidget/ui/NotesContainer/NotesContainer.test.tsx
+++ b/src/widgets/NotesWidget/ui/NotesContainer/NotesContainer.test.tsx
@@ -1,0 +1,54 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DragDropContext } from "react-beautiful-dnd";
+import { NotesContainer } from "./NotesContainer";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * Регресс-guard для row 101: заголовок колонки CRM показывал
+ * notes.length (количество заявок на ТЕКУЩЕЙ странице общего списка),
+ * а не реальный total этого статуса по всем страницам.
+ */
+describe("NotesContainer — счётчик в заголовке колонки", () => {
+    it("показывает total, если он передан, а не notes.length", () => {
+        render(
+            <DragDropContext onDragEnd={() => {}}>
+                <NotesContainer
+                    notes={[]}
+                    color="#000"
+                    status="new"
+                    isDragDisable={false}
+                    variant="host"
+                    onReviewClick={() => {}}
+                    locale="ru"
+                    total={37}
+                />
+            </DragDropContext>,
+        );
+
+        expect(screen.getByText("37")).toBeInTheDocument();
+    });
+
+    it("падает обратно на notes.length, если total не передан (обратная совместимость)", () => {
+        render(
+            <DragDropContext onDragEnd={() => {}}>
+                <NotesContainer
+                    notes={[]}
+                    color="#000"
+                    status="new"
+                    isDragDisable={false}
+                    variant="host"
+                    onReviewClick={() => {}}
+                    locale="ru"
+                />
+            </DragDropContext>,
+        );
+
+        expect(screen.getByText("0")).toBeInTheDocument();
+    });
+});

--- a/src/widgets/NotesWidget/ui/NotesContainer/NotesContainer.tsx
+++ b/src/widgets/NotesWidget/ui/NotesContainer/NotesContainer.tsx
@@ -2,6 +2,7 @@ import cn from "classnames";
 import React, { FC, memo } from "react";
 import { Droppable } from "react-beautiful-dnd";
 import { useTranslation } from "react-i18next";
+import { Pagination } from "@mui/material";
 
 import { NotesApplicationCard } from "../NotesApplicationCard/NotesApplicationCard";
 import { NotesCard } from "../NotesCard/NotesCard";
@@ -21,6 +22,13 @@ interface NotesContainerProps {
     onAcceptClick?: (applicationId: number) => void;
     onCancelClick?: (applicationId: number) => void;
     locale: Locale;
+    // Реальное количество заявок этого статуса (все страницы), не только
+    // notes.length — раньше заголовок колонки показывал количество на
+    // текущей странице общего списка (row 101).
+    total?: number;
+    page?: number;
+    totalPages?: number;
+    onPageChange?: (page: number) => void;
 }
 
 export const NotesContainer: FC<NotesContainerProps> = memo(
@@ -36,6 +44,10 @@ export const NotesContainer: FC<NotesContainerProps> = memo(
             onAcceptClick,
             onCancelClick,
             locale,
+            total,
+            page,
+            totalPages,
+            onPageChange,
         } = props;
         const { t } = useTranslation();
 
@@ -81,7 +93,7 @@ export const NotesContainer: FC<NotesContainerProps> = memo(
                     style={{ borderBottom: `2px solid ${color}` }}
                 >
                     <span className={styles.title}>{translateLib[status]}</span>
-                    <span className={styles.number}>{notes?.length || 0}</span>
+                    <span className={styles.number}>{total ?? notes?.length ?? 0}</span>
                 </div>
                 <div className={styles.container}>
                     <Droppable
@@ -99,6 +111,15 @@ export const NotesContainer: FC<NotesContainerProps> = memo(
                             </div>
                         )}
                     </Droppable>
+                    {!!totalPages && totalPages > 1 && (
+                        <Pagination
+                            className={styles.pagination}
+                            count={totalPages}
+                            page={page}
+                            onChange={(_, newPage) => onPageChange?.(newPage)}
+                            size="small"
+                        />
+                    )}
                 </div>
             </div>
         );

--- a/src/widgets/RequestsWidget/ui/RequestsWidget/RequestsWidget.tsx
+++ b/src/widgets/RequestsWidget/ui/RequestsWidget/RequestsWidget.tsx
@@ -39,6 +39,13 @@ export const RequestsWidget = memo((props: RequestsWidgetProps) => {
         isLoading: isApplicationsLoading,
         refetch,
     } = useGetMyHostApplicationsQuery({ limit: APPLICATIONS_PER_PAGE, page: 1 });
+    // Реальное число новых заявок по всем страницам, не только среди
+    // первых APPLICATIONS_PER_PAGE вперемешку со всеми статусами (row 101).
+    const { data: newApplicationsData } = useGetMyHostApplicationsQuery({
+        status: "new",
+        limit: 1,
+        page: 1,
+    });
     const [createVolunteerReview] = useCreateVolunteerReviewMutation();
     const [updateApplicationStatus] = useUpdateApplicationFormStatusByIdMutation();
     const { t } = useTranslation("host");
@@ -151,11 +158,7 @@ export const RequestsWidget = memo((props: RequestsWidgetProps) => {
                         {t("host-dashboard.Новых заявок")}
                         {": "}
                         <span className={styles.requestsCount}>
-                            {applications
-                                ? applications.data.filter(
-                                    (app) => app.status === "new",
-                                ).length
-                                : 0}
+                            {newApplicationsData?.pagination.total ?? 0}
                         </span>
                     </p>
                 </div>


### PR DESCRIPTION
## Причина

Row 101 (фидбэк-документ, п.21): дашборд организатора тянул одну общую страницу заявок и раскладывал по 3 колонкам (new/accepted/canceled) на фронте — счётчики и постраничность каждой колонки были неверны. Бэкенд-часть — gs-backend#235 (`status`/`vacancyId` фильтры, `Application.created`).

## Что изменилось

- `NotesHostForm.tsx` переписан: 3 независимых запроса (по одному на статус), каждый со своей страницей и верным `total`.
- `NotesContainer.tsx`: заголовок колонки показывает реальный `total`, добавлена пагинация внутри колонки. Обратно совместим — `NotesVolunteerForm`/`NotesWidget` не менялись.
- Фильтр по вакансии над колонками ("Все" + список вакансий организации).
- `RequestCard.tsx`: дата подачи заявки рядом с названием вакансии.
- `RequestsWidget.tsx` (мини-виджет на дашборде): счётчик "Новых заявок" — та же проблема была и там (фильтр по 10 последним заявкам), теперь отдельный `status=new` запрос.
- Drag-and-drop: статус меняется через мутацию с тегами → автоматически обновляет все 3 колонки.

## Тесты

`NotesContainer.test.tsx` — заголовок показывает `total`, а не `notes.length`. Регресс подтверждён revert/restore.

Требует gs-backend#235 задеплоенным (уже смёржен).