### PR TITLE
feat(blog): множественные категории у статьи блога (row 62)

### DIFF
--- a/src/entities/Admin/lib/adminBlogAdapter.ts
+++ b/src/entities/Admin/lib/adminBlogAdapter.ts
@@ -4,14 +4,14 @@ import { GetAdminBlog, UpdateAdminBlog } from "../model/types/adminBlogSchema";
 export const blogAdapter = (data: GetAdminBlog): AdminArticleFormFields => {
     const {
         name, image, description, isActive,
-        category, author,
+        categories, author,
     } = data;
 
     return {
         name,
         image,
         description,
-        categoryId: category.id,
+        categoryIds: categories.map((category) => category.id),
         isActive,
         author,
     };
@@ -20,7 +20,7 @@ export const blogAdapter = (data: GetAdminBlog): AdminArticleFormFields => {
 export const blogApiAdapter = (data: AdminArticleFormFields): UpdateAdminBlog => {
     const {
         name, image, description, isActive,
-        categoryId, author,
+        categoryIds, author,
     } = data;
 
     return {
@@ -28,7 +28,7 @@ export const blogApiAdapter = (data: AdminArticleFormFields): UpdateAdminBlog =>
         description,
         isActive,
         imageId: image.id,
-        blogCategoryId: categoryId,
+        blogCategoryIds: categoryIds ?? [],
         authorId: author?.id ?? "",
     };
 };

--- a/src/entities/Admin/lib/adminNewsAdapter.ts
+++ b/src/entities/Admin/lib/adminNewsAdapter.ts
@@ -28,7 +28,7 @@ export const newsApiAdapter = (data: AdminArticleFormFields): CreateAdminNews =>
         description,
         isActive,
         imageId: image.id,
-        categoryId,
+        categoryId: categoryId as number,
         authorId: author?.id ?? "",
     };
 };

--- a/src/entities/Admin/model/types/adminBlogSchema.ts
+++ b/src/entities/Admin/model/types/adminBlogSchema.ts
@@ -35,11 +35,11 @@ export type GetAdminBlog = Omit<GetAdminBlogList, "categoryName"> & {
     description: string;
     isGudserfing: boolean;
     image: Image;
-    category: BlogCategory;
+    categories: BlogCategory[];
 };
 
 export type UpdateAdminBlog = Pick<GetAdminBlog, "name" | "description" | "isActive"> & {
-    blogCategoryId: number;
+    blogCategoryIds: number[];
     imageId: string;
     authorId: string;
 };

--- a/src/entities/Article/model/types/article.ts
+++ b/src/entities/Article/model/types/article.ts
@@ -39,6 +39,11 @@ export interface ArticleCardType {
         name: string;
         color: string;
     };
+    categories?: {
+        id: number;
+        name: string;
+        color: string;
+    }[];
     created: string;
     likeCount: number;
     reviewCount: number;

--- a/src/entities/Article/ui/ArticleCard/ArticleCard.tsx
+++ b/src/entities/Article/ui/ArticleCard/ArticleCard.tsx
@@ -18,12 +18,14 @@ export const ArticleCard: FC<ArticleCardProps> = memo(
     (props: ArticleCardProps) => {
         const {
             article: {
-                image, name, category, created,
+                image, name, category, categories, created,
                 likeCount, reviewCount,
             },
             className,
             path,
         } = props;
+
+        const tags = categories && categories.length > 0 ? categories : [category];
 
         return (
             <Link className={styles.link} to={path}>
@@ -36,15 +38,18 @@ export const ArticleCard: FC<ArticleCardProps> = memo(
                     <span className={styles.title}>{name}</span>
                     <div className={styles.container}>
                         <span className={styles.date}>{created}</span>
-                        <div
-                            className={cn(
-                                styles.tag,
-                                { [styles.tagSmall]: category.name.length > 25 },
-                            )}
-                            style={{ backgroundColor: category.color === "" ? "#3DABF7" : category.color }}
-                        >
-                            {category.name}
-                        </div>
+                        {tags.map((tag) => (
+                            <div
+                                key={tag.id}
+                                className={cn(
+                                    styles.tag,
+                                    { [styles.tagSmall]: tag.name.length > 25 },
+                                )}
+                                style={{ backgroundColor: tag.color === "" ? "#3DABF7" : tag.color }}
+                            >
+                                {tag.name}
+                            </div>
+                        ))}
                     </div>
                     <p className={styles.description}>
                         {/* {description.substring(0, 300)} */}

--- a/src/entities/Blog/lib/blogAdapter.ts
+++ b/src/entities/Blog/lib/blogAdapter.ts
@@ -8,14 +8,15 @@ export const blogArticleCardAdapter = (
     data: GetBlogList[],
 ): ArticleCardType[] => data.map((blog) => {
     const {
-        id, name, image, created, blogCategory, likeCount,
+        id, name, image, created, blogCategories, likeCount,
         reviewCount, isActive,
     } = blog;
     return {
         id: String(id),
         name,
         image: getMediaContent(image.thumbnails?.large),
-        category: blogCategory,
+        category: blogCategories[0],
+        categories: blogCategories,
         created,
         likeCount,
         reviewCount,

--- a/src/entities/Blog/model/types/blogSchema.ts
+++ b/src/entities/Blog/model/types/blogSchema.ts
@@ -26,7 +26,7 @@ export interface GetBlogList {
     reviewCount: number;
     likeCount: number;
     image: Image;
-    blogCategory: BlogCategory;
+    blogCategories: BlogCategory[];
 }
 
 export interface GetBlogListResponse {
@@ -45,10 +45,10 @@ export interface GetBlogListParams {
     limit: number;
 }
 
-export type GetBlog = Omit<GetBlogList, "blogCategory"> & {
+export type GetBlog = Omit<GetBlogList, "blogCategories"> & {
     isHasLike: boolean;
     isGudserfing: boolean;
-    blogCategoryResult: BlogCategory;
+    blogCategoryResults: BlogCategory[];
     author: {
         id: string;
         firstName: string | null;
@@ -71,7 +71,7 @@ export interface PublicBlogParams {
 
 export type CreateBlog = Pick<GetBlog, "name" | "description" | "isActive"> & {
     imageId: string;
-    categoryId: number | null;
+    categoryIds: number[];
 };
 
 export interface UpdateBlogParams {

--- a/src/features/Admin/ui/AdminArticleForm/ui/AdminArticleForm/AdminArticleForm.tsx
+++ b/src/features/Admin/ui/AdminArticleForm/ui/AdminArticleForm/AdminArticleForm.tsx
@@ -29,7 +29,8 @@ interface AdminArticleFormProps {
 export interface AdminArticleFormFields {
     image: Image;
     name: string;
-    categoryId: number;
+    categoryId?: number;
+    categoryIds?: number[];
     description: string;
     author: {
         id: string;
@@ -142,13 +143,13 @@ export const AdminArticleForm: FC<AdminArticleFormProps> = memo(
                     <span className={styles.title}>
                         {t("volunteer-create-article.Категория статьи")}
                     </span>
-                    <Controller
-                        name="categoryId"
-                        control={control}
-                        rules={{ required: "Выберите категорию" }}
-                        render={({ field, fieldState }) => (
-                            <div className={styles.categoryWrapper}>
-                                {category === "Offer" ? (
+                    {category === "Offer" ? (
+                        <Controller
+                            name="categoryId"
+                            control={control}
+                            rules={{ required: "Выберите категорию" }}
+                            render={({ field, fieldState }) => (
+                                <div className={styles.categoryWrapper}>
                                     <OfferCategories
                                         locale={locale}
                                         exclusive
@@ -157,25 +158,40 @@ export const AdminArticleForm: FC<AdminArticleFormProps> = memo(
                                             value ? Number(value) : undefined,
                                         )}
                                     />
-                                )
-                                    : (
-                                        <BlogCategories
-                                            locale={locale}
-                                            exclusive
-                                            value={field.value ? Number(field.value) : undefined}
-                                            onChange={(value) => field.onChange(
-                                                value ? Number(value) : undefined,
-                                            )}
-                                        />
+                                    {fieldState.error && (
+                                        <span className={styles.error}>
+                                            {fieldState.error.message}
+                                        </span>
                                     )}
-                                {fieldState.error && (
-                                    <span className={styles.error}>
-                                        {fieldState.error.message}
-                                    </span>
-                                )}
-                            </div>
-                        )}
-                    />
+                                </div>
+                            )}
+                        />
+                    ) : (
+                        <Controller
+                            name="categoryIds"
+                            control={control}
+                            rules={{
+                                validate: (value) => (
+                                    (Array.isArray(value) && value.length > 0)
+                                        || "Выберите хотя бы одну категорию"
+                                ),
+                            }}
+                            render={({ field, fieldState }) => (
+                                <div className={styles.categoryWrapper}>
+                                    <BlogCategories
+                                        locale={locale}
+                                        value={field.value}
+                                        onChange={field.onChange}
+                                    />
+                                    {fieldState.error && (
+                                        <span className={styles.error}>
+                                            {fieldState.error.message}
+                                        </span>
+                                    )}
+                                </div>
+                            )}
+                        />
+                    )}
                 </div>
                 <Controller
                     name="description"

--- a/src/features/Article/ui/ArticleHeader/ArticleHeader.tsx
+++ b/src/features/Article/ui/ArticleHeader/ArticleHeader.tsx
@@ -17,6 +17,7 @@ interface ArticleHeaderProps {
     date: string;
     category?: string;
     categoryColor?: string;
+    categories?: { name: string; color: string }[];
     likes: number;
     reviews: number;
     onLike?: () => void;
@@ -26,8 +27,14 @@ interface ArticleHeaderProps {
 export const ArticleHeader: FC<ArticleHeaderProps> = (props: ArticleHeaderProps) => {
     const {
         className, authorId, authorAvatar, authorName, category, date, title,
-        categoryColor, onLike, likes, reviews, locale,
+        categoryColor, categories, onLike, likes, reviews, locale,
     } = props;
+    let tags: { name: string; color: string }[] = [];
+    if (categories && categories.length > 0) {
+        tags = categories;
+    } else if (category && categoryColor) {
+        tags = [{ name: category, color: categoryColor }];
+    }
     return (
         <div className={cn(className, styles.wrapper)}>
             <h1 className={styles.title}>{title}</h1>
@@ -44,14 +51,15 @@ export const ArticleHeader: FC<ArticleHeaderProps> = (props: ArticleHeaderProps)
                         </CustomLink>
                     )}
                     <span className={styles.date}>{date}</span>
-                    {(category && categoryColor) && (
+                    {tags.map((tag) => (
                         <div
+                            key={tag.name}
                             className={styles.category}
-                            style={{ backgroundColor: categoryColor }}
+                            style={{ backgroundColor: tag.color }}
                         >
-                            {category}
+                            {tag.name}
                         </div>
-                    )}
+                    ))}
                 </div>
                 <div className={styles.containerIcon}>
                     <div className={cn(styles.wrapperIcon, styles.like)} onClick={onLike}>

--- a/src/features/ArticleForm/ui/ArticleForm/ArticleForm.tsx
+++ b/src/features/ArticleForm/ui/ArticleForm/ArticleForm.tsx
@@ -30,6 +30,7 @@ export interface ArticleFormFields {
     image: Image;
     name: string;
     categoryId?: number;
+    categoryIds?: number[];
     description: string;
     // projectUrl: string;
     isActive: boolean;
@@ -139,13 +140,13 @@ export const ArticleForm: FC<ArticleFormProps> = memo(
                     <span className={styles.title}>
                         {t("volunteer-create-article.Категория статьи")}
                     </span>
-                    <Controller
-                        name="categoryId"
-                        control={control}
-                        rules={{ required: "Выберите категорию" }}
-                        render={({ field, fieldState }) => (
-                            <div className={styles.categoryWrapper}>
-                                {category === "Offer" ? (
+                    {category === "Offer" ? (
+                        <Controller
+                            name="categoryId"
+                            control={control}
+                            rules={{ required: "Выберите категорию" }}
+                            render={({ field, fieldState }) => (
+                                <div className={styles.categoryWrapper}>
                                     <OfferCategories
                                         locale={locale}
                                         exclusive
@@ -154,26 +155,42 @@ export const ArticleForm: FC<ArticleFormProps> = memo(
                                             value ? Number(value) : undefined,
                                         )}
                                     />
-                                )
-                                    : (
-                                        <BlogCategories
-                                            locale={locale}
-                                            exclusive
-                                            value={field.value ? Number(field.value) : undefined}
-                                            onChange={(value) => field.onChange(
-                                                value ? Number(value) : undefined,
-                                            )}
-                                        />
+                                    {fieldState.error && (
+                                        <span className={styles.error}>
+                                            {translate(fieldState.error.message)
+                                            ?? fieldState.error.message}
+                                        </span>
                                     )}
-                                {fieldState.error && (
-                                    <span className={styles.error}>
-                                        {translate(fieldState.error.message)
-                                        ?? fieldState.error.message}
-                                    </span>
-                                )}
-                            </div>
-                        )}
-                    />
+                                </div>
+                            )}
+                        />
+                    ) : (
+                        <Controller
+                            name="categoryIds"
+                            control={control}
+                            rules={{
+                                validate: (value) => (
+                                    (Array.isArray(value) && value.length > 0)
+                                        || "Выберите хотя бы одну категорию"
+                                ),
+                            }}
+                            render={({ field, fieldState }) => (
+                                <div className={styles.categoryWrapper}>
+                                    <BlogCategories
+                                        locale={locale}
+                                        value={field.value}
+                                        onChange={field.onChange}
+                                    />
+                                    {fieldState.error && (
+                                        <span className={styles.error}>
+                                            {translate(fieldState.error.message)
+                                            ?? fieldState.error.message}
+                                        </span>
+                                    )}
+                                </div>
+                            )}
+                        />
+                    )}
                 </div>
                 <Controller
                     name="description"

--- a/src/widgets/Admin/ui/AdminBlogTable/AdminBlogTable.tsx
+++ b/src/widgets/Admin/ui/AdminBlogTable/AdminBlogTable.tsx
@@ -97,8 +97,6 @@ const blogCustomFields: CustomFilterField<keyof BlogFilters>[] = [
                 >
                     <MenuItem value={AdminSort.NameAsc}>Название статьи ↑</MenuItem>
                     <MenuItem value={AdminSort.NameDesc}>Название статьи ↓</MenuItem>
-                    <MenuItem value={AdminSort.CategoryNameAsc}>Категории ↑</MenuItem>
-                    <MenuItem value={AdminSort.CategoryNameDesc}>Категории ↓</MenuItem>
                     <MenuItem value={AdminSort.FioAsc}>ФИО автора ↑</MenuItem>
                     <MenuItem value={AdminSort.FioDesc}>ФИО автора ↓</MenuItem>
                     <MenuItem value={AdminSort.IsActiveAsc}>

--- a/src/widgets/Article/ui/VolunteerArticleInfo/VolunteerArticleInfo.tsx
+++ b/src/widgets/Article/ui/VolunteerArticleInfo/VolunteerArticleInfo.tsx
@@ -31,7 +31,7 @@ export const VolunteerArticleInfo: FC<VolunteerArticleInfoProps> = (props) => {
     const onSubmit = async (data: ArticleFormFields) => {
         setToast(undefined);
         const {
-            name, description, image, isActive, categoryId,
+            name, description, image, isActive, categoryIds,
         } = data;
         try {
             await updateBlog({
@@ -41,7 +41,7 @@ export const VolunteerArticleInfo: FC<VolunteerArticleInfoProps> = (props) => {
                     description,
                     imageId: image?.id,
                     isActive,
-                    categoryId: categoryId || null,
+                    categoryIds: categoryIds || [],
                 },
             }).unwrap();
             const successToast = isActive ? "Статья успешно обновлена и опубликована" : "Статья успешно сохранена в черновиках";
@@ -54,14 +54,14 @@ export const VolunteerArticleInfo: FC<VolunteerArticleInfoProps> = (props) => {
     useEffect(() => {
         if (articleData) {
             const {
-                name, description, image, isActive, blogCategoryResult,
+                name, description, image, isActive, blogCategoryResults,
             } = articleData;
             setInitialDataForm({
                 name,
                 description,
                 image,
                 isActive,
-                categoryId: blogCategoryResult?.id,
+                categoryIds: blogCategoryResults?.map((c) => c.id),
             });
         }
     }, [articleData]);

--- a/src/widgets/Article/ui/VolunteerCreateArticle/VolunteerCreateArticle.tsx
+++ b/src/widgets/Article/ui/VolunteerCreateArticle/VolunteerCreateArticle.tsx
@@ -25,7 +25,7 @@ export const VolunteerCreateArticle: FC<VolunteerCreateArticleProps> = (props) =
     const onSubmit = async (data: ArticleFormFields) => {
         setToast(undefined);
         const {
-            name, description, image, isActive, categoryId,
+            name, description, image, isActive, categoryIds,
         } = data;
         try {
             await createBlog({
@@ -33,7 +33,7 @@ export const VolunteerCreateArticle: FC<VolunteerCreateArticleProps> = (props) =
                 description,
                 imageId: image?.id,
                 isActive,
-                categoryId: categoryId || null,
+                categoryIds: categoryIds || [],
             }).unwrap();
             onSuccess();
         } catch {

--- a/src/widgets/Blog/ui/BlogPersonal/BlogPersonal.tsx
+++ b/src/widgets/Blog/ui/BlogPersonal/BlogPersonal.tsx
@@ -159,8 +159,7 @@ export const BlogPersonal: FC<BlogPersonalProps> = (props) => {
                     authorId={data?.author?.id}
                     authorAvatar={getMediaContent(data?.author?.image?.thumbnails?.small)}
                     authorName={getFullName(data?.author?.firstName, data?.author?.lastName)}
-                    category={data?.blogCategoryResult.name}
-                    categoryColor={data?.blogCategoryResult.color}
+                    categories={data?.blogCategoryResults}
                     date={data?.created ?? ""}
                     likes={data?.likeCount ?? 0}
                     reviews={data?.reviewCount ?? 0}


### PR DESCRIPTION
## Summary
- Подтягивает фронтенд под backend-переход `blogCategory` → `blogCategories: BlogCategory[]` (ManyToMany), см. парный PR в gs-backend (#247).
- Форма создания/редактирования статьи блога (публичная и админка): Blog-ветка `ArticleForm`/`AdminArticleForm` теперь мультиселект без `exclusive` (лимит 5, как и раньше в виджете `BlogCategories.tsx`). Offer/News-ветки этих же общих компонентов не тронуты.
- Карточка статьи и шапка статьи рендерят несколько бейджей категорий (добавлено опциональное поле `categories[]` рядом с существующим `category`, чтобы не сломать News, который делит те же компоненты).
- Admin-таблица статей блога: убраны два пункта сортировки по категории, которые на бэкенде всегда падали 500 (несовпадение ключа сортировки).

## Test plan
- [x] `npm run type-check` — чисто
- [x] `npm run lint` — 0 новых предупреждений/ошибок в затронутых файлах
- [ ] Живая проверка на стейдже (после мержа): создание статьи с несколькими категориями, редактирование (добавление/удаление категорий), карточка блога, страница статьи, что News/Offer не затронуты

🤖 Generated with [Claude Code](https://claude.com/claude-code)