### PR TITLE
fix(membership): правки по фидбеку бизнеса на оплату членства

### DIFF
--- a/src/pages/MembershipPage/ui/MebmbershipPage/MembershipPage.tsx
+++ b/src/pages/MembershipPage/ui/MebmbershipPage/MembershipPage.tsx
@@ -98,11 +98,11 @@ const MembershipPage = () => {
                 <WhyMembership />
                 <ForVolunteer className={styles.section} />
                 <HowItWorks className={styles.section} />
-                <ForHost className={styles.section} />
-                {/* "После обычного мембершипа" по ТЗ — после обоих блоков
-                    покупки регулярного членства (ForVolunteer/ForHost),
-                    перед донатами. */}
+                {/* Правка бизнеса: международный клуб — между личным
+                    членством и членством для организаторов, а не после
+                    обоих блоков покупки (как было по прежнему ТЗ). */}
                 <InternationalClub className={styles.section} />
+                <ForHost className={styles.section} />
                 <DonationSection className={styles.section} />
                 <WhatIsGoodsurfing className={styles.section} />
                 <Review className={styles.section} />

--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.tsx
@@ -9,7 +9,7 @@ import Preloader from "@/shared/ui/Preloader/Preloader";
 import { useAuth } from "@/routes/model/guards/AuthProvider";
 import { useCheckoutMembershipMutation } from "@/store/api/membershipApi";
 import { useLocale } from "@/app/providers/LocaleProvider";
-import { getMembershipPageUrl } from "@/shared/config/routes/AppUrls";
+import { getMembershipPageUrl, getSignInPageUrl } from "@/shared/config/routes/AppUrls";
 import { TARIFF_CODE } from "@/shared/constants/membership";
 
 import styles from "./PaymentPage.module.scss";
@@ -33,7 +33,11 @@ const PaymentPage: React.FC = () => {
 
     useEffect(() => {
         if (!isAuth || !myProfile) {
-            navigate(`/${locale}/signin`);
+            // Прокидываем next/nextId, чтобы после логина AuthByEmail
+            // вернул пользователя сюда же с тем же tariffCode, а не на
+            // дефолтную страницу профиля (row: "просит войти — перебрасывает
+            // в личный кабинет — нужно искать страницу оплаты заново").
+            navigate(`${getSignInPageUrl(locale)}?next=payment&nextId=${tariffCode}`);
             return;
         }
         if (startedRef.current) return;

--- a/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.unauth.behavior.test.tsx
+++ b/src/pages/PaymentPage/ui/PaymentPage/PaymentPage.unauth.behavior.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import {
+    MemoryRouter, Routes, Route, useLocation,
+} from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import PaymentPage from "./PaymentPage";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/widgets/MainPageLayout", () => ({
+    MainPageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ isAuth: false, myProfile: null }),
+}));
+
+const LocationDisplay = () => {
+    const location = useLocation();
+    return (
+        <div data-testid="location">
+            {location.pathname}
+            {location.search}
+        </div>
+    );
+};
+
+/**
+ * Регресс-guard: раньше неавторизованный юзер терял выбранный тариф —
+ * редирект на /signin шёл без next/nextId, а после логина AuthByEmail
+ * уводил на дефолтную страницу профиля вместо возврата к оплате.
+ */
+describe("PaymentPage — редирект на signin для неавторизованного юзера", () => {
+    it("сохраняет tariffCode через next/nextId, чтобы после логина вернуться к оплате", async () => {
+        // PaymentPage монтируется через <Route>, как в реальном роутере
+        // приложения — после navigate() на /signin компонент размонтируется
+        // и не перечитывает searchParams уже сброшенной локации (иначе
+        // tariffCode откатывался бы к дефолту на втором рендере).
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment?tariff=host_4990"]}>
+                <Routes>
+                    <Route path="/:locale/payment" element={<PaymentPage />} />
+                    <Route path="*" element={null} />
+                </Routes>
+                <LocationDisplay />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByTestId("location")).toHaveTextContent(
+            "/ru/signin?next=payment&nextId=host_4990",
+        );
+    });
+});

--- a/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.behavior.test.tsx
+++ b/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.behavior.test.tsx
@@ -83,6 +83,25 @@ describe("PaymentSuccessPage — реальное поведение по paymen
         expect(screen.queryByText(/можете пользоваться всеми возможностями портала/i)).not.toBeInTheDocument();
     });
 
+    /**
+     * Замечание бизнеса: international не должен читаться как рядовая
+     * оплата членства ("вы успешно оплатили...") — нужна отдельная
+     * приветственная рамка ("вступили в клуб").
+     */
+    it("международный тариф: заголовок приветствует в клуб, а не сообщает про оплату", async () => {
+        mockMembershipCurrent("host_4990");
+        mockPaymentStatus("SUCCESS", "international_5000");
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/payment/success?payment_id=p1"]}>
+                <PaymentSuccessPage />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByText(/вы вступили в Международный клуб/i)).toBeInTheDocument();
+        expect(screen.queryByText(/вы успешно оплатили членство/i)).not.toBeInTheDocument();
+    });
+
     it("host-тариф: показывает host-контент и CTA на публикацию вакансий", async () => {
         mockMembershipCurrent("host_4990");
         mockPaymentStatus("SUCCESS", "host_4990");
@@ -94,6 +113,7 @@ describe("PaymentSuccessPage — реальное поведение по paymen
         );
 
         expect(await screen.findByText(/перейти к объявлениям/i)).toBeInTheDocument();
+        expect(screen.getByText(/вы успешно оплатили членство/i)).toBeInTheDocument();
     });
 
     it("volunteer-тариф (дефолт): показывает контент про поиск путешествий", async () => {
@@ -107,6 +127,7 @@ describe("PaymentSuccessPage — реальное поведение по paymen
         );
 
         expect(await screen.findByText(/искать путешествия/i)).toBeInTheDocument();
+        expect(screen.getByText(/вы успешно оплатили членство/i)).toBeInTheDocument();
     });
 
     it("пока payment.status не SUCCESS — показывает прелоадер, а не контент", async () => {

--- a/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.tsx
+++ b/src/pages/PaymentSuccessPage/ui/PaymentSuccessPage/PaymentSuccessPage.tsx
@@ -185,20 +185,29 @@ const PaymentSuccessPage: React.FC = () => {
         purchaseKind = "host";
     }
 
+    // У international своя приветственная рамка ("вступили в клуб"), а не
+    // общая транзакционная ("оплатили членство") — по замечанию бизнеса
+    // международный клуб не должен читаться как рядовая оплата членства.
     const PURCHASE_KIND_CONFIG = {
         international: {
+            title: "Добро пожаловать,",
+            subtitle: "вы вступили в Международный клуб GoodSurfing",
             benefits: INTERNATIONAL_BENEFITS,
             ctaText: "На страницу членства",
             ctaUrl: getMembershipPageUrl(locale),
-            callToAction: "Добро пожаловать в международный клуб GoodSurfing.",
+            callToAction: "Впереди — закрытые встречи и международные программы для участников клуба.",
         },
         host: {
+            title: "Спасибо,",
+            subtitle: "вы успешно оплатили членство в сообществе Гудсёрфинга",
             benefits: HOST_BENEFITS,
             ctaText: "Перейти к объявлениям",
             ctaUrl: getMyOffersPageUrl(locale),
             callToAction: "Самое время опубликовать объявление и принять волонтёров.",
         },
         volunteer: {
+            title: "Спасибо,",
+            subtitle: "вы успешно оплатили членство в сообществе Гудсёрфинга",
             benefits: VOLUNTEER_BENEFITS,
             ctaText: "Искать путешествия",
             ctaUrl: getOffersMapPageUrl(locale),
@@ -207,7 +216,7 @@ const PaymentSuccessPage: React.FC = () => {
     } as const;
 
     const {
-        benefits, ctaText, ctaUrl, callToAction,
+        title, subtitle, benefits, ctaText, ctaUrl, callToAction,
     } = PURCHASE_KIND_CONFIG[purchaseKind];
 
     return (
@@ -215,13 +224,13 @@ const PaymentSuccessPage: React.FC = () => {
             <div className={styles.container}>
                 <div className={styles.content}>
                     <h1 className={styles.title}>
-                        Спасибо,
+                        {title}
                         {" "}
                         <span className={styles.username}>{userName}</span>
-                        ,
+                        {isInternational ? "!" : ","}
                     </h1>
                     <p className={styles.subtitle}>
-                        вы успешно оплатили членство в сообществе Гудсёрфинга
+                        {subtitle}
                     </p>
 
                     <div className={styles.info}>

--- a/src/routes/model/lib/useNextRoutes.test.tsx
+++ b/src/routes/model/lib/useNextRoutes.test.tsx
@@ -1,0 +1,25 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useNextRoutes } from "./useNextRoutes";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+/**
+ * Регресс-guard: PaymentPage теперь редиректит неавторизованных юзеров
+ * через next=payment&nextId=<tariffCode>, а AuthByEmail.onSuccess
+ * резолвит его через getNextRoute — без этого маппинга юзера после
+ * логина уносило бы на дефолтную страницу профиля вместо оплаты.
+ */
+describe("useNextRoutes", () => {
+    it("payment резолвится в страницу оплаты с сохранённым tariffCode", () => {
+        const { result } = renderHook(() => useNextRoutes());
+
+        expect(result.current.getNextRoute("payment", "host_4990")).toBe(
+            "/ru/payment?tariff=host_4990",
+        );
+    });
+});

--- a/src/routes/model/lib/useNextRoutes.tsx
+++ b/src/routes/model/lib/useNextRoutes.tsx
@@ -4,10 +4,11 @@ import {
     getHostPersonalPageUrl,
     getMessengerPageCreateUrl,
     getOfferPersonalPageUrl,
+    getPaymentPageUrl,
     getVolunteerPersonalPageUrl,
 } from "@/shared/config/routes/AppUrls";
 
-export type NextRouteType = "offer" | "messenger" | "host" | "volunteer";
+export type NextRouteType = "offer" | "messenger" | "host" | "volunteer" | "payment";
 
 export const useNextRoutes = () => {
     const { locale } = useLocale();
@@ -18,6 +19,7 @@ export const useNextRoutes = () => {
             host: getHostPersonalPageUrl(locale, id),
             messenger: getMessengerPageCreateUrl(locale, id),
             volunteer: getVolunteerPersonalPageUrl(locale, id),
+            payment: `${getPaymentPageUrl(locale)}?tariff=${id}`,
         };
 
         return nextRoutes[type];


### PR DESCRIPTION
## Что изменено

По результатам ручного тестирования оплаты на стейдже (см. фидбек бизнеса):

1. **Порядок блока "Международный клуб"** — теперь между личным членством (`ForVolunteer`) и членством для организаторов (`ForHost`), а не после обоих блоков покупки, как было по прежнему ТЗ.
2. **Сохранение tariff при логине со страницы оплаты** — `PaymentPage` теперь редиректит на `/signin` с `?next=payment&nextId=<tariffCode>`, используя уже существующий в проекте паттерн (`useNextRoutes`, как у offer/host/messenger/volunteer). После логина юзера возвращает сразу к оплате выбранного тарифа, а не на дефолтную страницу профиля.
3. **Отдельный welcome-заголовок на странице успеха для international_5000** — вместо общего «вы успешно оплатили членство» теперь «Добро пожаловать, {имя}! — вы вступили в Международный клуб GoodSurfing».

## Test plan

- [x] `tsc --noEmit` — чисто
- [x] `eslint` на все изменённые файлы — чисто
- [x] Новые тесты: `PaymentPage.unauth.behavior.test.tsx`, `useNextRoutes.test.tsx`, расширен `PaymentSuccessPage.behavior.test.tsx`
- [x] Полный прогон затронутых сьютов (`MembershipPage`, `PaymentPage`, `PaymentSuccessPage`, `useNextRoutes`) — все зелёные

Не затронуты пункты фидбека про international.goodsurfing.org (кнопка оплаты взноса, ссылка на главный сайт) — это отдельный внешний сайт, не в этом репозитории.

🤖 Generated with [Claude Code](https://claude.com/claude-code)