### PR TITLE
fix(blog): синхронизировать кнопки выравнивания в тулбаре с состоянием курсора

### DIFF
--- a/src/shared/ui/ToolBar/ToolBar.test.tsx
+++ b/src/shared/ui/ToolBar/ToolBar.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { TextEditor } from "../TextEditor/TextEditor";
+
+/**
+ * Регресс-guard (row 63): кнопки выравнивания в тулбаре не отражали
+ * реальное состояние курсора — при открытии уже выровненного текста
+ * ни одна кнопка не подсвечивалась активной, из-за чего казалось,
+ * что выравнивание (особенно justify) "не работает".
+ */
+describe("ToolBar align buttons", () => {
+    it("подсвечивает justify активной для уже выровненного текста", () => {
+        const html = "<p style=\"text-align: justify\">Уже выровненный текст</p>";
+        const { container } = render(
+            <TextEditor value={html} onChange={() => {}} onErrorUploadImage={() => {}} />,
+        );
+
+        const justifyBtn = container.querySelector("[value=\"justify\"]");
+        const leftBtn = container.querySelector("[value=\"left\"]");
+
+        expect(justifyBtn?.getAttribute("aria-pressed")).toBe("true");
+        expect(leftBtn?.getAttribute("aria-pressed")).toBe("false");
+    });
+
+    it("подсвечивает left активной по умолчанию для невыровненного текста", () => {
+        const html = "<p>Обычный текст без выравнивания</p>";
+        const { container } = render(
+            <TextEditor value={html} onChange={() => {}} onErrorUploadImage={() => {}} />,
+        );
+
+        const leftBtn = container.querySelector("[value=\"left\"]");
+        const justifyBtn = container.querySelector("[value=\"justify\"]");
+
+        expect(leftBtn?.getAttribute("aria-pressed")).toBe("true");
+        expect(justifyBtn?.getAttribute("aria-pressed")).toBe("false");
+    });
+});

--- a/src/shared/ui/ToolBar/ToolBar.tsx
+++ b/src/shared/ui/ToolBar/ToolBar.tsx
@@ -73,6 +73,29 @@ export const ToolBar: FC<ToolBarProps> = memo((props: ToolBarProps) => {
         }
     }, [editor]);
 
+    useEffect(() => {
+        if (editor) {
+            const updateAlignType = () => {
+                if (editor.isActive({ textAlign: "center" })) {
+                    setAlignText("center");
+                } else if (editor.isActive({ textAlign: "justify" })) {
+                    setAlignText("justify");
+                } else {
+                    setAlignText("left");
+                }
+            };
+
+            updateAlignType();
+            editor.on("selectionUpdate", updateAlignType);
+            editor.on("update", updateAlignType);
+
+            return () => {
+                editor.off("selectionUpdate", updateAlignType);
+                editor.off("update", updateAlignType);
+            };
+        }
+    }, [editor]);
+
     if (!editor) {
         return null;
     }
@@ -149,20 +172,10 @@ export const ToolBar: FC<ToolBarProps> = memo((props: ToolBarProps) => {
     };
 
     const handleAlignText = (event: MouseEvent<HTMLElement>, newAlign: string | null) => {
-        setAlignText(newAlign);
-        switch (newAlign) {
-            case "left":
-                editor.commands.setTextAlign("left");
-                break;
-            case "center":
-                editor.commands.setTextAlign("center");
-                break;
-            case "justify":
-                editor.commands.setTextAlign("justify");
-                break;
-            default:
-                break;
+        if (!newAlign) {
+            return;
         }
+        editor.chain().focus().setTextAlign(newAlign).run();
     };
 
     editor.on("update", () => {


### PR DESCRIPTION
Row 63: "Блог: не работает выравнивание по ширине (justify)".

Проверил весь пайплайн: TipTap-редактор корректно сохраняет `style="text-align: justify"`, DOMPurify не режет inline-стили, и на реальных статьях (прод, `/ru/blog/76`) `text-align: justify` реально применяется и рендерится — computed style подтверждён вживую.

Реальный баг — в самом тулбаре: кнопки left/center/justify хранили состояние в отдельном `useState`, обновляемом только по клику пользователя, а не синхронизированном с фактическим выравниванием под курсором (в отличие от кнопок списков, у которых такая синхронизация уже была через `editor.on("selectionUpdate"/"update")`). При открытии уже выровненной статьи на редактирование ни одна кнопка не подсвечивалась активной — создавалось впечатление, что функция не работает.

- Добавлена синхронизация `alignText` по тому же паттерну, что уже используется для списков
- `handleAlignText` переведён на `editor.chain().focus().setTextAlign()` — возвращает фокус в редактор после клика, как у списков
- Тест-регресс: revert-and-confirm-fails подтверждён (без фикса оба новых теста падают)