### PR TITLE
fix(messenger): Enter в поле сообщения игнорировал disabled

### DIFF
--- a/src/features/Messenger/ui/ChatInput/ChatInput.test.tsx
+++ b/src/features/Messenger/ui/ChatInput/ChatInput.test.tsx
@@ -1,0 +1,42 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChatInput } from "./ChatInput";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * Регресс-guard: на странице заявки на вакансию (/messenger/create/{offerId})
+ * поле ввода намеренно disabled — отправка сообщения тут ещё не поддерживается
+ * (сначала нужно отправить даты через TermsApplication). Кнопка отправки
+ * disabled корректно блокировала клик, но Enter в textarea не проверял
+ * disabled и всё равно вызывал onSendMessage — запрос уходил на chatId
+ * "create" и падал с ошибкой (красная плашка), как только пользователь
+ * пытался написать что-то и нажать Enter.
+ */
+describe("ChatInput — disabled", () => {
+    it("не отправляет сообщение по Enter, если инпут disabled", () => {
+        const onSendMessage = vi.fn();
+        render(<ChatInput disabled onSendMessage={onSendMessage} onError={vi.fn()} />);
+
+        const input = screen.getByPlaceholderText("Написать сообщение");
+        fireEvent.change(input, { target: { value: "Привет" } });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("отправляет сообщение по Enter, если инпут не disabled", () => {
+        const onSendMessage = vi.fn();
+        render(<ChatInput onSendMessage={onSendMessage} onError={vi.fn()} />);
+
+        const input = screen.getByPlaceholderText("Написать сообщение");
+        fireEvent.change(input, { target: { value: "Привет" } });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        expect(onSendMessage).toHaveBeenCalledWith({ text: "Привет", attachments: [] });
+    });
+});

--- a/src/features/Messenger/ui/ChatInput/ChatInput.tsx
+++ b/src/features/Messenger/ui/ChatInput/ChatInput.tsx
@@ -57,6 +57,7 @@ export const ChatInput: FC<ChatInputProps> = (props) => {
     };
 
     const handleSendMessage = () => {
+        if (disabled) return;
         if (inputValue.trim() || attachmentValue) {
             const formMessage: SendMessageType = {
                 text: inputValue,


### PR DESCRIPTION
## Проблема
На странице заявки на вакансию (`/messenger/create/{offerId}`, скриншот пользователя) после клика «Участвовать» появляется чат, где поле «Написать сообщение» намеренно `disabled` — отправка обычных сообщений тут ещё не поддерживается, сначала нужно указать даты через форму заявки выше. Кнопка отправки это корректно блокировала (disabled), но при наборе текста и нажатии Enter сообщение всё равно уходило.

## Причина
`ChatInput.handleKeyDown` вызывал `handleSendMessage()` на Enter без проверки `disabled` — только кнопка учитывала этот пропс. Запрос улетал с `chatId="create"` (реального чата ещё нет) и без валидного получателя → бэкенд отвечал ошибкой → всплывала красная плашка «Произошла ошибка при отправке сообщения».

## Фикс
`handleSendMessage` в `ChatInput` теперь выходит рано, если `disabled` — Enter и кнопка ведут себя одинаково.

## Проверка
- Юнит-тесты: Enter не отправляет при `disabled`, отправляет при `!disabled`.
- revert-and-confirm-fails пройден.
- `tsc --noEmit` и `eslint` на изменённых файлах — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)