### PR TITLE
fix(host): аватар организации нужно отправлять как IRI, а не как id

### DIFF
--- a/src/features/HostDescription/lib/hostDescriptionAdapter.test.ts
+++ b/src/features/HostDescription/lib/hostDescriptionAdapter.test.ts
@@ -43,14 +43,16 @@ describe("hostDescriptionFormAdapter", () => {
 
 /**
  * Регресс-guard (row 88): поле avatar.id вручную собиралось как полный
- * внешний URL (`${BASE_URL}/api/v1/media_objects/${id}`) вместо сырого
- * id медиа-объекта. Бэкенд ожидает такой же id, как во всех остальных
- * рабочих загрузках (см. ProfileInfoFormAvatar — result.id). Из-за
- * несовпадения формата avatar_id не проставлялся ни у одной организации
- * на проде — иконка организации никогда не сохранялась и не отображалась.
+ * внешний URL (`${BASE_URL}/api/v1/media_objects/${id}`) вместо
+ * относительного IRI (`/api/v1/media_objects/{id}`), который на самом
+ * деле ожидает бэкенд для organizations (подтверждено вживую на
+ * стейдже: PATCH возвращал 400 "Invalid IRI" и на голом id, и на полном
+ * внешнем URL). Из-за несовпадения формата avatar_id не проставлялся ни
+ * у одной организации на проде — иконка организации никогда не
+ * сохранялась и не отображалась.
  */
 describe("hostDescriptionFormAdapter avatar id", () => {
-    it("передаёт сырой id медиа-объекта, а не сконструированный URL", () => {
+    it("реконструирует относительный IRI медиа-объекта, а не внешний URL с доменом", () => {
         const hostWithAvatar: Host = {
             ...baseHost,
             avatar: {
@@ -64,14 +66,14 @@ describe("hostDescriptionFormAdapter avatar id", () => {
 
         const result = hostDescriptionFormAdapter(hostWithAvatar);
 
-        expect(result.avatar?.id).toBe("media-object-uuid-123");
+        expect(result.avatar?.id).toBe("/api/v1/media_objects/media-object-uuid-123");
     });
 });
 
 describe("hostDescriptionApiAdapterUpdate avatar id", () => {
-    it("отправляет сырой id медиа-объекта в теле запроса", () => {
+    it("отправляет IRI медиа-объекта в теле запроса как есть", () => {
         const result = hostDescriptionApiAdapterUpdate({
-            avatar: { id: "media-object-uuid-456", contentUrl: "/media/avatar.jpg" },
+            avatar: { id: "/api/v1/media_objects/media-object-uuid-456", contentUrl: "/media/avatar.jpg" },
             mainInfo: {
                 aboutInfo: "", organization: "", shortOrganization: "", website: "",
             },
@@ -82,6 +84,6 @@ describe("hostDescriptionApiAdapterUpdate avatar id", () => {
             address: "",
         });
 
-        expect(result.avatar).toBe("media-object-uuid-456");
+        expect(result.avatar).toBe("/api/v1/media_objects/media-object-uuid-456");
     });
 });

--- a/src/features/HostDescription/lib/hostDescriptionAdapter.ts
+++ b/src/features/HostDescription/lib/hostDescriptionAdapter.ts
@@ -45,8 +45,12 @@ export const hostDescriptionFormAdapter = (data?: Host): Partial<HostDescription
         type: hostTypeFields,
         socialMedia: hostSocialFields,
         address: data.address,
+        // Organizations принимает avatar только как IRI (например
+        // "/api/v1/media_objects/{id}"), а не как сырой id — бэкенд
+        // отдаёт avatar.id уже без префикса, поэтому реконструируем
+        // тот же относительный путь, что использует загрузка файла.
         avatar: data?.avatar ? {
-            id: data.avatar.id,
+            id: `/api/v1/media_objects/${data.avatar.id}`,
             contentUrl: data.avatar.contentUrl,
             thumbnails: data.avatar.thumbnails,
         } : undefined,

--- a/src/features/HostDescription/ui/HostDescriptionAvatar/HostDescriptionAvatar.tsx
+++ b/src/features/HostDescription/ui/HostDescriptionAvatar/HostDescriptionAvatar.tsx
@@ -41,8 +41,10 @@ export const HostDescriptionAvatar = memo(
             try {
                 const result = await uploadFile(file.name, file);
                 if (result) {
+                    // Organizations принимает avatar только как IRI (@id),
+                    // а не как сырой id — в отличие от профиля волонтёра.
                     const avatarData = {
-                        id: result.id,
+                        id: result["@id"],
                         contentUrl: result.contentUrl,
                     };
                     onChange(avatarData);


### PR DESCRIPTION
Продолжение PR #396. Живая проверка на стейдже показала, что бэкенд для `organizations` принимает `avatar` только в виде относительного IRI (`/api/v1/media_objects/{id}`), а не сырого id медиа-объекта — PATCH падал 400 "Invalid IRI" на голом UUID (в отличие от профиля волонтёра, где именно raw id — верный формат; разные бэкенд-хендлеры для разных сущностей).

- Загрузка нового файла теперь берёт `result["@id"]` (уже готовый IRI из ответа API)
- Реконструкция IRI для уже сохранённого аватара при инициализации формы — относительный путь без домена

Живьём подтверждено на стейдже: `PATCH organizations/{id}` с новым avatar отдаёт 200 вместо 400.