### PR TITLE
Фикс: пустое место в блоке отзывов на главной

### DIFF
--- a/src/containers/ReviewsContainer/ReviewItem/ReviewItem.module.scss
+++ b/src/containers/ReviewsContainer/ReviewItem/ReviewItem.module.scss
@@ -6,6 +6,18 @@
 	box-shadow: 0 5px 20px rgb(14 29 39 / 5%);
 }
 
+.image {
+	// Источники фото — разного разрешения (портретное/широкое), но слайд
+	// должен всегда занимать одну и ту же высоту, иначе Swiper (effect="fade")
+	// оставляет пустое место под короткими слайдами.
+	width: 480px;
+	height: 400px;
+
+	object-fit: cover;
+
+	flex-shrink: 0;
+}
+
 .info {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## Проблема

На главной странице в блоке отзывов после добавления 3 новых историй
под карточкой оставалось большое пустое белое поле.

## Причина

Новые фото — 480×271, исходное — 480×400. У `.image` не было явного
размера, поэтому картинка рендерилась в своих натуральных пикселях.
Swiper с `effect="fade"` резервирует высоту под первый слайд (400px) —
на более коротких слайдах снизу оставалась пустота.

## Фикс

`.image` зафиксирован на 480×400 с `object-fit: cover` — все 4 слайда
теперь одной высоты, короткие фото аккуратно обрезаются по центру.

## Проверка

Прогнал локально (`npm run start`), прошёлся по всем 4 слайдам через
стрелки навигации — везде фото 480×400, пустот нет, кроп выглядит
нормально (не режет по головам/важным деталям).