### PR TITLE
feat(npo): вернуть отчёты Минюст и о деятельности на /npo (ROW 93)

### DIFF
--- a/src/pages/NPOPage/ui/GovernmentReports/GovernmentReports.module.scss
+++ b/src/pages/NPOPage/ui/GovernmentReports/GovernmentReports.module.scss
@@ -1,0 +1,31 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 60px;
+    margin-top: 30px;
+}
+
+.report {
+    display: flex;
+    flex-direction: column;
+}
+
+.title {
+    text-align: center;
+    font-size: 1.625rem;
+    font-weight: 400;
+}
+
+.container {
+    margin-top: 30px;
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+}
+
+@media (max-width: 992px) {
+    .container {
+        grid-template-columns: repeat(1, 1fr);
+    }
+}

--- a/src/pages/NPOPage/ui/GovernmentReports/GovernmentReports.test.tsx
+++ b/src/pages/NPOPage/ui/GovernmentReports/GovernmentReports.test.tsx
@@ -1,0 +1,37 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { GovernmentReports } from "./GovernmentReports";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+/**
+ * Регресс-guard (ROW 93): отчёты Минюст и о деятельности «пропали» —
+ * PDF физически лежат в public/assets/docs/npo, но ни один компонент
+ * страницы /npo на них не ссылался. GovernmentReports возвращает обе
+ * секции со ссылками на существующие файлы.
+ */
+describe("GovernmentReports", () => {
+    it("рендерит обе секции отчётов", () => {
+        render(<MemoryRouter><GovernmentReports /></MemoryRouter>);
+        expect(screen.getByText("Отчёты в Минюст")).toBeInTheDocument();
+        expect(screen.getByText("Отчёты о деятельности")).toBeInTheDocument();
+    });
+
+    it("ссылки ведут на существующие PDF в /assets/docs/npo (с URL-кодированием)", () => {
+        render(<MemoryRouter><GovernmentReports /></MemoryRouter>);
+        const links = screen.getAllByRole("link");
+        // 6 отчётов Минюст (2018–2023) + 7 о деятельности (2019–2025) = 13
+        expect(links).toHaveLength(13);
+        links.forEach((link) => {
+            const href = link.getAttribute("href") ?? "";
+            expect(href).toMatch(/^\/assets\/docs\/npo\/.+\.pdf$/i);
+            // кириллица/пробелы должны быть закодированы (нет сырых пробелов)
+            expect(href).not.toContain(" ");
+        });
+    });
+});

--- a/src/pages/NPOPage/ui/GovernmentReports/GovernmentReports.tsx
+++ b/src/pages/NPOPage/ui/GovernmentReports/GovernmentReports.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { ReportItem } from "@/shared/ui/ReportItem/ReportItem";
+import styles from "./GovernmentReports.module.scss";
+
+interface ReportFile {
+    year: string;
+    file: string;
+}
+
+const NPO_DOCS_BASE = "/assets/docs/npo";
+
+// PDF физически лежат в public/assets/docs/npo — перенесены со старого
+// сайта (old.goodsurfing.org/about-nko), но на странице /npo не были нигде
+// отрендерены, из-за чего отчёты «пропали» (ROW 93). Здесь возвращаем их
+// на страницу двумя секциями, как на исходном сайте.
+const MINISTRY_REPORTS: ReportFile[] = [
+    { year: "2018", file: "Отчётность в Минюст за 2018 г..pdf" },
+    { year: "2019", file: "Отчётность в Минюст за 2019 г..pdf" },
+    { year: "2020", file: "2020-report.pdf" },
+    { year: "2021", file: "Отчётность_Минюст _2021.pdf" },
+    { year: "2022", file: "Отчётность_Минюст_2022.pdf" },
+    { year: "2023", file: "Отчётность_Минюст_2023.pdf" },
+];
+
+const ACTIVITY_REPORTS: ReportFile[] = [
+    { year: "2019", file: "2019_отчет_деятельности.pdf" },
+    { year: "2020", file: "2020_отчет_деятельности.pdf" },
+    { year: "2021", file: "2021-report.pdf" },
+    { year: "2022", file: "Отчет о деятельности 2022.pdf" },
+    { year: "2023", file: "Отчет о деятельности 2023(1).pdf" },
+    { year: "2024", file: "Отчет о деятельности 2024(2).pdf" },
+    { year: "2025", file: "Отчет о деятельности 2025.pdf" },
+];
+
+const reportUrl = (file: string): string => encodeURI(`${NPO_DOCS_BASE}/${file}`);
+
+export const GovernmentReports = () => {
+    const { t } = useTranslation("npo");
+
+    const renderSection = (titleKey: string, fallback: string, reports: ReportFile[]) => (
+        <div className={styles.report}>
+            <h2 className={styles.title}>{t(titleKey, fallback)}</h2>
+            <div className={styles.container}>
+                {reports.map((report) => (
+                    <ReportItem
+                        key={report.file}
+                        title={`${report.year} год`}
+                        url={reportUrl(report.file)}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+
+    return (
+        <div className={styles.wrapper}>
+            {renderSection("Отчёты в Минюст", "Отчёты в Минюст", MINISTRY_REPORTS)}
+            {renderSection("Отчёты о деятельности", "Отчёты о деятельности", ACTIVITY_REPORTS)}
+        </div>
+    );
+};

--- a/src/pages/NPOPage/ui/NPOPage/NPOPage.tsx
+++ b/src/pages/NPOPage/ui/NPOPage/NPOPage.tsx
@@ -10,6 +10,7 @@ import { MainPageLayout } from "@/widgets/MainPageLayout";
 
 import { Description } from "../Description/Description";
 import { Documents } from "../Documents/Documents";
+import { GovernmentReports } from "../GovernmentReports/GovernmentReports";
 import { Header } from "../Header/Header";
 import styles from "./NPOPage.module.scss";
 
@@ -34,6 +35,7 @@ const NPOPage = () => {
                 <div className={styles.content}>
                     <Description />
                     <Documents />
+                    <GovernmentReports />
                     <Reports />
                 </div>
             </div>


### PR DESCRIPTION
## Что

ROW 93 (таблица фиксов прод-переезда): «Пропали отчёты Минюст и отчёты о деятельности».

**Причина:** PDF-файлы физически уже лежат в `public/assets/docs/npo/` (перенесены со старого сайта), но **ни один компонент страницы `/npo` на них не ссылался** — блок «Уставные документы» показывает только 2 картинки, а `Reports` — динамические донат-отчёты из API. Отчётов Минюст/деятельности на странице не было вообще.

**Фикс:** новый компонент `GovernmentReports` с двумя секциями (по образцу `old.goodsurfing.org/about-nko`), переиспользует существующий `ReportItem`. Добавлен на `/npo` между уставными документами и донат-отчётами.

Состав (все файлы уже в репо, проверено):
- **Отчёты в Минюст:** 2018, 2019, 2020, 2021, 2022, 2023
- **Отчёты о деятельности:** 2019, 2020, 2021, 2022, 2023, 2024, 2025

Ссылки URL-кодируются (`encodeURI`) — в именах файлов кириллица, пробелы, скобки.

## Test plan
- [x] Регресс-тест `GovernmentReports.test.tsx` — обе секции + 13 ссылок на `/assets/docs/npo/*.pdf`, без сырых пробелов
- [x] Проверено: все 13 PDF существуют в `public/assets/docs/npo/`
- [x] `tsc --noEmit` + `eslint` чисто

## Примечание
На старом сайте в этих секциях было меньше файлов (Минюст 2020–2023, деятельность 2019–2024). В новом репо уже лежат более свежие/полные (Минюст с 2018, деятельность по 2025) — включил всё, что есть. Если какой-то из них черновик — скажите, уберу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)