### PR TITLE
fix(our-team): страница команды грузила оригиналы фото по 1-2.4 МБ вместо превью

### DIFF
--- a/src/pages/OurTeamPage/ui/Founders/Founders.tsx
+++ b/src/pages/OurTeamPage/ui/Founders/Founders.tsx
@@ -23,7 +23,7 @@ export const Founders: FC<FoundersProps> = memo((props: FoundersProps) => {
     const renderItems = useMemo(
         () => data?.data?.map((item, index) => (
             <TeamItem
-                image={getMediaContent(item.image.contentUrl)}
+                image={getMediaContent(item.image, "LARGE")}
                 name={getFullName(item.firstName, item.lastName)}
                 description={item.position}
                 vk={item.vkontakte}

--- a/src/pages/OurTeamPage/ui/GoodsurfingTeam/GoodsurfingTeam.test.tsx
+++ b/src/pages/OurTeamPage/ui/GoodsurfingTeam/GoodsurfingTeam.test.tsx
@@ -1,0 +1,59 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GoodsurfingTeam } from "./GoodsurfingTeam";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+const contentUrl = "https://storage.yandexcloud.net/gs-media-prod/media/original-2mb-photo.jpg";
+const thumbnailUrl = "https://storage.yandexcloud.net/gs-media-prod/media/thumbnails/large/original-2mb-photo.webp";
+
+vi.mock("@/entities/Admin", () => ({
+    useGetOurTeamListQuery: () => ({
+        data: {
+            data: [{
+                id: "1",
+                firstName: "Милана",
+                lastName: "Фурман",
+                position: "Координатор",
+                userId: null,
+                vkontakte: null,
+                telegram: null,
+                image: {
+                    id: "img-1",
+                    contentUrl,
+                    thumbnails: { large: thumbnailUrl, medium: thumbnailUrl, small: thumbnailUrl },
+                },
+            }],
+        },
+        isLoading: false,
+    }),
+}));
+
+/**
+ * Регресс-guard: карточки команды на /ru/our-team рендерили оригинал фото
+ * (contentUrl) вместо превью — getMediaContent получал уже сузившуюся строку
+ * item.image.contentUrl вместо полного объекта image, из-за чего встроенный
+ * в getMediaContent выбор thumbnail никогда не срабатывал. На проде это
+ * приводило к загрузке фото по 1-2.4 МБ на маленькую 180×180 карточку.
+ */
+describe("GoodsurfingTeam", () => {
+    it("рендерит превью (thumbnails.large), а не оригинал фото", () => {
+        render(<GoodsurfingTeam />);
+
+        const img = screen.getByRole("img") as HTMLImageElement;
+        expect(img.src).toBe(thumbnailUrl);
+        expect(img.src).not.toBe(contentUrl);
+    });
+});

--- a/src/pages/OurTeamPage/ui/GoodsurfingTeam/GoodsurfingTeam.tsx
+++ b/src/pages/OurTeamPage/ui/GoodsurfingTeam/GoodsurfingTeam.tsx
@@ -23,7 +23,7 @@ export const GoodsurfingTeam: FC<GoodsurfingTeamProps> = memo((props: Goodsurfin
     const renderItems = useMemo(
         () => data?.data.map((item, index) => (
             <TeamItem
-                image={getMediaContent(item.image.contentUrl)}
+                image={getMediaContent(item.image, "LARGE")}
                 name={getFullName(item.firstName, item.lastName)}
                 description={item.position}
                 vk={item.vkontakte}


### PR DESCRIPTION
## Проблема
`/ru/our-team` рендерила фото участников команды в исходном разрешении (карточка 180×180, а с сервера прилетало по 1-2.4 МБ на фото).

## Причина
`GoodsurfingTeam.tsx` и `Founders.tsx` передавали в `getMediaContent()` уже сузившуюся строку `item.image.contentUrl` вместо полного объекта `image`, из-за чего встроенный в `getMediaContent` выбор нужного thumbnail никогда не срабатывал (тот же класс бага, что чинили для новостей — `newsAdapter.ts`). Бэкенд thumbnails генерировал исправно (small/medium/large webp) — фронт их просто не запрашивал.

## Фикс
`getMediaContent(item.image, "LARGE")` — 480×360 webp, с фолбэком на оригинал, если thumbnails почему-то нет.

## Проверка
- Юнит-тест на `GoodsurfingTeam` (рендерит `thumbnails.large`, не `contentUrl`).
- revert-and-confirm-fails пройден.
- `tsc --noEmit` и `eslint` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)