### PR TITLE
feat(seo): ЧПУ для News/Blog/Journal (row 117)

### DIFF
--- a/src/containers/CommunityNewsContainer/CommunityNewsContainer.tsx
+++ b/src/containers/CommunityNewsContainer/CommunityNewsContainer.tsx
@@ -69,7 +69,7 @@ const CommunityNewsContainer: FC = () => {
                             && data.data.map((item, index) => (
                                 <SwiperSlide key={index}>
                                     <CommunityNewsItem
-                                        id={item.id.toString()}
+                                        id={item.slug}
                                         title={item.name}
                                         date={item.created}
                                         image={getMediaContent(item.image, "LARGE")}

--- a/src/entities/Article/model/types/article.ts
+++ b/src/entities/Article/model/types/article.ts
@@ -31,6 +31,7 @@ export interface Video {
 
 export interface ArticleCardType {
     id: string;
+    slug: string;
     image?: string;
     name: string;
     isActive: boolean;

--- a/src/entities/Article/ui/JournalCard/JournalCard.tsx
+++ b/src/entities/Article/ui/JournalCard/JournalCard.tsx
@@ -11,6 +11,7 @@ import styles from "./JournalCard.module.scss";
 
 export interface JournalCardType {
     id: string;
+    slug: string;
     title: string;
     description: string;
     date: string;
@@ -27,14 +28,14 @@ interface JournalCardProps {
 export const JournalCard: FC<JournalCardProps> = (props) => {
     const {
         journal: {
-            id, title, description, date, comments, image, likes,
+            slug, title, description, date, comments, image, likes,
         },
         className,
     } = props;
     const { locale } = useLocale();
     return (
         <div className={cn(className, styles.wrapper)}>
-            <Link to={`/${locale}/journals/${id}`}>
+            <Link to={`/${locale}/journals/${slug}`}>
                 <img className={styles.image} src={image} alt={title} />
                 <span className={styles.title}>{title}</span>
                 <div className={styles.container}>

--- a/src/entities/Blog/lib/blogAdapter.ts
+++ b/src/entities/Blog/lib/blogAdapter.ts
@@ -8,11 +8,12 @@ export const blogArticleCardAdapter = (
     data: GetBlogList[],
 ): ArticleCardType[] => data.map((blog) => {
     const {
-        id, name, image, created, blogCategories, likeCount,
+        id, slug, name, image, created, blogCategories, likeCount,
         reviewCount, isActive,
     } = blog;
     return {
         id: String(id),
+        slug,
         name,
         image: getMediaContent(image.thumbnails?.large),
         category: blogCategories[0],

--- a/src/entities/Blog/model/types/blogSchema.ts
+++ b/src/entities/Blog/model/types/blogSchema.ts
@@ -19,6 +19,7 @@ export interface GetBlogCategoriesParams {
 
 export interface GetBlogList {
     id: number;
+    slug: string;
     name: string;
     description: string;
     created: string;
@@ -58,7 +59,9 @@ export type GetBlog = Omit<GetBlogList, "blogCategories"> & {
 };
 
 export interface GetBlogParams {
-    id: number;
+    // string — slug или сырой id из URL (row 117, ЧПУ); number — реальный id,
+    // когда он уже известен на руках (VolunteerArticleInfo и т.п.)
+    id: number | string;
     lang: Locale;
 }
 

--- a/src/entities/Journal/lib/journalAdapter.ts
+++ b/src/entities/Journal/lib/journalAdapter.ts
@@ -35,10 +35,11 @@ export const journalAdapter = (data: GetAdminJournal): AdminJournalFormFields =>
 
 export const journalCardAdapter = (data: GetJournals[]): JournalCardType[] => data.map((item) => {
     const {
-        id, name, image, likeCount, reviewCount, created,
+        id, slug, name, image, likeCount, reviewCount, created,
     } = item;
     return {
         id,
+        slug,
         title: name,
         image: getMediaContent(image.contentUrl) ?? "",
         description: "",

--- a/src/entities/Journal/model/journalSchema.ts
+++ b/src/entities/Journal/model/journalSchema.ts
@@ -10,6 +10,7 @@ export interface GetJournalsParams {
 
 export interface GetJournals {
     id: string;
+    slug: string;
     name: string;
     description: string;
     created: string;

--- a/src/entities/News/lib/newsAdapter.ts
+++ b/src/entities/News/lib/newsAdapter.ts
@@ -17,10 +17,11 @@ export const newsReviewsAdapter = (data: GetReviewsNews[]): Comments[] => data.m
 
 export const newsArticleCardAdapter = (data: GetNewsList): ArticleCardType => {
     const {
-        id, category, created, name, image, likeCount, reviewCount,
+        id, slug, category, created, name, image, likeCount, reviewCount,
     } = data;
     return {
         id,
+        slug,
         category,
         created,
         likeCount,

--- a/src/entities/News/model/types/newsSchema.ts
+++ b/src/entities/News/model/types/newsSchema.ts
@@ -15,6 +15,7 @@ export interface GetNewsListParams {
 
 export interface GetNewsList {
     id: string;
+    slug: string;
     name: string;
     description: string;
     created: string;

--- a/src/pages/BlogPage/ui/ArticlesList/ArticlesList.tsx
+++ b/src/pages/BlogPage/ui/ArticlesList/ArticlesList.tsx
@@ -25,7 +25,7 @@ export const ArticlesList: FC<ArticlesListProps> = (props) => {
                 article={article}
                 key={key}
                 className={styles.article}
-                path={getBlogPersonalPageUrl(locale, article.id.toString())}
+                path={getBlogPersonalPageUrl(locale, article.slug)}
             />
         )),
         [data, locale],

--- a/src/pages/BlogPersonalPage/ui/BlogPersonalPage/BlogPersonalPage.tsx
+++ b/src/pages/BlogPersonalPage/ui/BlogPersonalPage/BlogPersonalPage.tsx
@@ -10,7 +10,9 @@ const BlogPersonalPage = () => {
 
     return (
         <MainPageLayout headerVariant="static">
-            <BlogPersonal blogId={Number(id)} />
+            {id && (
+                <BlogPersonal blogIdOrSlug={id} />
+            )}
         </MainPageLayout>
     );
 };

--- a/src/pages/JournalPersonalPage/ui/JournalPersonalPage.tsx
+++ b/src/pages/JournalPersonalPage/ui/JournalPersonalPage.tsx
@@ -9,7 +9,7 @@ const JournalPersonalPage = () => {
     return (
         <MainPageLayout>
             {id && (
-                <JournalPersonal journalId={id} />
+                <JournalPersonal journalIdOrSlug={id} />
             )}
         </MainPageLayout>
     );

--- a/src/pages/NewsPage/ui/NewsList/NewsList.tsx
+++ b/src/pages/NewsPage/ui/NewsList/NewsList.tsx
@@ -20,7 +20,7 @@ export const NewsList: FC<NewsListProps> = (props) => {
             article={newsArticleCardAdapter(article)}
             key={article.id}
             className={styles.article}
-            path={getNewsPersonalPageUrl(locale, article.id.toString())}
+            path={getNewsPersonalPageUrl(locale, article.slug)}
         />
     )), [data, locale]);
 

--- a/src/pages/VolunteerArticlesPage/ui/ArticleEditCard/ArticleEditCard.tsx
+++ b/src/pages/VolunteerArticlesPage/ui/ArticleEditCard/ArticleEditCard.tsx
@@ -49,7 +49,10 @@ export const ArticleEditCard: FC<ArticleEditCardProps> = memo(
 
         return (
             <div className={cn(className, styles.wrapper)}>
-                <ArticleCard path={getBlogPersonalPageUrl(locale, article.id)} article={article} />
+                <ArticleCard
+                    path={getBlogPersonalPageUrl(locale, article.slug)}
+                    article={article}
+                />
                 <div ref={popupRef} className={styles.buttonContent}>
                     <button
                         type="button"

--- a/src/shared/config/routes/AppUrls.ts
+++ b/src/shared/config/routes/AppUrls.ts
@@ -195,7 +195,7 @@ export const getPrivacyPolicyPageUrl: RoutePathFunction = (locale) => `/${locale
 
 export const getJournalsPageUrl: RoutePathFunction = (locale) => `/${locale}${RoutePath.journals}`;
 
-export const getJournalPersonalPageUrl: RoutePathFunction = (locale) => `/${locale}${RoutePath.journals}/:id`;
+export const getJournalPersonalPageUrl: RoutePathFunction = (locale, id = ":id") => `/${locale}${RoutePath.journals}/${id}`;
 
 export const getVideoPageUrl: RoutePathFunction = (locale) => `/${locale}${RoutePath.video}`;
 

--- a/src/widgets/Blog/ui/BlogPersonal/BlogPersonal.tsx
+++ b/src/widgets/Blog/ui/BlogPersonal/BlogPersonal.tsx
@@ -18,7 +18,6 @@ import { CommentWidget } from "@/widgets/Article";
 import {
     getBlogPageUrl,
     getBlogPersonalPageUrl,
-    getNewsPersonalPageUrl,
 } from "@/shared/config/routes/AppUrls";
 import { MAIN_URL } from "@/shared/constants/api";
 import { useGetFullName } from "@/shared/lib/getFullName";
@@ -31,13 +30,13 @@ import { SeoHelmet } from "@/shared/ui/SeoHelmet";
 import styles from "./BlogPersonal.module.scss";
 
 interface BlogPersonalProps {
-    blogId: number;
+    blogIdOrSlug: string;
 }
 
 const VISIBLE_COUNT = 10;
 
 export const BlogPersonal: FC<BlogPersonalProps> = (props) => {
-    const { blogId } = props;
+    const { blogIdOrSlug } = props;
     const { locale } = useLocale();
     const { isAuth } = useAuth();
     const { t, ready } = useTranslation("blog");
@@ -46,13 +45,20 @@ export const BlogPersonal: FC<BlogPersonalProps> = (props) => {
     const [reviews, setReviews] = useState<GetReviewBlog[]>([]);
     const { getFullName } = useGetFullName();
 
-    const { data, isLoading } = useGetBlogByIdQuery({ id: blogId, lang: locale });
+    const { data, isLoading } = useGetBlogByIdQuery({ id: blogIdOrSlug, lang: locale });
     const articleContent = data?.description ?? "<p>Данная статья пустая</p>";
     const [putLike] = usePutLikeBlogMutation();
     const [createBlog] = useCreateReviewBlogMutation();
     const [getReviews, { data: reviewsData }] = useLazyGetReviewsBlogQuery();
 
+    // Реальный числовой id статьи, а не blogIdOrSlug (это может быть slug из
+    // URL) — лайки/комментарии/отклики на бэкенде завязаны на настоящий id.
+    const blogId = data?.id;
+
     const fetchReviews = useCallback(async (pageItem: number) => {
+        if (blogId === undefined) {
+            return;
+        }
         try {
             await getReviews({
                 blogId,
@@ -90,6 +96,9 @@ export const BlogPersonal: FC<BlogPersonalProps> = (props) => {
             });
             return;
         }
+        if (blogId === undefined) {
+            return;
+        }
         try {
             setToast(undefined);
             await putLike(blogId).unwrap();
@@ -102,6 +111,9 @@ export const BlogPersonal: FC<BlogPersonalProps> = (props) => {
     };
 
     const onComment = async (description: string) => {
+        if (blogId === undefined) {
+            return;
+        }
         try {
             await createBlog({ blogId, description }).unwrap();
             await fetchReviews(1);
@@ -129,7 +141,10 @@ export const BlogPersonal: FC<BlogPersonalProps> = (props) => {
     const seoDescription = data?.description
         ? getSeoDescription(data.description) || t("seo.description")
         : t("seo.description");
-    const seoUrl = getSeoUrl(getBlogPersonalPageUrl(locale, String(blogId)));
+    // data?.slug, а не blogIdOrSlug (сырой параметр из URL) — иначе переход
+    // по старой ссылке с голым числовым id даёт canonical на ту же
+    // нечитаемую ссылку, а не на новый человекопонятный slug (row 117).
+    const seoUrl = getSeoUrl(getBlogPersonalPageUrl(locale, data?.slug ?? blogIdOrSlug));
     const seoImage = getMediaContent(data?.image?.contentUrl);
 
     return (
@@ -169,7 +184,7 @@ export const BlogPersonal: FC<BlogPersonalProps> = (props) => {
                 <ArticleContent className={styles.content} content={articleContent} />
                 <ArticleShare
                     className={styles.shareBlock}
-                    url={`${MAIN_URL}${getNewsPersonalPageUrl(locale, String(data?.id))}`}
+                    url={`${MAIN_URL}${getBlogPersonalPageUrl(locale, data?.slug ?? String(data?.id))}`}
                 />
             </div>
             <div className={styles.commentWrapper}>

--- a/src/widgets/Journal/ui/JournalPersonal/JournalPersonal.tsx
+++ b/src/widgets/Journal/ui/JournalPersonal/JournalPersonal.tsx
@@ -25,7 +25,7 @@ import { SeoHelmet } from "@/shared/ui/SeoHelmet";
 import styles from "./JournalPersonal.module.scss";
 
 interface JournalPersonalProps {
-    journalId: string;
+    journalIdOrSlug: string;
 }
 
 const VISIBLE_COUNT = 10;
@@ -46,7 +46,7 @@ const getCalameoEmbedUrl = (url?: string) => {
 };
 
 export const JournalPersonal: FC<JournalPersonalProps> = (props) => {
-    const { journalId } = props;
+    const { journalIdOrSlug } = props;
     const { locale } = useLocale();
     const { isAuth } = useAuth();
     const { t, ready } = useTranslation("journals");
@@ -54,14 +54,21 @@ export const JournalPersonal: FC<JournalPersonalProps> = (props) => {
     const [page, setPage] = useState<number>(1);
     const [reviews, setReviews] = useState<GetReviewsJournal[]>([]);
 
-    const { data, isLoading } = useGetJournalByIdQuery(journalId);
+    const { data, isLoading } = useGetJournalByIdQuery(journalIdOrSlug);
     const articleContent = data?.description ?? "<p>Данная статья пустая</p>";
     const embedUrl = getCalameoEmbedUrl(data?.url);
     const [putLike] = usePutLikeJournalMutation();
     const [createReview] = useCreateReviewJournalMutation();
     const [getReviews, { data: reviewsData }] = useLazyGetReviewsByJournalIdQuery();
 
+    // Реальный id, а не journalIdOrSlug (может быть slug из URL) — лайки/
+    // комментарии на бэкенде завязаны на настоящий id (row 117).
+    const journalId = data?.id;
+
     const fetchReviews = useCallback(async (pageItem: number) => {
+        if (journalId === undefined) {
+            return;
+        }
         try {
             await getReviews({
                 journalId,
@@ -99,6 +106,9 @@ export const JournalPersonal: FC<JournalPersonalProps> = (props) => {
             });
             return;
         }
+        if (journalId === undefined) {
+            return;
+        }
         try {
             setToast(undefined);
             await putLike(journalId).unwrap();
@@ -116,6 +126,9 @@ export const JournalPersonal: FC<JournalPersonalProps> = (props) => {
                 text: "Чтобы оставить комментарий, нужно авторизоваться",
                 type: HintType.Error,
             });
+            return;
+        }
+        if (journalId === undefined) {
             return;
         }
         try {
@@ -145,7 +158,10 @@ export const JournalPersonal: FC<JournalPersonalProps> = (props) => {
     const seoDescription = data?.description
         ? getSeoDescription(data.description) || t("seo.description")
         : t("seo.description");
-    const seoUrl = getSeoUrl(getJournalPersonalPageUrl(locale, journalId));
+    // data?.slug, а не journalIdOrSlug (сырой параметр из URL) — иначе переход
+    // по старой ссылке с голым UUID даёт canonical на ту же нечитаемую
+    // ссылку, а не на новый человекопонятный slug (row 117).
+    const seoUrl = getSeoUrl(getJournalPersonalPageUrl(locale, data?.slug ?? journalIdOrSlug));
     const seoImage = getMediaContent(data?.image?.contentUrl);
     const seoKeywords = [
         data?.name,
@@ -198,7 +214,7 @@ export const JournalPersonal: FC<JournalPersonalProps> = (props) => {
                 </div>
                 <ArticleShare
                     className={styles.shareBlock}
-                    url={`${MAIN_URL}${getJournalPersonalPageUrl(locale, data?.id)}`}
+                    url={`${MAIN_URL}${getJournalPersonalPageUrl(locale, data?.slug ?? data?.id)}`}
                 />
             </div>
             <div className={styles.commentWrapper}>

--- a/src/widgets/News/ui/NewsPersonal/NewsPersonal.tsx
+++ b/src/widgets/News/ui/NewsPersonal/NewsPersonal.tsx
@@ -130,7 +130,10 @@ export const NewsPersonal: FC<NewsPersonalProps> = (props) => {
     const seoDescription = data?.description
         ? getSeoDescription(data.description) || t("seo.description")
         : t("seo.description");
-    const seoUrl = getSeoUrl(getNewsPersonalPageUrl(locale, newsId));
+    // data?.slug, а не newsId (сырой параметр из URL) — иначе переход по
+    // старой ссылке с голым UUID даёт canonical на ту же нечитаемую ссылку,
+    // а не на новый человекопонятный slug (весь смысл ЧПУ, row 117).
+    const seoUrl = getSeoUrl(getNewsPersonalPageUrl(locale, data?.slug ?? newsId));
     const seoImage = getMediaContent(data?.image?.contentUrl);
     const seoKeywords = [
         data?.name,
@@ -174,7 +177,7 @@ export const NewsPersonal: FC<NewsPersonalProps> = (props) => {
                 <ArticleContent className={styles.content} content={articleContent} />
                 <ArticleShare
                     className={styles.shareBlock}
-                    url={`${MAIN_URL}${getNewsPersonalPageUrl(locale, data?.id)}`}
+                    url={`${MAIN_URL}${getNewsPersonalPageUrl(locale, data?.slug)}`}
                 />
             </div>
             <div className={styles.commentWrapper}>


### PR DESCRIPTION
## Проблема
Row 117: URL контента — голые UUID/числовые id (`/news/{uuid}`, `/blog/{id}`, `/journals/{uuid}`), плохо для SEO. Бэкенд (gs-backend PR #259) уже отдаёт `slug` в списках/детальной и резолвит route-параметр `{id}` по slug ИЛИ старому id.

## Фикс
- Списки (News/Blog/Journal, включая `CommunityNewsContainer`) строят путь на детальную по `slug`.
- Canonical/OG URL на детальной берётся из `data.slug`, а не из сырого параметра URL — переход по старой ссылке с голым id корректно канонизируется на новый ЧПУ.
- Blog/Journal: лайк/комментарии/список отзывов используют `data.id` (реальный id уже загруженной статьи), а не сырой параметр из URL — эти бэкенд-роуты slug не резолвят.

Заодно найдены и починены 2 пред-существующих бага:
- `BlogPersonal.tsx` строил canonical/share URL через `getNewsPersonalPageUrl` вместо `getBlogPersonalPageUrl` — ссылки годами указывали не туда.
- `getJournalPersonalPageUrl` игнорировал свой `id`-аргумент и всегда возвращал буквальный `/journals/:id` — ломало canonical/share на детальной журнала и ссылку "Редактировать" в админке.

## Проверка
- `tsc --noEmit` — чисто по всему проекту
- `eslint` на все затронутые файлы — чисто
- Существующий `newsAdapter.test.ts` — зелёный

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>