### PR TITLE
fix: своё сообщение в чате теперь слева, собеседника — справа (row 102, п.24)

### DIFF
--- a/src/widgets/Messenger/ui/Message/Message.module.scss
+++ b/src/widgets/Messenger/ui/Message/Message.module.scss
@@ -103,7 +103,14 @@
         // display: none;
     }
 
+    // Row 102, п.24: своё сообщение — слева, сообщение собеседника —
+    // справа (по явной просьбе в фидбэк-документе, разворот привычной
+    // конвенции мессенджеров).
     .userMessage {
+        align-self: flex-start;
+    }
+
+    .otherMessage {
         align-self: flex-end;
         flex-direction: row-reverse;
         margin-left: auto;
@@ -112,10 +119,6 @@
             margin-left: 0;
             margin-right: 8px;
         }
-    }
-
-    .otherMessage {
-        align-self: flex-start;
     }
 }
 

--- a/src/widgets/Messenger/ui/Message/Message.side.test.ts
+++ b/src/widgets/Messenger/ui/Message/Message.side.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Регресс-guard для row 102, п.24: по явной просьбе в фидбэк-документе
+ * своё сообщение должно быть слева, сообщение собеседника — справа
+ * (разворот привычной конвенции мессенджеров).
+ */
+describe("Message — сторона своих/чужих сообщений в чате", () => {
+    it(".userMessage внутри медиа-блока выровнено слева (flex-start), без row-reverse", () => {
+        const scss = readFileSync(join(__dirname, "Message.module.scss"), "utf-8");
+        // В файле два блока .userMessage: .messageContent.userMessage (цвет
+        // фона пузыря) и позиционирующий блок внутри @media — берём последний.
+        const blocks = scss.match(/(?<!\.messageContent)\.userMessage\s*{[^}]*}/g) ?? [];
+        const positioningBlock = blocks.at(-1) ?? "";
+
+        expect(positioningBlock).toMatch(/align-self:\s*flex-start/);
+        expect(positioningBlock).not.toMatch(/row-reverse/);
+    });
+
+    it(".otherMessage выровнено справа (flex-end) с row-reverse", () => {
+        const scss = readFileSync(join(__dirname, "Message.module.scss"), "utf-8");
+        const otherMessageBlock = scss.match(/\.otherMessage\s*{[\s\S]*?\n {4}}/)?.[0] ?? "";
+
+        expect(otherMessageBlock).toMatch(/align-self:\s*flex-end/);
+        expect(otherMessageBlock).toMatch(/row-reverse/);
+    });
+});


### PR DESCRIPTION
## Причина

Row 102, п.24 (фидбэк-документ) явно просит развернуть привычную конвенцию мессенджеров: "Моё сообщение находится всегда слева. Сообщение собеседника - всегда справа". Раньше было наоборот (стандартно: своё — справа).

## Фикс

`.userMessage`/`.otherMessage` в `Message.module.scss` поменяны местами.

## Тесты

`Message.side.test.ts` (SCSS source-guard) — подтверждён revert/restore.