### PR TITLE
fix(membership): якорь id="host" на секцию членства организатора (ROW 70)

### DIFF
--- a/src/pages/MembershipPage/ui/ForHost/ForHost.test.tsx
+++ b/src/pages/MembershipPage/ui/ForHost/ForHost.test.tsx
@@ -1,0 +1,39 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render } from "@testing-library/react";
+import { ForHost } from "./ForHost";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ isAuth: false }),
+}));
+
+vi.mock("@/store/api/membershipApi", () => ({
+    useGetTariffsQuery: () => ({ data: undefined }),
+}));
+
+/**
+ * Регресс-guard (ROW 70): у секции членства организатора не было
+ * id-якоря, из-за чего ссылки вида /membership#host (с рабочего стола
+ * хоста и с international-сайта) не прокручивали к нужному блоку.
+ * У соседних секций якоря есть: ForVolunteer id="tariffs",
+ * InternationalClub id="international".
+ */
+describe("ForHost", () => {
+    it("секция имеет id=\"host\" для якорной навигации", () => {
+        const { container } = render(<ForHost />);
+        expect(container.querySelector("section#host")).not.toBeNull();
+    });
+});

--- a/src/pages/MembershipPage/ui/ForHost/ForHost.tsx
+++ b/src/pages/MembershipPage/ui/ForHost/ForHost.tsx
@@ -58,7 +58,10 @@ export const ForHost: FC<ForHostProps> = (props: ForHostProps) => {
     ];
 
     return (
-        <section className={cn(className, styles.wrapper)}>
+        // id="host" — якорь на секцию членства организатора: ссылки с
+        // рабочего стола хоста и с international-сайта ведут на /membership#host
+        // (у ForVolunteer уже есть id="tariffs", у InternationalClub — id="international").
+        <section id="host" className={cn(className, styles.wrapper)}>
             <div className={styles.inner}>
                 <h2 className={styles.sectionTitle}>
                     {t("for-host.section-title", "Если вы — организатор, который создаёт возможности")}


### PR DESCRIPTION
## Что

ROW 70 (таблица фиксов прод-переезда): у секции `ForHost` на `/membership` не было `id`-якоря, из-за чего ссылки вида `/membership#host` (с рабочего стола хоста и с international-сайта) не прокручивали к блоку членства организатора.

Добавлен `id="host"`. У соседних секций якоря уже есть: `ForVolunteer` → `id="tariffs"`, `InternationalClub` → `id="international"`.

## Test plan
- [x] Регресс-тест `ForHost.test.tsx` — проверяет наличие `section#host`
- [x] `tsc --noEmit` чисто
- [x] `eslint` чисто

## Осталось за рамками (требует ТЗ/дизайна)
Полное закрытие ROW 70 требует ещё **баннера на дашборде организатора** (`HostDashboardPage`) — аналог волонтёрского `MemberBanner`, ведущего на `/membership#host` с перечнем преимуществ. Этот PR только делает якорь рабочим; баннер — отдельной задачей, когда придёт текст/картинка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)