### PR TITLE
feat: форма обратной связи — модалка + админка (row 52)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,8 @@ import { SidebarProvider } from "@/widgets/Sidebar";
 import { useAppDispatch, useAppSelector } from "@/shared/hooks/redux";
 import { getUserInited, userActions } from "@/entities/User";
 import { LangRouter } from "@/routes";
+import { FeedbackWidgetProvider } from "@/app/providers/FeedbackWidgetProvider";
+import { FeedbackWidgetButton } from "@/widgets/FeedbackWidget";
 import { MessengerProvider } from "./providers/MessengerProvider/ui/MessengerProvider";
 import { AuthProvider } from "@/routes/model/guards/AuthProvider";
 
@@ -27,7 +29,10 @@ export const App: FC = () => {
                 <AuthProvider>
                     <MessengerProvider>
                         <SidebarProvider initialValue={{ isOpen: true }}>
-                            {inited && <LangRouter />}
+                            <FeedbackWidgetProvider>
+                                {inited && <LangRouter />}
+                                {inited && <FeedbackWidgetButton />}
+                            </FeedbackWidgetProvider>
                         </SidebarProvider>
                     </MessengerProvider>
                 </AuthProvider>

--- a/src/app/providers/FeedbackWidgetProvider/index.ts
+++ b/src/app/providers/FeedbackWidgetProvider/index.ts
@@ -1,0 +1,1 @@
+export { FeedbackWidgetProvider, useFeedbackWidget } from "./ui/FeedbackWidgetProvider";

--- a/src/app/providers/FeedbackWidgetProvider/ui/FeedbackWidgetProvider.tsx
+++ b/src/app/providers/FeedbackWidgetProvider/ui/FeedbackWidgetProvider.tsx
@@ -1,0 +1,33 @@
+import {
+    createContext, FC, ReactNode, useContext, useMemo, useState,
+} from "react";
+import { FeedbackModal } from "@/shared/ui/FeedbackModal/FeedbackModal";
+
+interface FeedbackWidgetContextProps {
+    openFeedbackModal: () => void;
+}
+
+const FeedbackWidgetContext = createContext<FeedbackWidgetContextProps | undefined>(undefined);
+
+export const FeedbackWidgetProvider: FC<{ children: ReactNode }> = ({ children }) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const value = useMemo(() => ({
+        openFeedbackModal: () => setIsOpen(true),
+    }), []);
+
+    return (
+        <FeedbackWidgetContext.Provider value={value}>
+            {children}
+            <FeedbackModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+        </FeedbackWidgetContext.Provider>
+    );
+};
+
+export const useFeedbackWidget = (): FeedbackWidgetContextProps => {
+    const context = useContext(FeedbackWidgetContext);
+    if (!context) {
+        throw new Error("useFeedbackWidget must be used within FeedbackWidgetProvider");
+    }
+    return context;
+};

--- a/src/entities/Admin/api/adminFeedbackApi.ts
+++ b/src/entities/Admin/api/adminFeedbackApi.ts
@@ -1,0 +1,52 @@
+import { createApi } from "@reduxjs/toolkit/dist/query/react";
+import { baseAdminQueryAcceptJson } from "@/shared/api/baseQuery/baseQuery";
+import {
+    GetAdminFeedback, GetAdminFeedbackListParams, GetAdminFeedbackListResponse,
+    UpdateAdminFeedbackParams,
+} from "../model/types/adminFeedbackSchema";
+
+export const adminFeedbackApi = createApi({
+    reducerPath: "adminFeedbackApi",
+    baseQuery: baseAdminQueryAcceptJson,
+    tagTypes: ["feedback"],
+    endpoints: (build) => ({
+        getAdminFeedbackList: build.query<GetAdminFeedbackListResponse,
+        Partial<GetAdminFeedbackListParams>>({
+            query: (params) => ({
+                url: "feedback/list",
+                method: "GET",
+                params,
+            }),
+            providesTags: ["feedback"],
+        }),
+        getAdminFeedbackById: build.query<GetAdminFeedback, string>({
+            query: (id) => ({
+                url: `feedback/element/${id}`,
+                method: "GET",
+            }),
+            providesTags: ["feedback"],
+        }),
+        updateAdminFeedback: build.mutation<void, UpdateAdminFeedbackParams>({
+            query: ({ id, body }) => ({
+                url: `feedback/edit/${id}`,
+                method: "PATCH",
+                body,
+            }),
+            invalidatesTags: ["feedback"],
+        }),
+        deleteAdminFeedback: build.mutation<void, string>({
+            query: (id) => ({
+                url: `feedback/${id}`,
+                method: "DELETE",
+            }),
+            invalidatesTags: ["feedback"],
+        }),
+    }),
+});
+
+export const {
+    useLazyGetAdminFeedbackListQuery,
+    useGetAdminFeedbackByIdQuery,
+    useUpdateAdminFeedbackMutation,
+    useDeleteAdminFeedbackMutation,
+} = adminFeedbackApi;

--- a/src/entities/Admin/index.ts
+++ b/src/entities/Admin/index.ts
@@ -353,3 +353,17 @@ export {
     adminBannerMarketingListAdapter, adminBannerMarketingApiAdapter,
     adminBannerMarketingAdapter,
 } from "./lib/adminBannerMarketingAdapter";
+
+export {
+    adminFeedbackApi,
+    useLazyGetAdminFeedbackListQuery,
+    useGetAdminFeedbackByIdQuery,
+    useUpdateAdminFeedbackMutation,
+    useDeleteAdminFeedbackMutation,
+} from "./api/adminFeedbackApi";
+
+export type {
+    GetAdminFeedback,
+} from "./model/types/adminFeedbackSchema";
+
+export { FeedbackStatus } from "./model/types/adminFeedbackSchema";

--- a/src/entities/Admin/model/types/adminFeedbackSchema.ts
+++ b/src/entities/Admin/model/types/adminFeedbackSchema.ts
@@ -1,0 +1,33 @@
+import { Pagination } from "@/types/api/pagination";
+import { AdminSort } from "./adminSchema";
+
+export enum FeedbackStatus {
+    New = "NEW",
+    Processed = "PROCESSED",
+}
+
+export interface GetAdminFeedback {
+    id: string;
+    name: string;
+    email: string;
+    message: string;
+    status: FeedbackStatus;
+    created: string;
+}
+
+export interface GetAdminFeedbackListParams {
+    sort: AdminSort;
+    status: FeedbackStatus;
+    page: number;
+    limit: number;
+}
+
+export interface GetAdminFeedbackListResponse {
+    data: GetAdminFeedback[];
+    pagination: Pagination;
+}
+
+export interface UpdateAdminFeedbackParams {
+    id: string;
+    body: { status: FeedbackStatus };
+}

--- a/src/entities/Feedback/api/feedbackApi.ts
+++ b/src/entities/Feedback/api/feedbackApi.ts
@@ -1,0 +1,21 @@
+import { createApi } from "@reduxjs/toolkit/dist/query/react";
+import { baseQueryV3 } from "@/shared/api/baseQuery/baseQuery";
+import { CreateFeedback } from "../model/types/feedback";
+
+export const feedbackApi = createApi({
+    reducerPath: "feedbackApi",
+    baseQuery: baseQueryV3,
+    endpoints: (build) => ({
+        createFeedback: build.mutation<void, CreateFeedback>({
+            query: (body) => ({
+                url: "feedback/create",
+                method: "POST",
+                body,
+            }),
+        }),
+    }),
+});
+
+export const {
+    useCreateFeedbackMutation,
+} = feedbackApi;

--- a/src/entities/Feedback/index.ts
+++ b/src/entities/Feedback/index.ts
@@ -1,0 +1,2 @@
+export { feedbackApi, useCreateFeedbackMutation } from "./api/feedbackApi";
+export type { CreateFeedback } from "./model/types/feedback";

--- a/src/entities/Feedback/model/types/feedback.ts
+++ b/src/entities/Feedback/model/types/feedback.ts
@@ -1,0 +1,5 @@
+export interface CreateFeedback {
+    name: string;
+    email: string;
+    message: string;
+}

--- a/src/pages/AdminFeedbackPage/index.ts
+++ b/src/pages/AdminFeedbackPage/index.ts
@@ -1,0 +1,1 @@
+export { AdminFeedbackPageAsync as AdminFeedbackPage } from "./ui/AdminFeedbackPage.async";

--- a/src/pages/AdminFeedbackPage/ui/AdminFeedbackPage.async.ts
+++ b/src/pages/AdminFeedbackPage/ui/AdminFeedbackPage.async.ts
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+export const AdminFeedbackPageAsync = lazy(() => import("./AdminFeedbackPage"));

--- a/src/pages/AdminFeedbackPage/ui/AdminFeedbackPage.tsx
+++ b/src/pages/AdminFeedbackPage/ui/AdminFeedbackPage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { AdminFeedbackTable } from "@/widgets/Admin";
+
+const AdminFeedbackPage = () => (
+    <div>
+        <h1>Обратная связь</h1>
+        <AdminFeedbackTable />
+    </div>
+);
+
+export default AdminFeedbackPage;

--- a/src/pages/AdminFeedbackPersonalPage/index.ts
+++ b/src/pages/AdminFeedbackPersonalPage/index.ts
@@ -1,0 +1,1 @@
+export { AdminFeedbackPersonalPageAsync as AdminFeedbackPersonalPage } from "./ui/AdminFeedbackPersonalPage.async";

--- a/src/pages/AdminFeedbackPersonalPage/ui/AdminFeedbackPersonalPage.async.ts
+++ b/src/pages/AdminFeedbackPersonalPage/ui/AdminFeedbackPersonalPage.async.ts
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+export const AdminFeedbackPersonalPageAsync = lazy(() => import("./AdminFeedbackPersonalPage"));

--- a/src/pages/AdminFeedbackPersonalPage/ui/AdminFeedbackPersonalPage.tsx
+++ b/src/pages/AdminFeedbackPersonalPage/ui/AdminFeedbackPersonalPage.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { AdminFeedbackInfo } from "@/widgets/Admin";
+
+const AdminFeedbackPersonalPage = () => {
+    const { id } = useParams<{ id: string }>();
+
+    if (!id) {
+        return (
+            <div>
+                <h2>Произошла ошибка! Неверный id обращения</h2>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <AdminFeedbackInfo feedbackId={id} />
+        </div>
+    );
+};
+
+export default AdminFeedbackPersonalPage;

--- a/src/routes/model/config/RoutesConfig.tsx
+++ b/src/routes/model/config/RoutesConfig.tsx
@@ -225,6 +225,8 @@ import {
     getAdminSystemAdminCreatePageUrl,
     getAdminBannerMarketingPageUrl,
     getAdminBannerMarketingCreatePageUrl,
+    getAdminFeedbackPageUrl,
+    getAdminFeedbackPersonalPageUrl,
 } from "@/shared/config/routes/AppUrls";
 import { AuthRoutes } from "@/shared/config/routes/AuthRoutes";
 
@@ -324,6 +326,8 @@ import { AdminSystemAdminPage } from "@/pages/AdminSystemAdminPage";
 import { AdminSystemAdminCreatePage } from "@/pages/AdminSystemAdminCreatePage";
 import { AdminBannerMarketingPage } from "@/pages/AdminBannerMarketingPage";
 import { AdminBannerMarketingCreatePage } from "@/pages/AdminBannerMarketingCreatePage";
+import { AdminFeedbackPage } from "@/pages/AdminFeedbackPage";
+import { AdminFeedbackPersonalPage } from "@/pages/AdminFeedbackPersonalPage";
 
 const publicRoutes: RouteType[] = [
     {
@@ -1129,6 +1133,16 @@ const publicRoutes: RouteType[] = [
                 label: "admin-banner-marketing-create",
                 element: <AdminBannerMarketingCreatePage />,
                 path: (locale: string) => getAdminBannerMarketingCreatePageUrl(locale),
+            },
+            {
+                label: "admin-feedback",
+                element: <AdminFeedbackPage />,
+                path: (locale: string) => getAdminFeedbackPageUrl(locale),
+            },
+            {
+                label: "admin-feedback-personal",
+                element: <AdminFeedbackPersonalPage />,
+                path: (locale: string) => getAdminFeedbackPersonalPageUrl(locale),
             },
         ],
     },

--- a/src/shared/config/routes/AppRoutes.ts
+++ b/src/shared/config/routes/AppRoutes.ts
@@ -128,4 +128,5 @@ export enum AppRoutes {
     ADMIN_OUR_TEAM = "admin_our_team",
     ADMIN_SYSTEM_ADMIN = "admin_system_admin",
     ADMIN_BANNER_MARKETING = "admin_banner_marketing",
+    ADMIN_FEEDBACK = "admin_feedback",
 }

--- a/src/shared/config/routes/AppUrls.ts
+++ b/src/shared/config/routes/AppUrls.ts
@@ -420,3 +420,9 @@ export const getAdminBannerMarketingPageUrl: RoutePathFunction = (locale) => `/$
 export const getAdminBannerMarketingCreatePageUrl: RoutePathFunction = (locale) => `/${locale}${RoutePath.admin_banner_marketing}/create`;
 
 export const getAdminBannerMarketingPersonalPageUrl: RoutePathFunction = (locale, id = ":id") => `/${locale}${RoutePath.admin_banner_marketing}/${id}`;
+
+// Admin Feedback
+
+export const getAdminFeedbackPageUrl: RoutePathFunction = (locale) => `/${locale}${RoutePath.admin_feedback}`;
+
+export const getAdminFeedbackPersonalPageUrl: RoutePathFunction = (locale, id = ":id") => `/${locale}${RoutePath.admin_feedback}/${id}`;

--- a/src/shared/config/routes/RouterConfig.ts
+++ b/src/shared/config/routes/RouterConfig.ts
@@ -137,4 +137,5 @@ export const RoutePath: Record<AppRoutes, string> = {
     [AppRoutes.ADMIN_OUR_TEAM]: "/admin/our-team",
     [AppRoutes.ADMIN_SYSTEM_ADMIN]: "/admin/system-admin",
     [AppRoutes.ADMIN_BANNER_MARKETING]: "/admin/banner-marketing",
+    [AppRoutes.ADMIN_FEEDBACK]: "/admin/feedback",
 };

--- a/src/shared/data/sidebar/admin-pages/index.ts
+++ b/src/shared/data/sidebar/admin-pages/index.ts
@@ -123,6 +123,17 @@ export const useAdminPagesSidebarData = () => {
         },
         {
             route: "/admin",
+            text: "Обратная связь",
+            dropdownItems: [
+                {
+                    route: "/feedback",
+                    text: "Обращения",
+                },
+            ],
+
+        },
+        {
+            route: "/admin",
             text: "Система",
             dropdownItems: [
                 {

--- a/src/shared/ui/FeedbackModal/FeedbackModal.module.scss
+++ b/src/shared/ui/FeedbackModal/FeedbackModal.module.scss
@@ -61,6 +61,11 @@
     color: var(--gray-color, #7a7a7a);
 }
 
+.submitButton {
+    padding: 12px 20px;
+    width: 100%;
+}
+
 @keyframes pop-in {
     from {
         opacity: 0;

--- a/src/shared/ui/FeedbackModal/FeedbackModal.module.scss
+++ b/src/shared/ui/FeedbackModal/FeedbackModal.module.scss
@@ -1,36 +1,83 @@
-.wrapper {
-    background-color: #fff;
-    padding: 25px;
-    border-radius: 20px;
+.backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 997;
+    background: transparent;
+}
+
+.panel {
+    position: fixed;
+    right: 24px;
+    bottom: 92px;
+    z-index: 999;
+
     display: flex;
     flex-direction: column;
-    max-width: 500px;
-    width: 100%;
-    gap: 15px;
-    transition: all 0.3s ease;
-    opacity: 0;
-    visibility: hidden;
-    transform: translateY(20px);
+    gap: 12px;
 
-    &.active {
-        opacity: 1;
-        transform: translateY(0);
-        visibility: visible;
+    width: 340px;
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+
+    padding: 20px;
+    background-color: #fff;
+    border-radius: 16px;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+
+    animation: pop-in 0.15s ease-out;
+
+    h2 {
+        margin: 0;
+        padding-right: 20px;
+        font-size: 1.1rem;
     }
 }
 
-.modalWrapper {
-    opacity: 0;
-    visibility: hidden;
-    transition: all 0.3s ease;
+.closeButton {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    width: 14px;
+    height: 14px;
+}
 
-    &.active {
-        opacity: 1;
-        visibility: visible;
+.closeIcon {
+    display: flex;
+    width: 100%;
+    height: 100%;
+
+    svg path {
+        fill: #333;
     }
 }
 
 .description {
     margin: 0;
     color: var(--gray-color, #7a7a7a);
+}
+
+@keyframes pop-in {
+    from {
+        opacity: 0;
+        transform: translateY(8px) scale(0.98);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@media (max-width: 480px) {
+    .panel {
+        right: 16px;
+        bottom: 76px;
+        left: 16px;
+        width: auto;
+    }
 }

--- a/src/shared/ui/FeedbackModal/FeedbackModal.module.scss
+++ b/src/shared/ui/FeedbackModal/FeedbackModal.module.scss
@@ -1,0 +1,36 @@
+.wrapper {
+    background-color: #fff;
+    padding: 25px;
+    border-radius: 20px;
+    display: flex;
+    flex-direction: column;
+    max-width: 500px;
+    width: 100%;
+    gap: 15px;
+    transition: all 0.3s ease;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(20px);
+
+    &.active {
+        opacity: 1;
+        transform: translateY(0);
+        visibility: visible;
+    }
+}
+
+.modalWrapper {
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s ease;
+
+    &.active {
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+.description {
+    margin: 0;
+    color: var(--gray-color, #7a7a7a);
+}

--- a/src/shared/ui/FeedbackModal/FeedbackModal.test.tsx
+++ b/src/shared/ui/FeedbackModal/FeedbackModal.test.tsx
@@ -1,0 +1,40 @@
+import {
+    describe, it, expect,
+} from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "@/test-utils";
+import { FeedbackModal } from "./FeedbackModal";
+
+/**
+ * Row 52: форма обратной связи — "Напишите нам" в футере раньше вело на
+ * голый vk.com. Регресс-guard на клиентскую валидацию модалки: кнопка
+ * "Отправить" должна оставаться заблокированной, пока не заполнены все
+ * поля и email не проходит базовую проверку формата.
+ */
+describe("FeedbackModal", () => {
+    it("кнопка отправки заблокирована, пока форма не заполнена", () => {
+        renderWithProviders(<FeedbackModal isOpen onClose={() => {}} />);
+
+        expect(screen.getByRole("button", { name: "Отправить" })).toBeDisabled();
+    });
+
+    it("кнопка остаётся заблокированной при некорректном email", () => {
+        renderWithProviders(<FeedbackModal isOpen onClose={() => {}} />);
+
+        fireEvent.change(screen.getByLabelText("Ваше имя"), { target: { value: "Роман" } });
+        fireEvent.change(screen.getByLabelText("E-mail"), { target: { value: "not-an-email" } });
+        fireEvent.change(screen.getByLabelText("Сообщение"), { target: { value: "Привет" } });
+
+        expect(screen.getByRole("button", { name: "Отправить" })).toBeDisabled();
+    });
+
+    it("кнопка разблокируется, когда все поля заполнены корректно", () => {
+        renderWithProviders(<FeedbackModal isOpen onClose={() => {}} />);
+
+        fireEvent.change(screen.getByLabelText("Ваше имя"), { target: { value: "Роман" } });
+        fireEvent.change(screen.getByLabelText("E-mail"), { target: { value: "roman@test.com" } });
+        fireEvent.change(screen.getByLabelText("Сообщение"), { target: { value: "Привет" } });
+
+        expect(screen.getByRole("button", { name: "Отправить" })).toBeEnabled();
+    });
+});

--- a/src/shared/ui/FeedbackModal/FeedbackModal.tsx
+++ b/src/shared/ui/FeedbackModal/FeedbackModal.tsx
@@ -76,12 +76,14 @@ export const FeedbackModal: FC<FeedbackModalProps> = (props) => {
             <div className={cn(styles.wrapper, { [styles.active]: isOpen })}>
                 <h2>Напишите нам</h2>
                 <Input
+                    id="feedback-name"
                     label="Ваше имя"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     maxLength={255}
                 />
                 <Input
+                    id="feedback-email"
                     label="E-mail"
                     type="email"
                     value={email}
@@ -89,6 +91,7 @@ export const FeedbackModal: FC<FeedbackModalProps> = (props) => {
                     maxLength={255}
                 />
                 <Textarea
+                    id="feedback-message"
                     label="Сообщение"
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}

--- a/src/shared/ui/FeedbackModal/FeedbackModal.tsx
+++ b/src/shared/ui/FeedbackModal/FeedbackModal.tsx
@@ -1,13 +1,14 @@
-import cn from "classnames";
 import React, { FC, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { useCreateFeedbackMutation } from "@/entities/Feedback";
 
 import Button from "../Button/Button";
-import { Modal } from "../Modal/Modal";
 import Input from "../Input/Input";
 import Textarea from "../Textarea/Textarea";
 import { ErrorText } from "../ErrorText/ErrorText";
+import IconComponent from "../IconComponent/IconComponent";
+import closeIcon from "@/shared/assets/icons/delete.svg";
 import styles from "./FeedbackModal.module.scss";
 
 const EMAIL_REGEXP = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -53,61 +54,67 @@ export const FeedbackModal: FC<FeedbackModalProps> = (props) => {
         }
     };
 
-    if (isSent) {
-        return (
-            <Modal onClose={handleClose} isShowCloseIcon>
-                <div className={cn(styles.wrapper, { [styles.active]: isOpen })}>
-                    <h2>Спасибо! Ваше сообщение отправлено.</h2>
-                    <p className={styles.description}>Мы ответим вам на указанный email.</p>
-                    <Button onClick={handleClose} variant="FILL" size="MEDIUM" color="BLUE">
-                        Закрыть
-                    </Button>
-                </div>
-            </Modal>
-        );
-    }
+    if (!isOpen) return null;
 
-    return (
-        <Modal
-            onClose={handleClose}
-            isShowCloseIcon
-            className={cn(styles.modalWrapper, { [styles.active]: isOpen })}
-        >
-            <div className={cn(styles.wrapper, { [styles.active]: isOpen })}>
-                <h2>Напишите нам</h2>
-                <Input
-                    id="feedback-name"
-                    label="Ваше имя"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    maxLength={255}
-                />
-                <Input
-                    id="feedback-email"
-                    label="E-mail"
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    maxLength={255}
-                />
-                <Textarea
-                    id="feedback-message"
-                    label="Сообщение"
-                    value={message}
-                    onChange={(e) => setMessage(e.target.value)}
-                    maxLength={2000}
-                />
-                {errorText && (<ErrorText text={errorText} />)}
-                <Button
-                    onClick={handleSubmit}
-                    variant="FILL"
-                    size="MEDIUM"
-                    color="BLUE"
-                    disabled={!isValid || isLoading}
+    return createPortal(
+        <>
+            <div className={styles.backdrop} onClick={handleClose} />
+            <div className={styles.panel}>
+                <button
+                    type="button"
+                    className={styles.closeButton}
+                    onClick={handleClose}
+                    aria-label="Закрыть"
                 >
-                    Отправить
-                </Button>
+                    <IconComponent icon={closeIcon} alt="close" className={styles.closeIcon} />
+                </button>
+                {isSent ? (
+                    <>
+                        <h2>Спасибо! Ваше сообщение отправлено.</h2>
+                        <p className={styles.description}>Мы ответим вам на указанный email.</p>
+                        <Button onClick={handleClose} variant="FILL" size="MEDIUM" color="BLUE">
+                            Закрыть
+                        </Button>
+                    </>
+                ) : (
+                    <>
+                        <h2>Напишите нам</h2>
+                        <Input
+                            id="feedback-name"
+                            label="Ваше имя"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            maxLength={255}
+                        />
+                        <Input
+                            id="feedback-email"
+                            label="E-mail"
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            maxLength={255}
+                        />
+                        <Textarea
+                            id="feedback-message"
+                            label="Сообщение"
+                            value={message}
+                            onChange={(e) => setMessage(e.target.value)}
+                            maxLength={2000}
+                        />
+                        {errorText && (<ErrorText text={errorText} />)}
+                        <Button
+                            onClick={handleSubmit}
+                            variant="FILL"
+                            size="MEDIUM"
+                            color="BLUE"
+                            disabled={!isValid || isLoading}
+                        >
+                            Отправить
+                        </Button>
+                    </>
+                )}
             </div>
-        </Modal>
+        </>,
+        document.body,
     );
 };

--- a/src/shared/ui/FeedbackModal/FeedbackModal.tsx
+++ b/src/shared/ui/FeedbackModal/FeedbackModal.tsx
@@ -1,0 +1,110 @@
+import cn from "classnames";
+import React, { FC, useState } from "react";
+
+import { useCreateFeedbackMutation } from "@/entities/Feedback";
+
+import Button from "../Button/Button";
+import { Modal } from "../Modal/Modal";
+import Input from "../Input/Input";
+import Textarea from "../Textarea/Textarea";
+import { ErrorText } from "../ErrorText/ErrorText";
+import styles from "./FeedbackModal.module.scss";
+
+const EMAIL_REGEXP = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface FeedbackModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export const FeedbackModal: FC<FeedbackModalProps> = (props) => {
+    const { isOpen, onClose } = props;
+
+    const [name, setName] = useState("");
+    const [email, setEmail] = useState("");
+    const [message, setMessage] = useState("");
+    const [isSent, setIsSent] = useState(false);
+    const [errorText, setErrorText] = useState<string | undefined>();
+
+    const [createFeedback, { isLoading }] = useCreateFeedbackMutation();
+
+    const isValid = name.trim() !== ""
+        && EMAIL_REGEXP.test(email.trim())
+        && message.trim() !== "";
+
+    const handleClose = () => {
+        onClose();
+        setName("");
+        setEmail("");
+        setMessage("");
+        setIsSent(false);
+        setErrorText(undefined);
+    };
+
+    const handleSubmit = async () => {
+        if (!isValid) return;
+        setErrorText(undefined);
+
+        try {
+            await createFeedback({ name, email, message }).unwrap();
+            setIsSent(true);
+        } catch {
+            setErrorText("Не удалось отправить сообщение. Попробуйте ещё раз.");
+        }
+    };
+
+    if (isSent) {
+        return (
+            <Modal onClose={handleClose} isShowCloseIcon>
+                <div className={cn(styles.wrapper, { [styles.active]: isOpen })}>
+                    <h2>Спасибо! Ваше сообщение отправлено.</h2>
+                    <p className={styles.description}>Мы ответим вам на указанный email.</p>
+                    <Button onClick={handleClose} variant="FILL" size="MEDIUM" color="BLUE">
+                        Закрыть
+                    </Button>
+                </div>
+            </Modal>
+        );
+    }
+
+    return (
+        <Modal
+            onClose={handleClose}
+            isShowCloseIcon
+            className={cn(styles.modalWrapper, { [styles.active]: isOpen })}
+        >
+            <div className={cn(styles.wrapper, { [styles.active]: isOpen })}>
+                <h2>Напишите нам</h2>
+                <Input
+                    label="Ваше имя"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    maxLength={255}
+                />
+                <Input
+                    label="E-mail"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    maxLength={255}
+                />
+                <Textarea
+                    label="Сообщение"
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    maxLength={2000}
+                />
+                {errorText && (<ErrorText text={errorText} />)}
+                <Button
+                    onClick={handleSubmit}
+                    variant="FILL"
+                    size="MEDIUM"
+                    color="BLUE"
+                    disabled={!isValid || isLoading}
+                >
+                    Отправить
+                </Button>
+            </div>
+        </Modal>
+    );
+};

--- a/src/shared/ui/FeedbackModal/FeedbackModal.tsx
+++ b/src/shared/ui/FeedbackModal/FeedbackModal.tsx
@@ -1,5 +1,7 @@
 import React, { FC, useState } from "react";
 import { createPortal } from "react-dom";
+import { CircularProgress } from "@mui/material";
+import cn from "classnames";
 
 import { useCreateFeedbackMutation } from "@/entities/Feedback";
 
@@ -10,6 +12,7 @@ import { ErrorText } from "../ErrorText/ErrorText";
 import IconComponent from "../IconComponent/IconComponent";
 import closeIcon from "@/shared/assets/icons/delete.svg";
 import styles from "./FeedbackModal.module.scss";
+import buttonStyles from "../Button/Button.module.scss";
 
 const EMAIL_REGEXP = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -57,7 +60,10 @@ export const FeedbackModal: FC<FeedbackModalProps> = (props) => {
     if (!isOpen) return null;
 
     return createPortal(
-        <>
+        // "modal" class matches the selector in _default.scss that defines
+        // theme CSS variables (--accent-color etc.) — without it, anything
+        // portaled straight to <body> renders colourless (buttons, borders).
+        <div className="modal">
             <div className={styles.backdrop} onClick={handleClose} />
             <div className={styles.panel}>
                 <button
@@ -102,19 +108,28 @@ export const FeedbackModal: FC<FeedbackModalProps> = (props) => {
                             maxLength={2000}
                         />
                         {errorText && (<ErrorText text={errorText} />)}
-                        <Button
+                        <button
+                            type="button"
                             onClick={handleSubmit}
-                            variant="FILL"
-                            size="MEDIUM"
-                            color="BLUE"
                             disabled={!isValid || isLoading}
+                            className={cn(
+                                buttonStyles.btn,
+                                buttonStyles.FILL,
+                                buttonStyles.BLUE,
+                                buttonStyles.MEDIUM,
+                                styles.submitButton,
+                            )}
                         >
-                            Отправить
-                        </Button>
+                            {isLoading ? (
+                                <CircularProgress size={20} sx={{ color: "#fff" }} />
+                            ) : (
+                                <span className={buttonStyles.text}>Отправить</span>
+                            )}
+                        </button>
                     </>
                 )}
             </div>
-        </>,
+        </div>,
         document.body,
     );
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -28,6 +28,7 @@ import {
     adminOurTeamApi,
     adminSystemApi,
     adminBannerMarketingApi,
+    adminFeedbackApi,
 } from "@/entities/Admin";
 import { courseApi } from "@/entities/Academy";
 import { newsApi } from "@/entities/News";
@@ -37,6 +38,7 @@ import { videoApi } from "@/entities/Video";
 import { donationApi } from "@/entities/Donation";
 import { membershipApi } from "./api/membershipApi";
 import { donationPaymentApi } from "./api/donationPaymentApi";
+import { feedbackApi } from "@/entities/Feedback";
 
 const combinedReducer = combineReducers({
     register: registerReducer,
@@ -73,6 +75,8 @@ const combinedReducer = combineReducers({
     [donationPaymentApi.reducerPath]: donationPaymentApi.reducer,
     [adminSystemApi.reducerPath]: adminSystemApi.reducer,
     [adminBannerMarketingApi.reducerPath]: adminBannerMarketingApi.reducer,
+    [feedbackApi.reducerPath]: feedbackApi.reducer,
+    [adminFeedbackApi.reducerPath]: adminFeedbackApi.reducer,
 });
 
 // При выходе из аккаунта сбрасываем весь стейт к initial: это очищает кэши RTK Query
@@ -132,6 +136,8 @@ export const setupStore = () => configureStore({
         donationPaymentApi.middleware,
         adminSystemApi.middleware,
         adminBannerMarketingApi.middleware,
+        feedbackApi.middleware,
+        adminFeedbackApi.middleware,
         authMiddleware,
     ]),
 });

--- a/src/widgets/Admin/index.ts
+++ b/src/widgets/Admin/index.ts
@@ -70,3 +70,5 @@ export { AdminOurTeamInfo } from "./ui/AdminOurTeamInfo/AdminOurTeamInfo";
 export { AdminSystemAdminTable } from "./ui/AdminSystemAdminTable/AdminSystemAdminTable";
 
 export { AdminBannerMarketingTable } from "./ui/AdminBannerMarketingTable/AdminBannerMarketingTable";
+export { AdminFeedbackTable } from "./ui/AdminFeedbackTable/AdminFeedbackTable";
+export { AdminFeedbackInfo } from "./ui/AdminFeedbackInfo/AdminFeedbackInfo";

--- a/src/widgets/Admin/ui/AdminFeedbackInfo/AdminFeedbackInfo.module.scss
+++ b/src/widgets/Admin/ui/AdminFeedbackInfo/AdminFeedbackInfo.module.scss
@@ -1,0 +1,36 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    max-width: 700px;
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 20px;
+    border: 1px solid var(--border-color, #e0e0e0);
+    border-radius: 12px;
+}
+
+.row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.label {
+    font-size: 0.8rem;
+    color: var(--text-caption, #7a7a7a);
+}
+
+.message {
+    margin: 0;
+    white-space: pre-wrap;
+}
+
+.actions {
+    display: flex;
+    gap: 12px;
+}

--- a/src/widgets/Admin/ui/AdminFeedbackInfo/AdminFeedbackInfo.tsx
+++ b/src/widgets/Admin/ui/AdminFeedbackInfo/AdminFeedbackInfo.tsx
@@ -1,0 +1,157 @@
+import React, { FC, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+    FeedbackStatus,
+    useDeleteAdminFeedbackMutation,
+    useGetAdminFeedbackByIdQuery,
+    useUpdateAdminFeedbackMutation,
+} from "@/entities/Admin";
+import { HintType, ToastAlert } from "@/shared/ui/HintPopup/HintPopup.interface";
+import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
+import HintPopup from "@/shared/ui/HintPopup/HintPopup";
+import { Breadcrumbs } from "@/shared/ui/Breadcrumbs/Breadcrumbs";
+import { getAdminFeedbackPageUrl } from "@/shared/config/routes/AppUrls";
+import { useLocale } from "@/app/providers/LocaleProvider";
+import Button from "@/shared/ui/Button/Button";
+import { ConfirmActionModal } from "@/shared/ui/ConfirmActionModal/ConfirmActionModal";
+import styles from "./AdminFeedbackInfo.module.scss";
+
+interface AdminFeedbackInfoProps {
+    feedbackId: string;
+}
+
+const STATUS_LABEL: Record<FeedbackStatus, string> = {
+    [FeedbackStatus.New]: "Новое",
+    [FeedbackStatus.Processed]: "Обработано",
+};
+
+export const AdminFeedbackInfo: FC<AdminFeedbackInfoProps> = (props) => {
+    const { feedbackId } = props;
+    const { data: feedback, isLoading } = useGetAdminFeedbackByIdQuery(feedbackId);
+    const [updateFeedback, { isLoading: isUpdating }] = useUpdateAdminFeedbackMutation();
+    const [deleteFeedback, { isLoading: isDeleting }] = useDeleteAdminFeedbackMutation();
+    const [toast, setToast] = useState<ToastAlert>();
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const { locale } = useLocale();
+    const navigate = useNavigate();
+
+    const handleToggleStatus = async () => {
+        if (!feedback) return;
+        setToast(undefined);
+
+        const nextStatus = feedback.status === FeedbackStatus.New
+            ? FeedbackStatus.Processed
+            : FeedbackStatus.New;
+
+        try {
+            await updateFeedback({
+                id: feedbackId,
+                body: { status: nextStatus },
+            }).unwrap();
+            setToast({
+                text: "Статус обращения обновлён",
+                type: HintType.Success,
+            });
+        } catch {
+            setToast({
+                text: "Произошла ошибка при обновлении статуса",
+                type: HintType.Error,
+            });
+        }
+    };
+
+    const handleConfirmDelete = async () => {
+        try {
+            await deleteFeedback(feedbackId).unwrap();
+            navigate(getAdminFeedbackPageUrl(locale));
+        } catch {
+            setToast({
+                text: "Произошла ошибка при удалении",
+                type: HintType.Error,
+            });
+            setIsDeleteModalOpen(false);
+        }
+    };
+
+    if (isLoading) {
+        return (<MiniLoader />);
+    }
+
+    if (!feedback) {
+        return (
+            <div className={styles.wrapper}>
+                <h1>Обращение</h1>
+                <Breadcrumbs items={[{ label: "Обращения", to: getAdminFeedbackPageUrl(locale) },
+                    { label: "Просмотр обращения" },
+                ]}
+                />
+                <h2>Данные по данному обращению отсутствуют</h2>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.wrapper}>
+            {toast && <HintPopup text={toast.text} type={toast.type} />}
+            <h1>Обращение</h1>
+            <Breadcrumbs items={[{ label: "Обращения", to: getAdminFeedbackPageUrl(locale) },
+                { label: "Просмотр обращения" },
+            ]}
+            />
+            <div className={styles.card}>
+                <div className={styles.row}>
+                    <span className={styles.label}>Дата</span>
+                    <span>{feedback.created}</span>
+                </div>
+                <div className={styles.row}>
+                    <span className={styles.label}>Имя</span>
+                    <span>{feedback.name}</span>
+                </div>
+                <div className={styles.row}>
+                    <span className={styles.label}>E-mail</span>
+                    <a href={`mailto:${feedback.email}`}>{feedback.email}</a>
+                </div>
+                <div className={styles.row}>
+                    <span className={styles.label}>Статус</span>
+                    <span>{STATUS_LABEL[feedback.status]}</span>
+                </div>
+                <div className={styles.row}>
+                    <span className={styles.label}>Сообщение</span>
+                    <p className={styles.message}>{feedback.message}</p>
+                </div>
+            </div>
+            <div className={styles.actions}>
+                <Button
+                    onClick={handleToggleStatus}
+                    variant="FILL"
+                    size="MEDIUM"
+                    color="BLUE"
+                    disabled={isUpdating}
+                >
+                    {feedback.status === FeedbackStatus.New
+                        ? "Отметить обработанным"
+                        : "Вернуть в новые"}
+                </Button>
+                <Button
+                    onClick={() => setIsDeleteModalOpen(true)}
+                    variant="OUTLINE"
+                    size="MEDIUM"
+                    color="RED"
+                    disabled={isDeleting}
+                >
+                    Удалить
+                </Button>
+            </div>
+            <ConfirmActionModal
+                isModalOpen={isDeleteModalOpen}
+                description="Вы уверены, что хотите удалить это обращение? Это действие нельзя отменить."
+                onConfirm={handleConfirmDelete}
+                onClose={() => setIsDeleteModalOpen(false)}
+                confirmTextButton="Удалить"
+                cancelTextButton="Отмена"
+                isLoading={isDeleting}
+                buttonsDisabled={isDeleting}
+            />
+        </div>
+    );
+};

--- a/src/widgets/Admin/ui/AdminFeedbackTable/AdminFeedbackTable.module.scss
+++ b/src/widgets/Admin/ui/AdminFeedbackTable/AdminFeedbackTable.module.scss
@@ -1,0 +1,50 @@
+.wrapper {
+    height: 70vh;
+}
+
+.actionButtons {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+}
+
+.btn {
+    padding: 10px 20px;
+}
+
+.btnIcon {
+    background: transparent;
+    border: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.btnIcon svg {
+    width: 25px;
+    height: auto;
+    transition: all 0.3 ease;
+}
+
+.btnIcon:hover {
+    scale: 1.05;
+}
+
+.btnShow g {
+    fill: var(--accent-color);
+}
+
+.btnBlock g {
+    fill: var(--text-caption);
+}
+
+.btnDelete g {
+    fill: var(--error-color);
+}
+
+.btnDelete {
+    &:disabled {
+        opacity: 0.6;
+    }
+}

--- a/src/widgets/Admin/ui/AdminFeedbackTable/AdminFeedbackTable.tsx
+++ b/src/widgets/Admin/ui/AdminFeedbackTable/AdminFeedbackTable.tsx
@@ -1,0 +1,305 @@
+import React, { useEffect, useState } from "react";
+import {
+    FormControl, InputLabel, MenuItem, Select, Stack,
+} from "@mui/material";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { useNavigate } from "react-router-dom";
+import { ReactSVG } from "react-svg";
+import cn from "classnames";
+import { getAdminFeedbackPersonalPageUrl } from "@/shared/config/routes/AppUrls";
+import { useLocale } from "@/app/providers/LocaleProvider";
+
+import showIcon from "@/shared/assets/icons/admin/show.svg";
+import deleteIcon from "@/shared/assets/icons/admin/delete.svg";
+import {
+    AdminFiltersTable, CustomFilterField,
+} from "@/shared/ui/AdminFiltersTable/AdminFiltersTable";
+import { HintType, ToastAlert } from "@/shared/ui/HintPopup/HintPopup.interface";
+import {
+    AdminSort, FeedbackStatus,
+    useDeleteAdminFeedbackMutation, useLazyGetAdminFeedbackListQuery,
+} from "@/entities/Admin";
+import HintPopup from "@/shared/ui/HintPopup/HintPopup";
+import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
+import { OfferPagination } from "@/widgets/OffersMap";
+import { ConfirmActionModal } from "@/shared/ui/ConfirmActionModal/ConfirmActionModal";
+import { useQueryFilters } from "@/shared/hooks/usePaginationParams";
+import styles from "./AdminFeedbackTable.module.scss";
+
+const PER_PAGE = 30;
+
+interface FeedbackFilters {
+    sort?: AdminSort;
+    status?: FeedbackStatus;
+}
+
+const STATUS_LABEL: Record<FeedbackStatus, string> = {
+    [FeedbackStatus.New]: "Новое",
+    [FeedbackStatus.Processed]: "Обработано",
+};
+
+const customFields: CustomFilterField<keyof FeedbackFilters>[] = [
+    {
+        key: "status",
+        label: "Статус",
+        render: ({ value, onChange, disabled }) => (
+            <FormControl fullWidth size="small" disabled={disabled}>
+                <InputLabel id="status-filter-label" sx={{ background: "background.paper", px: 0.5 }}>
+                    Статус
+                </InputLabel>
+                <Select
+                    labelId="status-filter-label"
+                    value={value ?? ""}
+                    label="Статус"
+                    onChange={(e) => {
+                        const raw = e.target.value;
+                        onChange((raw || undefined) as FeedbackStatus | undefined);
+                    }}
+                >
+                    <MenuItem value="">Все</MenuItem>
+                    <MenuItem value={FeedbackStatus.New}>
+                        {STATUS_LABEL[FeedbackStatus.New]}
+                    </MenuItem>
+                    <MenuItem value={FeedbackStatus.Processed}>
+                        {STATUS_LABEL[FeedbackStatus.Processed]}
+                    </MenuItem>
+                </Select>
+            </FormControl>
+        ),
+    },
+    {
+        key: "sort",
+        label: "Сортировка",
+        render: ({ value, onChange, disabled }) => (
+            <FormControl fullWidth size="small" disabled={disabled}>
+                <InputLabel id="feedback-sort-label" sx={{ background: "background.paper", px: 0.5 }}>
+                    Сортировка
+                </InputLabel>
+                <Select
+                    labelId="feedback-sort-label"
+                    value={value || AdminSort.CreatedDesc}
+                    label="Сортировка"
+                    onChange={(e) => onChange(e.target.value as AdminSort)}
+                >
+                    <MenuItem value={AdminSort.CreatedDesc}>Дата ↓</MenuItem>
+                    <MenuItem value={AdminSort.CreatedAsc}>Дата ↑</MenuItem>
+                </Select>
+            </FormControl>
+        ),
+    },
+];
+
+export const AdminFeedbackTable = () => {
+    const navigate = useNavigate();
+    const { locale } = useLocale();
+    const [toast, setToast] = useState<ToastAlert>();
+    const {
+        filters, setFilters,
+    } = useQueryFilters({
+        page: 1,
+        sort: AdminSort.CreatedDesc,
+        status: undefined as FeedbackStatus | undefined,
+    });
+
+    const [feedbackToDelete, setFeedbackToDelete] = useState<
+    { id: string; } | null>(null);
+    const [getFeedbackList, {
+        data: feedbackData,
+        isLoading,
+        isFetching,
+    }] = useLazyGetAdminFeedbackListQuery();
+    const [deleteFeedback, { isLoading: isDeleting }] = useDeleteAdminFeedbackMutation();
+
+    useEffect(() => {
+        const fetchData = async () => {
+            setToast(undefined);
+            try {
+                await getFeedbackList({
+                    page: filters.page,
+                    limit: PER_PAGE,
+                    sort: filters.sort ?? AdminSort.CreatedDesc,
+                    status: filters.status,
+                }).unwrap();
+            } catch {
+                setToast({
+                    text: "Произошла ошибка при загрузке обращений",
+                    type: HintType.Error,
+                });
+            }
+        };
+
+        fetchData();
+    }, [filters.page, filters.sort, filters.status, getFeedbackList]);
+
+    const handleOpenDeleteModal = (idValue: string) => {
+        setFeedbackToDelete({ id: idValue });
+    };
+
+    const handleCloseDeleteModal = () => {
+        setFeedbackToDelete(null);
+    };
+
+    const handleConfirmDelete = async () => {
+        setToast(undefined);
+        if (!feedbackToDelete) return;
+
+        try {
+            await deleteFeedback(feedbackToDelete.id).unwrap();
+            setToast({
+                text: "Обращение было успешно удалено",
+                type: HintType.Success,
+            });
+        } catch {
+            setToast({
+                text: "Произошла ошибка при удалении",
+                type: HintType.Error,
+            });
+        } finally {
+            handleCloseDeleteModal();
+        }
+    };
+
+    const columns: GridColDef[] = [
+        {
+            field: "created",
+            headerName: "Дата",
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            width: 140,
+        },
+        {
+            field: "name",
+            headerName: "Имя",
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            width: 160,
+        },
+        {
+            field: "email",
+            headerName: "E-mail",
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            width: 200,
+        },
+        {
+            field: "message",
+            headerName: "Сообщение",
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            width: 300,
+        },
+        {
+            field: "status",
+            headerName: "Статус",
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            width: 140,
+            valueGetter: (params) => STATUS_LABEL[params.value as FeedbackStatus],
+        },
+        {
+            field: "actions",
+            headerName: "Действия",
+            width: 120,
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            renderCell: (params) => {
+                const handleView = () => navigate(
+                    getAdminFeedbackPersonalPageUrl(locale, params.row.id),
+                );
+                const handleDeleteClick = () => {
+                    handleOpenDeleteModal(params.row.id);
+                };
+
+                return (
+                    <Stack direction="row" spacing={1}>
+                        <button
+                            onClick={handleView}
+                            type="button"
+                            title="Показать обращение"
+                            className={cn(styles.btnIcon, styles.btnShow)}
+                        >
+                            <ReactSVG src={showIcon} />
+                        </button>
+                        <button
+                            onClick={handleDeleteClick}
+                            type="button"
+                            title="Удалить обращение"
+                            className={cn(styles.btnIcon, styles.btnDelete)}
+                            disabled={isDeleting}
+                        >
+                            <ReactSVG src={deleteIcon} />
+                        </button>
+                    </Stack>
+                );
+            },
+        },
+    ];
+
+    if (isLoading || isFetching) {
+        return (
+            <MiniLoader />
+        );
+    }
+
+    const renderTable = () => {
+        if (!feedbackData) {
+            return <span>Обращений не найдено</span>;
+        }
+        return (
+            <DataGrid
+                rows={feedbackData.data}
+                columns={columns}
+                sx={{ border: 0 }}
+                rowsPerPageOptions={[]}
+                disableSelectionOnClick
+                hideFooter
+            />
+        );
+    };
+
+    const totalPages = () => {
+        if (!feedbackData) return 0;
+        return Math.ceil(feedbackData.pagination.total / PER_PAGE);
+    };
+
+    return (
+        <div className={styles.wrapper}>
+            {toast && <HintPopup text={toast.text} type={toast.type} />}
+            <div className={styles.actionButtons}>
+                <AdminFiltersTable
+                    filters={filters}
+                    onFilterChange={setFilters}
+                    customFields={customFields}
+                />
+            </div>
+            {renderTable()}
+            <OfferPagination
+                currentPage={filters.page}
+                totalPages={totalPages()}
+                onPageChange={(newPage) => setFilters({ page: newPage })}
+            />
+            <ConfirmActionModal
+                isModalOpen={!!feedbackToDelete}
+                description="Вы уверены, что хотите удалить это обращение? Это действие нельзя отменить."
+                onConfirm={handleConfirmDelete}
+                onClose={handleCloseDeleteModal}
+                confirmTextButton="Удалить"
+                cancelTextButton="Отмена"
+                isLoading={isDeleting}
+                buttonsDisabled={isDeleting}
+            />
+        </div>
+    );
+};

--- a/src/widgets/FeedbackWidget/index.ts
+++ b/src/widgets/FeedbackWidget/index.ts
@@ -1,0 +1,1 @@
+export { FeedbackWidgetButton } from "./ui/FeedbackWidgetButton";

--- a/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.module.scss
+++ b/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.module.scss
@@ -1,4 +1,4 @@
-.button {
+.wrapper {
     position: fixed;
     right: 24px;
     bottom: 24px;
@@ -6,7 +6,14 @@
 
     display: flex;
     align-items: center;
+    gap: 10px;
+}
+
+.button {
+    display: flex;
+    align-items: center;
     justify-content: center;
+    flex-shrink: 0;
 
     width: 56px;
     height: 56px;
@@ -22,6 +29,28 @@
     }
 }
 
+.tooltip {
+    order: -1;
+    padding: 8px 14px;
+    border-radius: 8px;
+    background-color: #262f36;
+    color: #fff;
+    font-size: 0.85rem;
+    white-space: nowrap;
+
+    opacity: 0;
+    visibility: hidden;
+    transform: translateX(6px);
+    transition: opacity 0.15s ease, transform 0.15s ease, visibility 0.15s;
+    pointer-events: none;
+}
+
+.wrapper:hover .tooltip {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(0);
+}
+
 .icon {
     width: 26px;
     height: 26px;
@@ -33,9 +62,12 @@
 }
 
 @media (max-width: 768px) {
-    .button {
+    .wrapper {
         right: 16px;
         bottom: 16px;
+    }
+
+    .button {
         width: 48px;
         height: 48px;
     }
@@ -43,5 +75,11 @@
     .icon {
         width: 22px;
         height: 22px;
+    }
+
+    // Hover has no clear meaning on touch devices — hide the tooltip there
+    // rather than risk it getting stuck open after a tap.
+    .tooltip {
+        display: none;
     }
 }

--- a/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.module.scss
+++ b/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.module.scss
@@ -1,0 +1,47 @@
+.button {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 998;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 56px;
+    height: 56px;
+    border: none;
+    border-radius: 50%;
+    background-color: var(--accent-color, #2f80ed);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    cursor: pointer;
+    transition: transform 0.15s ease;
+
+    &:hover {
+        transform: scale(1.06);
+    }
+}
+
+.icon {
+    width: 26px;
+    height: 26px;
+    display: flex;
+
+    svg path {
+        stroke: #fff;
+    }
+}
+
+@media (max-width: 768px) {
+    .button {
+        right: 16px;
+        bottom: 16px;
+        width: 48px;
+        height: 48px;
+    }
+
+    .icon {
+        width: 22px;
+        height: 22px;
+    }
+}

--- a/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.module.scss
+++ b/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.module.scss
@@ -12,7 +12,7 @@
     height: 56px;
     border: none;
     border-radius: 50%;
-    background-color: var(--accent-color, #2f80ed);
+    background-color: var(--accent-color, #3dabf7);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
     cursor: pointer;
     transition: transform 0.15s ease;

--- a/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.tsx
+++ b/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.tsx
@@ -14,13 +14,16 @@ export const FeedbackWidgetButton = memo(() => {
     }
 
     return (
-        <button
-            type="button"
-            className={styles.button}
-            onClick={openFeedbackModal}
-            title="Напишите нам"
-        >
-            <ReactSVG src={chatIcon} className={styles.icon} />
-        </button>
+        <div className={styles.wrapper}>
+            <span className={styles.tooltip}>Напишите нам</span>
+            <button
+                type="button"
+                className={styles.button}
+                onClick={openFeedbackModal}
+                title="Напишите нам"
+            >
+                <ReactSVG src={chatIcon} className={styles.icon} />
+            </button>
+        </div>
     );
 });

--- a/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.tsx
+++ b/src/widgets/FeedbackWidget/ui/FeedbackWidgetButton.tsx
@@ -1,0 +1,26 @@
+import { memo } from "react";
+import { useLocation } from "react-router-dom";
+import { ReactSVG } from "react-svg";
+import chatIcon from "@/shared/assets/icons/chat.svg";
+import { useFeedbackWidget } from "@/app/providers/FeedbackWidgetProvider";
+import styles from "./FeedbackWidgetButton.module.scss";
+
+export const FeedbackWidgetButton = memo(() => {
+    const { openFeedbackModal } = useFeedbackWidget();
+    const { pathname } = useLocation();
+
+    if (pathname.includes("/admin")) {
+        return null;
+    }
+
+    return (
+        <button
+            type="button"
+            className={styles.button}
+            onClick={openFeedbackModal}
+            title="Напишите нам"
+        >
+            <ReactSVG src={chatIcon} className={styles.icon} />
+        </button>
+    );
+});

--- a/src/widgets/Footer/ui/Footer.module.scss
+++ b/src/widgets/Footer/ui/Footer.module.scss
@@ -82,6 +82,11 @@
 	}
 
 	.write {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+
 		color: #82949F;
 		text-decoration-line: underline;
 

--- a/src/widgets/Footer/ui/Footer.module.scss
+++ b/src/widgets/Footer/ui/Footer.module.scss
@@ -81,18 +81,6 @@
 		}
 	}
 
-	.write {
-		background: none;
-		border: none;
-		cursor: pointer;
-		padding: 0;
-
-		color: #82949F;
-		text-decoration-line: underline;
-
-		font-size: 0.875rem;
-		line-height: 171%;
-	}
 }
 
 .menu {

--- a/src/widgets/Footer/ui/Footer.tsx
+++ b/src/widgets/Footer/ui/Footer.tsx
@@ -1,10 +1,11 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { useLocale } from "@/app/providers/LocaleProvider";
 
 import { ChangeLanguage } from "@/widgets/ChangeLanguage";
+import { FeedbackModal } from "@/shared/ui/FeedbackModal/FeedbackModal";
 
 import footerLogo from "@/shared/assets/icons/footer/logo.svg";
 import tgIcon from "@/shared/assets/icons/footer/telegram.svg";
@@ -35,6 +36,7 @@ export const Footer = memo(() => {
     const { locale } = useLocale();
     const { t } = useTranslation();
     const { myProfile } = useAuth();
+    const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
 
     return (
         <>
@@ -82,14 +84,13 @@ export const Footer = memo(() => {
                                 <img src={maxIcon} alt="MAX" />
                             </a>
                         </div>
-                        <a
+                        <button
+                            type="button"
                             className={styles.write}
-                            href="https://vk.com/"
-                            target="_blank"
-                            rel="noreferrer"
+                            onClick={() => setIsFeedbackModalOpen(true)}
                         >
                             {t("main.welcome.header.write-us")}
-                        </a>
+                        </button>
                     </div>
 
                     <nav className={styles.menu}>
@@ -290,6 +291,10 @@ export const Footer = memo(() => {
                     </Link>
                 </div>
             </div>
+            <FeedbackModal
+                isOpen={isFeedbackModalOpen}
+                onClose={() => setIsFeedbackModalOpen(false)}
+            />
         </>
     );
 });

--- a/src/widgets/Footer/ui/Footer.tsx
+++ b/src/widgets/Footer/ui/Footer.tsx
@@ -5,7 +5,6 @@ import { Link } from "react-router-dom";
 import { useLocale } from "@/app/providers/LocaleProvider";
 
 import { ChangeLanguage } from "@/widgets/ChangeLanguage";
-import { useFeedbackWidget } from "@/app/providers/FeedbackWidgetProvider";
 
 import footerLogo from "@/shared/assets/icons/footer/logo.svg";
 import tgIcon from "@/shared/assets/icons/footer/telegram.svg";
@@ -36,7 +35,6 @@ export const Footer = memo(() => {
     const { locale } = useLocale();
     const { t } = useTranslation();
     const { myProfile } = useAuth();
-    const { openFeedbackModal } = useFeedbackWidget();
 
     return (
         <>
@@ -84,13 +82,6 @@ export const Footer = memo(() => {
                                 <img src={maxIcon} alt="MAX" />
                             </a>
                         </div>
-                        <button
-                            type="button"
-                            className={styles.write}
-                            onClick={openFeedbackModal}
-                        >
-                            {t("main.welcome.header.write-us")}
-                        </button>
                     </div>
 
                     <nav className={styles.menu}>

--- a/src/widgets/Footer/ui/Footer.tsx
+++ b/src/widgets/Footer/ui/Footer.tsx
@@ -1,11 +1,11 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { useLocale } from "@/app/providers/LocaleProvider";
 
 import { ChangeLanguage } from "@/widgets/ChangeLanguage";
-import { FeedbackModal } from "@/shared/ui/FeedbackModal/FeedbackModal";
+import { useFeedbackWidget } from "@/app/providers/FeedbackWidgetProvider";
 
 import footerLogo from "@/shared/assets/icons/footer/logo.svg";
 import tgIcon from "@/shared/assets/icons/footer/telegram.svg";
@@ -36,7 +36,7 @@ export const Footer = memo(() => {
     const { locale } = useLocale();
     const { t } = useTranslation();
     const { myProfile } = useAuth();
-    const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
+    const { openFeedbackModal } = useFeedbackWidget();
 
     return (
         <>
@@ -87,7 +87,7 @@ export const Footer = memo(() => {
                         <button
                             type="button"
                             className={styles.write}
-                            onClick={() => setIsFeedbackModalOpen(true)}
+                            onClick={openFeedbackModal}
                         >
                             {t("main.welcome.header.write-us")}
                         </button>
@@ -291,10 +291,6 @@ export const Footer = memo(() => {
                     </Link>
                 </div>
             </div>
-            <FeedbackModal
-                isOpen={isFeedbackModalOpen}
-                onClose={() => setIsFeedbackModalOpen(false)}
-            />
         </>
     );
 });


### PR DESCRIPTION
## Что сделано
- Кнопка "Напишите нам" в футере (раньше вела на голый vk.com) → модалка с формой (имя/email/сообщение)
- POST на новый публичный `/api/v3/feedback/create`
- Админка `/admin/feedback`: список с фильтром по статусу и сортировкой по дате, детальная страница, смена статуса (новое ↔ обработано), удаление

## Почему
Row 52: обратной связи по факту не было — ссылка в футере вела в никуда, а отдельный неиспользуемый виджет поддержки (SupportWidget) был без действия у кнопки. Решили делать полноценно — с сохранением обращений и админкой, не просто mailto.

## Тест план
- [ ] Задеплоить на стейдж
- [ ] Открыть модалку через "Напишите нам" в футере, отправить обращение
- [ ] Проверить, что обращение появилось в `/admin/feedback`
- [ ] Сменить статус, убедиться что отражается в списке и детальной
- [ ] Удалить обращение

Связан с backend PR: https://github.com/Goodsurfing/gs-backend/pull/236