### PR TITLE
fix(profile): переход в Telegram не работал при заполнении хэндлом без URL

### DIFF
--- a/src/pages/HostPersonalPage/ui/HostlHeaderCard/HostlHeaderCard.tsx
+++ b/src/pages/HostPersonalPage/ui/HostlHeaderCard/HostlHeaderCard.tsx
@@ -5,6 +5,7 @@ import { ReactSVG } from "react-svg";
 import { Host } from "@/entities/Host";
 
 import { getMediaContent } from "@/shared/lib/getMediaContent";
+import { getSocialLink } from "@/shared/lib/getSocialLink";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
 import Button from "@/shared/ui/Button/Button";
 import {
@@ -94,13 +95,13 @@ export const HostlHeaderCard: FC<HostlHeaderCardProps> = memo(
                     <span className={styles.address}>{address}</span>
                     <div className={styles.socials}>
                         {vk !== "" && (
-                            <a href={vk} target="_blank" rel="noreferrer" className={styles.social}>
+                            <a href={getSocialLink(vk, "vk")} target="_blank" rel="noreferrer" className={styles.social}>
                                 <ReactSVG src={vkIcon} />
                                 <p className={styles.socialLabel}>Вконтакте</p>
                             </a>
                         )}
                         {telegram !== "" && (
-                            <a href={telegram} target="_blank" rel="noreferrer" className={styles.social}>
+                            <a href={getSocialLink(telegram, "telegram")} target="_blank" rel="noreferrer" className={styles.social}>
                                 <ReactSVG src={telegramIcon} />
                                 <p className={styles.socialLabel}>Telegram</p>
                             </a>

--- a/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.tsx
+++ b/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.tsx
@@ -9,6 +9,7 @@ import { Tooltip } from "@mui/material";
 // import { medalsData } from "@/shared/data/medals";
 import { ReactSVG } from "react-svg";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
+import { getSocialLink } from "@/shared/lib/getSocialLink";
 import memberIcon from "@/shared/assets/icons/select-check.svg";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
 import Button from "@/shared/ui/Button/Button";
@@ -208,25 +209,25 @@ export const VolunteerHeaderCard: FC<VolunteerHeaderCardProps> = memo(
                                 </span>
                                 <div className={styles.socials}>
                                     {((vk !== "") && (vk !== null)) && (
-                                        <a href={vk ?? undefined} target="_blank" rel="noreferrer" className={styles.social}>
+                                        <a href={getSocialLink(vk, "vk")} target="_blank" rel="noreferrer" className={styles.social}>
                                             <ReactSVG src={vkIcon} />
                                             <p className={styles.socialLabel}>Вконтакте</p>
                                         </a>
                                     )}
                                     {((telegram !== "") && (telegram !== null)) && (
-                                        <a href={telegram ?? undefined} target="_blank" rel="noreferrer" className={styles.social}>
+                                        <a href={getSocialLink(telegram, "telegram")} target="_blank" rel="noreferrer" className={styles.social}>
                                             <ReactSVG src={telegramIcon} />
                                             <p className={styles.socialLabel}>Telegram</p>
                                         </a>
                                     )}
                                     {((facebook !== "") && (facebook !== null)) && (
-                                        <a href={facebook ?? undefined} target="_blank" rel="noreferrer" className={styles.social}>
+                                        <a href={getSocialLink(facebook, "facebook")} target="_blank" rel="noreferrer" className={styles.social}>
                                             <ReactSVG src={facebookIcon} />
                                             <p className={styles.socialLabel}>Facebook</p>
                                         </a>
                                     )}
                                     {((instagram !== "") && (instagram !== null)) && (
-                                        <a href={instagram ?? undefined} target="_blank" rel="noreferrer" className={styles.social}>
+                                        <a href={getSocialLink(instagram, "instagram")} target="_blank" rel="noreferrer" className={styles.social}>
                                             <ReactSVG src={instaIcon} />
                                             <p className={styles.socialLabel}>Instagram</p>
                                         </a>

--- a/src/shared/lib/getSocialLink.test.ts
+++ b/src/shared/lib/getSocialLink.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { getSocialLink } from "./getSocialLink";
+
+/**
+ * Регресс-тест: переход в Telegram не работал на /volunteer-personal, если
+ * пользователь заполнял поле хэндлом вида "@username" (как в самом Telegram),
+ * а не полным URL — href становился относительной ссылкой на текущий сайт.
+ */
+describe("getSocialLink", () => {
+    it("converts a bare @handle to a full telegram URL", () => {
+        expect(getSocialLink("@lavillahotel", "telegram")).toBe("https://t.me/lavillahotel");
+    });
+
+    it("converts a handle without @ to a full telegram URL", () => {
+        expect(getSocialLink("lavillahotel", "telegram")).toBe("https://t.me/lavillahotel");
+    });
+
+    it("leaves a full URL untouched", () => {
+        expect(getSocialLink("https://t.me/lavillahotel", "telegram")).toBe("https://t.me/lavillahotel");
+    });
+
+    it("normalizes a vk handle to a full vk.com URL", () => {
+        expect(getSocialLink("@goodsurfing", "vk")).toBe("https://vk.com/goodsurfing");
+    });
+
+    it("returns undefined for empty or missing values", () => {
+        expect(getSocialLink("", "telegram")).toBeUndefined();
+        expect(getSocialLink(null, "telegram")).toBeUndefined();
+        expect(getSocialLink(undefined, "telegram")).toBeUndefined();
+    });
+});

--- a/src/shared/lib/getSocialLink.ts
+++ b/src/shared/lib/getSocialLink.ts
@@ -1,0 +1,29 @@
+type SocialPlatform = "vk" | "telegram" | "facebook" | "instagram";
+
+const PLATFORM_HOST: Record<SocialPlatform, string> = {
+    vk: "vk.com",
+    telegram: "t.me",
+    facebook: "facebook.com",
+    instagram: "instagram.com",
+};
+
+/**
+ * Профильные соцсети хранятся как произвольный текст (пользователи вводят как
+ * полный URL, так и просто хэндл вида "@username"), а рендерятся как <a href>.
+ * Хэндл без протокола становится относительной ссылкой на текущий сайт вместо
+ * перехода в соцсеть — нормализуем к полному https-URL.
+ */
+export const getSocialLink = (
+    value: string | null | undefined,
+    platform: SocialPlatform,
+): string | undefined => {
+    if (!value) return undefined;
+
+    const trimmed = value.trim();
+    if (trimmed === "") return undefined;
+
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+
+    const handle = trimmed.replace(/^@/, "");
+    return `https://${PLATFORM_HOST[platform]}/${handle}`;
+};


### PR DESCRIPTION
## Проблема
На странице волонтёра (пример: https://goodsurfing.org/ru/volunteer-personal/019dbe7f-ae55-72b7-b2ec-37c2e81061dd) переход в Telegram не работал — ссылка вела не в Telegram, а на текущий сайт.

## Причина
Поле Telegram (как и VK/Facebook/Instagram) в профиле — обычный текст без подсказки формата. Пользователь заполнил его хэндлом `@lavillahotel` (как принято в самом Telegram), а не полным URL. Значение подставлялось напрямую в `href` без нормализации — браузер трактовал `@lavillahotel` как относительный путь на текущем сайте.

## Фикс
Добавлен shared-хелпер `getSocialLink(value, platform)`, который приводит хэндл (с `@` или без) к полному `https://{host}/{handle}` для нужной соцсети, а уже полный URL оставляет без изменений. Применён в `VolunteerHeaderCard` и `HostlHeaderCard` для vk/telegram/facebook/instagram — та же проблема потенциально затрагивала и организаторов.

## Проверка
- Юнит-тесты на `getSocialLink`: хэндл с `@`, хэндл без `@`, готовый URL, пустое/null значение — все проходят.
- revert-and-confirm-fails: временно упростил нормализацию, тесты упали как ожидалось, восстановил.
- `tsc --noEmit` и `eslint` на изменённых файлах — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)