### PR TITLE
feat(main-page): показывать 7 категорий на главной вместо 3

### DIFF
--- a/src/pages/MainPage/ui/WelcomeContainer/InfoSide/ActivityContainer/ActivityContainer.tsx
+++ b/src/pages/MainPage/ui/WelcomeContainer/InfoSide/ActivityContainer/ActivityContainer.tsx
@@ -38,7 +38,7 @@ const ActivityContainer: FC<ActivityContainerProps> = (props) => {
 
     return (
         <div className={cn(styles.wrapper, className)}>
-            {categoriesData.slice(0, 3).map((item, index) => (
+            {categoriesData.slice(0, 7).map((item, index) => (
                 <ActivityItem
                     title={item.name}
                     image={item.imagePath}


### PR DESCRIPTION
## Summary
На главной странице блок категорий (`ActivityContainer`) показывал только 3 категории + плитку "Другие категории" — один неполный ряд с пустым местом под ним, хотя категорий на сервере уже 14 (используется `findBy([])` без пагинации, так что все доступны).

Плитка 126px + gap 10px, `.wrapper` max-width 560px → ровно 4 плитки в ряд. 7 категорий + "Другие категории" = 8 = два полных ряда.

## Test plan
- [x] Живая проверка в браузере (dev-сервер + локальный бэкенд, Playwright)
- [x] 1440px (десктоп) — два чистых ряда по 4
- [x] 768px (мобильная раскладка, `justify-content: center`) — два чистых центрированных ряда
- [x] На промежуточных ширинах (~1000–1300px) последний ряд может быть неполным — то же уже было с 3 категориями, не новый эффект, а следствие flex-раскладки между текстовой и hero-колонками

🤖 Generated with [Claude Code](https://claude.com/claude-code)