### PR TITLE
feat(nginx): проксировать старые URL вакансий /offers/host/{id} на backend

### DIFF
--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -79,6 +79,21 @@ server {
         return 200 "OK\n";
     }
 
+    # ─── Legacy vacancy URLs: /offers/host/{legacyId} ──────────
+    # Проиндексированы поисковиками ещё на прежнем домене (до появления
+    # old.goodsurfing.org). Резолвим legacyId -> актуальный ID через
+    # gs-backend (Vacancy.legacyId), который отдаёт 301 на /ru/offer-personal/{id}.
+    # Docker embedded DNS (127.0.0.11) + переменная в proxy_pass — иначе nginx
+    # резолвит "backend" один раз при старте и не увидит новый IP после
+    # передеплоя backend-контейнера независимо от frontend.
+    location ~ ^/offers/host/\d+$ {
+        resolver 127.0.0.11 valid=10s;
+        set $legacy_backend "http://backend:80";
+        proxy_pass $legacy_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ─── SPA fallback ──────────────────────────────────────────
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Проблема
Поисковики проиндексировали старые URL вакансий вида `/offers/host/1094` ещё на прежнем домене (до появления `old.goodsurfing.org`, когда легаси-сайт жил на текущем apex-домене `goodsurfing.org`). SPA не знает такого роута — эти ссылки 404-ились.

## Фикс
gs-backend теперь умеет резолвить `legacyId` → актуальный ID вакансии и отдавать `301 → /ru/offer-personal/{id}` (см. [Goodsurfing/gs-backend#252](https://github.com/Goodsurfing/gs-backend/pull/252)). Добавлен nginx location-блок, который проксирует запросы `/offers/host/{digits}` внутрь docker-сети на `backend`-контейнер — SPA/index.html тут не участвует.

Resolver на embedded Docker DNS (`127.0.0.11`) + переменная в `proxy_pass`, чтобы nginx не кэшировал IP backend-контейнера на старте и не терял его после независимого передеплоя backend.

Легаси-сервер `old.goodsurfing.org` в этом решении не участвует и не затрагивается.

## Проверка
Локально поднял frontend-nginx с этим конфигом + мок-backend в одной docker-сети:
- `/offers/host/1094` → корректно проксируется, отдаёт `301`
- `/offers/host/abc` (не число) → не матчится, падает в обычный SPA fallback
- остальные роуты (`/assets`, `/locales`, `/ru/offer-personal/...`) не задеты

🤖 Generated with [Claude Code](https://claude.com/claude-code)