### PR TITLE
fix: страница редактирования баннера в админке (row 53)

### DIFF
--- a/src/entities/Admin/lib/adminBannerMarketingAdapter.ts
+++ b/src/entities/Admin/lib/adminBannerMarketingAdapter.ts
@@ -6,10 +6,11 @@ import {
 export const adminBannerMarketingListAdapter = (data: GetAdminBannerMarketingList[]) => data.map(
     (item) => {
         const {
-            id, description, url, isActive, type,
+            id, name, description, url, isActive, type,
         } = item;
         return {
             id,
+            name,
             description,
             url,
             isActive,
@@ -22,7 +23,7 @@ export const adminBannerMarketingApiAdapter = (
     data: AdminBannerMarketingFileds,
 ): CreateAdminBannerMarketing => {
     const {
-        description, image, isActive, type, url,
+        name, description, image, isActive, type, url,
     } = data;
 
     if (!type) {
@@ -30,6 +31,7 @@ export const adminBannerMarketingApiAdapter = (
     }
 
     return {
+        name,
         description,
         imageId: image?.id ?? null,
         isActive,
@@ -42,10 +44,11 @@ export const adminBannerMarketingAdapter = (
     data: GetAdminMarketingBanner,
 ): AdminBannerMarketingFileds => {
     const {
-        description, image, isActive, type, url,
+        name, description, image, isActive, type, url,
     } = data;
 
     return {
+        name,
         description,
         image,
         isActive,

--- a/src/entities/Admin/model/types/adminBannerMarketingSchema.ts
+++ b/src/entities/Admin/model/types/adminBannerMarketingSchema.ts
@@ -9,6 +9,7 @@ export const enum BannerMarketingType {
 }
 
 export interface AdminBannerMarketingFileds {
+    name: string;
     url: string;
     description: string;
     type: BannerMarketingType | null;
@@ -23,7 +24,7 @@ export interface GetBannerMarketingParams {
 export interface BannerMarketingElement {
     url: string;
     description: string;
-    image: Image;
+    image?: Image;
 }
 
 export interface GetAdminBannerMarketingListParams {
@@ -34,7 +35,7 @@ export interface GetAdminBannerMarketingListParams {
 
 export interface GetAdminBannerMarketingList {
     id: string;
-    // name: string;
+    name: string;
     url: string;
     description: string;
     isActive: boolean;
@@ -47,7 +48,7 @@ export interface GetAdminBannerMarketingListResponse {
 }
 
 export type GetAdminMarketingBanner = GetAdminBannerMarketingList & {
-    image: Image;
+    image?: Image;
 };
 
 export type CreateAdminBannerMarketing = Omit<GetAdminBannerMarketingList, "id"> & {

--- a/src/features/Admin/ui/AdminBannerMarketingForm/ui/AdminBannerMarketingForm/AdminBannerMarketingForm.tsx
+++ b/src/features/Admin/ui/AdminBannerMarketingForm/ui/AdminBannerMarketingForm/AdminBannerMarketingForm.tsx
@@ -48,6 +48,7 @@ const bannerMarketingTypeConfig: Record<BannerMarketingType, BannerMarketingType
 const requiredErrorMessage = "Это поле является обязательным";
 
 const defaultValues: DefaultValues<AdminBannerMarketingFileds> = {
+    name: "",
     image: undefined,
     isActive: false,
     type: null,
@@ -110,6 +111,17 @@ export const AdminBannerMarketingForm: FC<AdminBannerMarketingFormProps> = (prop
                             <SelectType value={value} onChange={onChange} />
                         )}
                     />
+
+                    <InputControl
+                        label="Внутреннее название (чтобы отличать баннеры в списке)"
+                        rules={{ required: requiredErrorMessage }}
+                        control={control}
+                        name="name"
+                        isError={!!errors.name?.message}
+                    />
+                    {errors.name?.message && (
+                        <ErrorText text={errors.name.message} className={styles.error} />
+                    )}
 
                     {isFieldVisible("description") && (
                         <>

--- a/src/pages/AdminBannerMarketingPersonalPage/index.ts
+++ b/src/pages/AdminBannerMarketingPersonalPage/index.ts
@@ -1,0 +1,1 @@
+export { AdminBannerMarketingPersonalPageAsync as AdminBannerMarketingPersonalPage } from "./ui/AdminBannerMarketingPersonalPage.async";

--- a/src/pages/AdminBannerMarketingPersonalPage/ui/AdminBannerMarketingPersonalPage.async.ts
+++ b/src/pages/AdminBannerMarketingPersonalPage/ui/AdminBannerMarketingPersonalPage.async.ts
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+export const AdminBannerMarketingPersonalPageAsync = lazy(() => import("./AdminBannerMarketingPersonalPage"));

--- a/src/pages/AdminBannerMarketingPersonalPage/ui/AdminBannerMarketingPersonalPage.module.scss
+++ b/src/pages/AdminBannerMarketingPersonalPage/ui/AdminBannerMarketingPersonalPage.module.scss
@@ -1,0 +1,5 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}

--- a/src/pages/AdminBannerMarketingPersonalPage/ui/AdminBannerMarketingPersonalPage.tsx
+++ b/src/pages/AdminBannerMarketingPersonalPage/ui/AdminBannerMarketingPersonalPage.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useLocale } from "@/app/providers/LocaleProvider";
+import {
+    adminBannerMarketingAdapter,
+    adminBannerMarketingApiAdapter,
+    AdminBannerMarketingFileds,
+    useGetAdminBannerMarketingQuery,
+    useUpdateAdminBannerMarketingMutation,
+} from "@/entities/Admin";
+import { AdminBannerMarketingForm } from "@/features/Admin";
+import { getAdminBannerMarketingPageUrl } from "@/shared/config/routes/AppUrls";
+import HintPopup from "@/shared/ui/HintPopup/HintPopup";
+import { HintType, ToastAlert } from "@/shared/ui/HintPopup/HintPopup.interface";
+import { Breadcrumbs } from "@/shared/ui/Breadcrumbs/Breadcrumbs";
+import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
+import styles from "./AdminBannerMarketingPersonalPage.module.scss";
+
+const AdminBannerMarketingPersonalPage = () => {
+    const { locale } = useLocale();
+    const navigate = useNavigate();
+    const { id } = useParams<{ id: string }>();
+    const [toast, setToast] = useState<ToastAlert>();
+
+    const { data: banner, isLoading: isBannerLoading } = useGetAdminBannerMarketingQuery(id ?? "", {
+        skip: !id,
+    });
+    const [updateBanner, { isLoading: isUpdating }] = useUpdateAdminBannerMarketingMutation();
+
+    if (!id) {
+        return (
+            <div>
+                <h2>Произошла ошибка! Неверный id рекламы</h2>
+            </div>
+        );
+    }
+
+    const onSubmit = async (data: AdminBannerMarketingFileds) => {
+        setToast(undefined);
+        try {
+            await updateBanner({ id, body: adminBannerMarketingApiAdapter(data) }).unwrap();
+            navigate(getAdminBannerMarketingPageUrl(locale));
+        } catch {
+            setToast({
+                text: "Произошла ошибка при обновлении рекламы",
+                type: HintType.Error,
+            });
+        }
+    };
+
+    return (
+        <div className={styles.wrapper}>
+            {toast && <HintPopup text={toast.text} type={toast.type} />}
+            <h1>Редактирование рекламы</h1>
+            <Breadcrumbs items={[{ label: "Реклама", to: getAdminBannerMarketingPageUrl(locale) },
+                { label: "Редактирование рекламы" },
+            ]}
+            />
+            {isBannerLoading || !banner ? (
+                <MiniLoader />
+            ) : (
+                <AdminBannerMarketingForm
+                    initialData={adminBannerMarketingAdapter(banner)}
+                    onSubmit={onSubmit}
+                    isLoading={isUpdating}
+                />
+            )}
+        </div>
+    );
+};
+
+export default AdminBannerMarketingPersonalPage;

--- a/src/routes/model/config/RoutesConfig.tsx
+++ b/src/routes/model/config/RoutesConfig.tsx
@@ -225,6 +225,7 @@ import {
     getAdminSystemAdminCreatePageUrl,
     getAdminBannerMarketingPageUrl,
     getAdminBannerMarketingCreatePageUrl,
+    getAdminBannerMarketingPersonalPageUrl,
     getAdminFeedbackPageUrl,
     getAdminFeedbackPersonalPageUrl,
 } from "@/shared/config/routes/AppUrls";
@@ -326,6 +327,7 @@ import { AdminSystemAdminPage } from "@/pages/AdminSystemAdminPage";
 import { AdminSystemAdminCreatePage } from "@/pages/AdminSystemAdminCreatePage";
 import { AdminBannerMarketingPage } from "@/pages/AdminBannerMarketingPage";
 import { AdminBannerMarketingCreatePage } from "@/pages/AdminBannerMarketingCreatePage";
+import { AdminBannerMarketingPersonalPage } from "@/pages/AdminBannerMarketingPersonalPage";
 import { AdminFeedbackPage } from "@/pages/AdminFeedbackPage";
 import { AdminFeedbackPersonalPage } from "@/pages/AdminFeedbackPersonalPage";
 
@@ -1133,6 +1135,11 @@ const publicRoutes: RouteType[] = [
                 label: "admin-banner-marketing-create",
                 element: <AdminBannerMarketingCreatePage />,
                 path: (locale: string) => getAdminBannerMarketingCreatePageUrl(locale),
+            },
+            {
+                label: "admin-banner-marketing-personal",
+                element: <AdminBannerMarketingPersonalPage />,
+                path: (locale: string) => getAdminBannerMarketingPersonalPageUrl(locale),
             },
             {
                 label: "admin-feedback",

--- a/src/widgets/Admin/ui/AdminBannerMarketingTable/AdminBannerMarketingTable.tsx
+++ b/src/widgets/Admin/ui/AdminBannerMarketingTable/AdminBannerMarketingTable.tsx
@@ -142,6 +142,15 @@ export const AdminBannerMarketingTable = () => {
             hideable: false,
         },
         {
+            field: "name",
+            headerName: "Название",
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            width: 150,
+        },
+        {
             field: "description",
             headerName: "Текст рекламы",
             sortable: false,


### PR DESCRIPTION
## Проблема
Кнопка "Показать рекламу" в списке `/admin/banner-marketing` вела на несуществующий маршрут (404). URL-хелпер `getAdminBannerMarketingPersonalPageUrl`, API-запрос по id и мутация update уже существовали, но страница-обёртка и сам маршрут не были реализованы.

Дополнительно (в процессе тестирования на стейдже вскрылось): само сохранение падало с 400, потому что форма никогда не собирала поле `name` (в схеме оно было буквально закомментировано — `// name: string;`), а `imageId` требовался бэкендом даже для типа баннера, у которого нет картинки. Бэкенд-часть фикса — в gs-backend#237.

Это блокировало row 53: "Лента вверху с важными сообщениями + управление из админки" — управление показом/скрытием баннера `UNDER_HEADER_ALL_PAGES` (та самая зелёная полоса "Запись в экспедицию...") технически уже было реализовано на бэкенде (поле `isActive`), но администратор не мог ни открыть, ни сохранить редактирование через UI.

## Решение
- Добавил `AdminBannerMarketingPersonalPage` по образцу `AdminBannerMarketingCreatePage`: подгружает баннер по id, переиспользует `AdminBannerMarketingForm` с готовыми кнопками "Сохранить и опубликовать" / "Сохранить в черновики" (переключатель показывать/не показывать). Зарегистрировал маршрут в `RoutesConfig.tsx`.
- Добавил поле "Внутреннее название" в форму (для всех типов баннера) и колонку в таблице списка — соответствует требуемому бэкендом `name`.
- `image` в типах сделал опциональным — баннер "под шапкой" картинку не использует.

## Test plan
- [x] Проверено на стейдже (в связке с gs-backend#237): переход по кнопке "Показать рекламу" больше не даёт 404, форма подгружает текущие данные баннера, включая новое поле "Внутреннее название"
- [x] Снятие с публикации ("Сохранить в черновики") реально убирает баннер с публичного сайта; повторная публикация возвращает баннер — проверено на живом баннере `UNDER_HEADER_ALL_PAGES`, стейдж возвращён в исходное состояние