### PR TITLE
test(payment): поведенческие RTL-тесты PaymentPage/PaymentSuccessPage через MSW

### DIFF
--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.behavior.test.tsx
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.behavior.test.tsx
@@ -38,11 +38,13 @@ describe("PaymentPage — реальное поведение чекаута", (
         // чтобы проверить факт редиректа, не пытаясь реально перейти по URL.
         // @ts-expect-error — намеренно упрощённый мок под тест
         delete window.location;
-        window.location = { href: "" } as Location;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).location = { href: "" };
     });
 
     afterEach(() => {
-        window.location = originalLocation;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).location = originalLocation;
     });
 
     it("при успешном чекауте редиректит на paymentUrl от бэка", async () => {

--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.behavior.test.tsx
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.behavior.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import {
+    describe, it, expect, vi, beforeEach, afterEach,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import PaymentPage from "./PaymentPage";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/widgets/MainPageLayout", () => ({
+    MainPageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ isAuth: true, myProfile: { id: "u1", email: "u@test.com" } }),
+}));
+
+const CHECKOUT_URL = "*/api/v1/membership/checkout";
+
+/**
+ * Поведенческий тест поверх старого PaymentPage.regression.test.ts
+ * (source-inspection): здесь реально монтируем компонент и гоняем через
+ * MSW настоящий цикл запрос/ответ, а не проверяем текст исходника.
+ */
+describe("PaymentPage — реальное поведение чекаута", () => {
+    let originalLocation: Location;
+
+    beforeEach(() => {
+        originalLocation = window.location;
+        // window.location.href = '...' в jsdom не поддерживается как
+        // настоящая навигация — подменяем на объект с шпионским сеттером,
+        // чтобы проверить факт редиректа, не пытаясь реально перейти по URL.
+        // @ts-expect-error — намеренно упрощённый мок под тест
+        delete window.location;
+        window.location = { href: "" } as Location;
+    });
+
+    afterEach(() => {
+        window.location = originalLocation;
+    });
+
+    it("при успешном чекауте редиректит на paymentUrl от бэка", async () => {
+        server.use(
+            rest.post(CHECKOUT_URL, (req, res, ctx) => res(ctx.status(200), ctx.json({
+                membershipId: "m1",
+                paymentId: "p1",
+                paymentUrl: "https://yookassa.ru/pay/p1",
+                status: "PENDING",
+                tariffCode: "volunteer_990",
+            }))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment?tariff=volunteer_990"]}>
+                <PaymentPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(window.location.href).toBe("https://yookassa.ru/pay/p1"));
+    });
+
+    /**
+     * Регресс-guard для row 95 ("После нажатия на любую из кнопок оплаты,
+     * просто возвращает в начало страницы") — 409 раньше молча уводил на
+     * страницу членства без единого сообщения.
+     */
+    it("на 409 (уже есть активное членство) показывает сообщение, а не молча возвращает назад", async () => {
+        server.use(
+            rest.post(CHECKOUT_URL, (req, res, ctx) => res(ctx.status(409), ctx.json({
+                detail: "MembershipAlreadyActive",
+            }))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment?tariff=volunteer_990"]}>
+                <PaymentPage />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByText(/уже есть активное членство/i)).toBeInTheDocument();
+        expect(window.location.href).toBe("");
+    });
+
+    it("на 502 показывает дружелюбное сообщение о недоступности провайдера", async () => {
+        server.use(
+            rest.post(CHECKOUT_URL, (req, res, ctx) => res(ctx.status(502), ctx.json({
+                detail: "",
+            }))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment?tariff=volunteer_990"]}>
+                <PaymentPage />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByText(/сервис оплаты временно недоступен/i)).toBeInTheDocument();
+    });
+
+    it("показывает detail из ответа бэка для прочих ошибок", async () => {
+        server.use(
+            rest.post(CHECKOUT_URL, (req, res, ctx) => res(ctx.status(400), ctx.json({
+                detail: "tariffCode: This value should not be blank.",
+            }))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment?tariff=volunteer_990"]}>
+                <PaymentPage />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByText(/tariffCode: This value should not be blank/i)).toBeInTheDocument();
+    });
+});

--- a/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.behavior.test.tsx
+++ b/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.behavior.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import PaymentSuccessPage from "./PaymentSuccessPage";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/widgets/MainPageLayout", () => ({
+    MainPageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ isAuth: true, myProfile: { id: "u1", email: "u@test.com", firstName: "Вася" } }),
+}));
+
+const MEMBERSHIP_CURRENT_URL = "*/api/v1/membership/current";
+const PAYMENT_STATUS_URL = "*/api/v1/payments/:id";
+
+function mockMembershipCurrent(tariffCode: string | null) {
+    server.use(
+        rest.get(MEMBERSHIP_CURRENT_URL, (req, res, ctx) => res(ctx.status(200), ctx.json(
+            tariffCode
+                ? {
+                    membershipId: "m1",
+                    status: "ACTIVE",
+                    isActive: true,
+                    startDate: "2026-01-01T00:00:00Z",
+                    endDate: "2026-12-31T23:59:59Z",
+                    tariff: { code: tariffCode },
+                }
+                : {
+                    membershipId: null,
+                    status: null,
+                    isActive: false,
+                    startDate: null,
+                    endDate: null,
+                    tariff: null,
+                },
+        ))),
+    );
+}
+
+function mockPaymentStatus(status: string, tariffCode: string | null) {
+    server.use(
+        rest.get(PAYMENT_STATUS_URL, (req, res, ctx) => res(ctx.status(200), ctx.json({
+            id: "p1",
+            status,
+            amount: "990.00",
+            currency: "RUB",
+            paidAt: status === "SUCCESS" ? "2026-07-11T10:00:00Z" : null,
+            tariffCode,
+        }))),
+    );
+}
+
+/**
+ * Регресс-guard: до фикса payment.tariffCode отсутствовал в ответе бэка,
+ * а страница угадывала купленный тариф по membership.tariff.code — что
+ * стало неоднозначным, когда у юзера может быть больше одного активного
+ * членства одновременно (см. PaymentSuccessPage.regression.test.ts —
+ * тот проверяет исходник, этот — реальное поведение при монтировании).
+ */
+describe("PaymentSuccessPage — реальное поведение по payment.tariffCode", () => {
+    it("международный тариф: показывает international-контент по payment.tariffCode, даже если membership другой", async () => {
+        mockMembershipCurrent("host_4990"); // у юзера уже было другое активное членство
+        mockPaymentStatus("SUCCESS", "international_5000");
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment/success?payment_id=p1"]}>
+                <PaymentSuccessPage />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByText(/международный клуб/i)).toBeInTheDocument();
+        expect(screen.queryByText(/можете пользоваться всеми возможностями портала/i)).not.toBeInTheDocument();
+    });
+
+    it("host-тариф: показывает host-контент и CTA на публикацию вакансий", async () => {
+        mockMembershipCurrent("host_4990");
+        mockPaymentStatus("SUCCESS", "host_4990");
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment/success?payment_id=p1"]}>
+                <PaymentSuccessPage />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByText(/перейти к объявлениям/i)).toBeInTheDocument();
+    });
+
+    it("volunteer-тариф (дефолт): показывает контент про поиск путешествий", async () => {
+        mockMembershipCurrent("volunteer_990");
+        mockPaymentStatus("SUCCESS", "volunteer_990");
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment/success?payment_id=p1"]}>
+                <PaymentSuccessPage />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByText(/искать путешествия/i)).toBeInTheDocument();
+    });
+
+    it("пока payment.status не SUCCESS — показывает прелоадер, а не контент", async () => {
+        mockMembershipCurrent(null);
+        mockPaymentStatus("PENDING", null);
+
+        const { container } = renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment/success?payment_id=p1"]}>
+                <PaymentSuccessPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(container.querySelector(".preloader")).not.toBeNull());
+        expect(screen.queryByText(/искать путешествия/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/международный клуб/i)).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Что здесь

Последний пункт из "закрыть всё по оплате". До этого на `PaymentPage`/`PaymentSuccessPage` были только source-inspection regression-тесты — грепают текст исходника, не проверяют реальное поведение.

Рядом уже был прецедент — `DonationPaySuccessPage.test.tsx`, реальный рендер через `renderWithProviders` + MSW. Использовал тот же паттерн.

### PaymentPage.behavior.test.tsx
- успешный чекаут → редирект на `paymentUrl`
- 409 → сообщение "уже есть активное членство" (не молчаливый `navigate`, row 95)
- 502 → дружелюбное "сервис оплаты недоступен"
- прочие ошибки → `detail` из ответа бэка

### PaymentSuccessPage.behavior.test.tsx
- international/host/volunteer — правильный контент по `payment.tariffCode`
- ключевой кейс: `payment.tariffCode=international_5000` даёт international-контент, даже если `membership.tariff.code=host_4990` (у юзера уже было другое активное членство) — ровно тот регресс, который чинили на бэке добавлением `tariffCode` в `/api/v1/payments/{id}` (см. gs-backend#244)
- до `payment.status=SUCCESS` — прелоадер, не контент

Оба набора (старые regression + новые behavior) прогнаны через revert-and-confirm-fails на одних и тех же местах — старые продолжают работать параллельно с новыми, не заменял их.

🤖 Generated with [Claude Code](https://claude.com/claude-code)