### PR TITLE
fix(host): иконка организации не сохранялась — неверный формат id медиа-объекта

### DIFF
--- a/src/features/HostDescription/lib/hostDescriptionAdapter.test.ts
+++ b/src/features/HostDescription/lib/hostDescriptionAdapter.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { Host } from "@/entities/Host";
-import { hostDescriptionFormAdapter } from "./hostDescriptionAdapter";
+import {
+    hostDescriptionApiAdapterUpdate,
+    hostDescriptionFormAdapter,
+} from "./hostDescriptionAdapter";
 
 const baseHost: Host = {
     id: "1",
@@ -35,5 +38,50 @@ describe("hostDescriptionFormAdapter", () => {
 
         expect(result.type?.organizationType).toBe("НКО");
         expect(result.type?.otherOrganizationType).toBe("");
+    });
+});
+
+/**
+ * Регресс-guard (row 88): поле avatar.id вручную собиралось как полный
+ * внешний URL (`${BASE_URL}/api/v1/media_objects/${id}`) вместо сырого
+ * id медиа-объекта. Бэкенд ожидает такой же id, как во всех остальных
+ * рабочих загрузках (см. ProfileInfoFormAvatar — result.id). Из-за
+ * несовпадения формата avatar_id не проставлялся ни у одной организации
+ * на проде — иконка организации никогда не сохранялась и не отображалась.
+ */
+describe("hostDescriptionFormAdapter avatar id", () => {
+    it("передаёт сырой id медиа-объекта, а не сконструированный URL", () => {
+        const hostWithAvatar: Host = {
+            ...baseHost,
+            avatar: {
+                id: "media-object-uuid-123",
+                contentUrl: "/media/avatar.jpg",
+                isImage: true,
+                originalHeight: 100,
+                originalWidth: 100,
+            },
+        };
+
+        const result = hostDescriptionFormAdapter(hostWithAvatar);
+
+        expect(result.avatar?.id).toBe("media-object-uuid-123");
+    });
+});
+
+describe("hostDescriptionApiAdapterUpdate avatar id", () => {
+    it("отправляет сырой id медиа-объекта в теле запроса", () => {
+        const result = hostDescriptionApiAdapterUpdate({
+            avatar: { id: "media-object-uuid-456", contentUrl: "/media/avatar.jpg" },
+            mainInfo: {
+                aboutInfo: "", organization: "", shortOrganization: "", website: "",
+            },
+            socialMedia: {
+                facebook: "", instagram: "", telegram: "", vk: "",
+            },
+            type: { organizationType: "НКО", otherOrganizationType: "" },
+            address: "",
+        });
+
+        expect(result.avatar).toBe("media-object-uuid-456");
     });
 });

--- a/src/features/HostDescription/lib/hostDescriptionAdapter.ts
+++ b/src/features/HostDescription/lib/hostDescriptionAdapter.ts
@@ -6,7 +6,6 @@ import {
     HostDescriptionTypeFields,
     OrganizationType,
 } from "../model/types/hostDescription";
-import { BASE_URL } from "@/shared/constants/api";
 
 const organizationType: readonly OrganizationType[] = ["ИП", "ОАО", "ООО", "ООПТ", "НКО"] as const;
 
@@ -47,7 +46,7 @@ export const hostDescriptionFormAdapter = (data?: Host): Partial<HostDescription
         socialMedia: hostSocialFields,
         address: data.address,
         avatar: data?.avatar ? {
-            id: `${BASE_URL}/api/v1/media_objects/${data.avatar.id}`,
+            id: data.avatar.id,
             contentUrl: data.avatar.contentUrl,
             thumbnails: data.avatar.thumbnails,
         } : undefined,

--- a/src/features/HostDescription/ui/HostDescriptionAvatar/HostDescriptionAvatar.tsx
+++ b/src/features/HostDescription/ui/HostDescriptionAvatar/HostDescriptionAvatar.tsx
@@ -13,7 +13,6 @@ import { getMediaContent } from "@/shared/lib/getMediaContent";
 import HintPopup from "@/shared/ui/HintPopup/HintPopup";
 import { HintType, ToastAlert } from "@/shared/ui/HintPopup/HintPopup.interface";
 import { HostDescriptionFormFields } from "../../model/types/hostDescription";
-import { BASE_URL } from "@/shared/constants/api";
 
 interface HostDescriptionAvatarProps {
     className?: string;
@@ -43,7 +42,7 @@ export const HostDescriptionAvatar = memo(
                 const result = await uploadFile(file.name, file);
                 if (result) {
                     const avatarData = {
-                        id: `${BASE_URL}${result?.["@id"].slice(1)}`,
+                        id: result.id,
                         contentUrl: result.contentUrl,
                     };
                     onChange(avatarData);


### PR DESCRIPTION
Row 88: "Не отображается иконка организации. Ошибка загрузки иконки".

При загрузке аватара организации (`HostDescriptionAvatar`) и при инициализации формы существующим аватаром (`hostDescriptionAdapter`) поле `id` вручную собиралось как полный внешний URL вместо сырого id медиа-объекта, который бэкенд ожидает в поле `avatar`. Из-за этого `avatar_id` никогда не проставлялся ни у одной организации на проде (подтверждено прямым запросом к БД: `SELECT ... FROM organization o JOIN media_object mo ON o.avatar_id = mo.id` — пусто).

Исправлено по образцу уже рабочего `ProfileInfoFormAvatar` — `id` берётся напрямую из ответа загрузки (`result.id`), без реконструкции URL.

Тест-регресс (revert-and-confirm-fails подтверждён).