### PR TITLE
Фикс: превьюшки новостей пропадали для легаси-статей без thumbnails

### DIFF
--- a/src/containers/CommunityNewsContainer/CommunityNewsContainer.tsx
+++ b/src/containers/CommunityNewsContainer/CommunityNewsContainer.tsx
@@ -72,7 +72,7 @@ const CommunityNewsContainer: FC = () => {
                                         id={item.id.toString()}
                                         title={item.name}
                                         date={item.created}
-                                        image={getMediaContent(item.image.thumbnails?.large)}
+                                        image={getMediaContent(item.image, "LARGE")}
                                         locale={locale}
                                     />
                                 </SwiperSlide>

--- a/src/entities/News/lib/newsAdapter.test.ts
+++ b/src/entities/News/lib/newsAdapter.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { newsArticleCardAdapter } from "./newsAdapter";
+import { GetNewsList } from "../model/types/newsSchema";
+
+/**
+ * Регресс-тест: превьюшки пропадали на /ru/news для легаси-новостей без
+ * thumbnails (только contentUrl) — адаптер передавал в getMediaContent
+ * уже сузившуюся строку image?.thumbnails?.large (undefined), из-за чего
+ * встроенный фолбэк на contentUrl внутри getMediaContent никогда не срабатывал.
+ */
+describe("newsArticleCardAdapter", () => {
+    const base: GetNewsList = {
+        id: "1",
+        name: "Заголовок",
+        description: "",
+        created: "2026-01-01",
+        reviewCount: 0,
+        likeCount: 0,
+        category: { id: "c1", name: "Другое" },
+        image: {
+            id: "img1",
+            contentUrl: "https://cdn.example/legacy-original.png",
+        },
+    } as unknown as GetNewsList;
+
+    it("падает на contentUrl для легаси-новостей без thumbnails", () => {
+        const result = newsArticleCardAdapter(base);
+        expect(result.image).toBe("https://cdn.example/legacy-original.png");
+    });
+
+    it("использует thumbnails.large, когда он есть", () => {
+        const result = newsArticleCardAdapter({
+            ...base,
+            image: {
+                id: "img2",
+                contentUrl: "https://cdn.example/original.png",
+                thumbnails: {
+                    large: "https://cdn.example/large.webp",
+                    medium: "https://cdn.example/medium.webp",
+                    small: "https://cdn.example/small.webp",
+                },
+            },
+        } as unknown as GetNewsList);
+        expect(result.image).toBe("https://cdn.example/large.webp");
+    });
+});

--- a/src/entities/News/lib/newsAdapter.ts
+++ b/src/entities/News/lib/newsAdapter.ts
@@ -27,6 +27,6 @@ export const newsArticleCardAdapter = (data: GetNewsList): ArticleCardType => {
         name,
         reviewCount,
         isActive: true,
-        image: getMediaContent(image?.thumbnails?.large),
+        image: getMediaContent(image, "LARGE"),
     };
 };

--- a/src/shared/lib/getMediaContent.ts
+++ b/src/shared/lib/getMediaContent.ts
@@ -12,7 +12,7 @@ const toAbsoluteUrl = (url: string): string => {
 };
 
 export const getMediaContent = (
-    value: string | MediaObjectType | ImageType | undefined,
+    value: string | MediaObjectType | ImageType | Image | undefined,
     size: MediaContentSize = "ORIGINAL",
 ): string | undefined => {
     if (!value) return undefined;


### PR DESCRIPTION
## Проблема

На `/ru/news` у 3 из 5 новостей не отображалось превью (пустой `src`
у `<img>`) — это мигрированные/старые статьи, у которых картинка
загружена напрямую по `contentUrl`, без прогона через пайплайн генерации
webp-thumbnails (`thumbnails: null` в API-ответе).

## Причина

`newsArticleCardAdapter` и `CommunityNewsContainer` передавали в
`getMediaContent` уже сузившееся значение `image?.thumbnails?.large`
(`undefined`, когда `thumbnails` нет), из-за чего встроенный в
`getMediaContent` фолбэк на `contentUrl` никогда не срабатывал. Та же
природа бага, что уже чинили для `/offers-map` (PR gs-frontend#337/#338,
`getOfferImagePath`).

## Фикс

Передавать в `getMediaContent` весь объект `image` с `size="LARGE"` —
тогда используется уже существующая внутри `getMediaContent` логика
фолбэка на оригинал (`contentUrl`), просто раньше до неё не доходило.
Заодно расширил принимаемый `getMediaContent` тип на `Image` (тип из
`types/media`, которым уже пользуется News/Blog/Video).

## Проверка

- Добавлен `newsAdapter.test.ts` — 2 теста (фолбэк на `contentUrl` /
  использование `thumbnails.large`, когда он есть)
- revert-and-confirm-fails: тест ловит регресс на старой версии кода
- `tsc --noEmit` и `eslint` чистые