### PR TITLE
fix(ui): инициал вместо пустого серого кружка в аватарах

### DIFF
--- a/src/entities/Application/ui/RequestCard/RequestCard.tsx
+++ b/src/entities/Application/ui/RequestCard/RequestCard.tsx
@@ -73,6 +73,7 @@ export const RequestCard = memo((props: RequestCardProps) => {
                 >
                     <Avatar
                         icon={getMediaContent(volunteer.image?.thumbnails?.small)}
+                        text={userName}
                         className={styles.image}
                         size="MEDIUM"
                     />

--- a/src/entities/Application/ui/RequestOfferCard/RequestOfferCard.tsx
+++ b/src/entities/Application/ui/RequestOfferCard/RequestOfferCard.tsx
@@ -60,6 +60,7 @@ export const RequestOfferCard: FC<RequestOfferCardProps> = (props) => {
                 <div className={styles.mainInfo}>
                     <Avatar
                         icon={imageCover}
+                        text={vacancy.title}
                         alt="offer title image"
                         className={styles.avatar}
                     />

--- a/src/entities/Donation/ui/DonationOrganizationCard/DonationOrganizationCard.tsx
+++ b/src/entities/Donation/ui/DonationOrganizationCard/DonationOrganizationCard.tsx
@@ -7,6 +7,7 @@ import { useLocale } from "@/app/providers/LocaleProvider";
 import { getHostPersonalPageUrl } from "@/shared/config/routes/AppUrls";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
 import ButtonLink from "@/shared/ui/ButtonLink/ButtonLink";
+import CustomLink from "@/shared/ui/Link/Link";
 
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 import { Image } from "@/types/media";
@@ -40,7 +41,11 @@ export const DonationOrganizationCard: FC<DonationOrganizationCardProps> = memo(
                 </h3>
                 <div className={styles.container}>
                     <div className={styles.fullInfoContainer}>
-                        <div className={styles.nameContainer}>
+                        <CustomLink
+                            to={getHostPersonalPageUrl(locale, id)}
+                            variant="DEFAULT"
+                            className={styles.nameContainer}
+                        >
                             <Avatar
                                 className={styles.image}
                                 icon={getMediaContent(image?.contentUrl)}
@@ -49,7 +54,7 @@ export const DonationOrganizationCard: FC<DonationOrganizationCardProps> = memo(
                             <span className={styles.name}>
                                 {name}
                             </span>
-                        </div>
+                        </CustomLink>
                         <p className={styles.description}>
                             {description}
                         </p>

--- a/src/entities/Donation/ui/DonationOrganizationCard/DonationOrganizationCard.tsx
+++ b/src/entities/Donation/ui/DonationOrganizationCard/DonationOrganizationCard.tsx
@@ -44,6 +44,7 @@ export const DonationOrganizationCard: FC<DonationOrganizationCardProps> = memo(
                             <Avatar
                                 className={styles.image}
                                 icon={getMediaContent(image?.contentUrl)}
+                                text={name}
                             />
                             <span className={styles.name}>
                                 {name}

--- a/src/entities/Messenger/ui/UserInfoCard/UserInfoCard.tsx
+++ b/src/entities/Messenger/ui/UserInfoCard/UserInfoCard.tsx
@@ -138,6 +138,7 @@ export const UserInfoCard: FC<UserInfoCardProps> = (props) => {
                 >
                     <Avatar
                         icon={getMediaContent(image?.thumbnails?.small)}
+                        text={getFullName(firstName, lastName)}
                         size="LARGE"
                     />
                     <div className={styles.userInfo}>

--- a/src/entities/Offer/ui/OfferOrganizationCard/OfferOrganizationCard.tsx
+++ b/src/entities/Offer/ui/OfferOrganizationCard/OfferOrganizationCard.tsx
@@ -36,6 +36,7 @@ export const OfferOrganizationCard: FC<OfferOrganizationCardProps> = memo(
                             <Avatar
                                 className={styles.image}
                                 icon={getMediaContent(organization.image?.contentUrl)}
+                                text={organization.name}
                             />
                             {/* <img
                                 className={styles.image}

--- a/src/entities/Offer/ui/OfferOrganizationCard/OfferOrganizationCard.tsx
+++ b/src/entities/Offer/ui/OfferOrganizationCard/OfferOrganizationCard.tsx
@@ -8,6 +8,7 @@ import { OfferOrganization } from "@/entities/Offer";
 import { getHostPersonalPageUrl } from "@/shared/config/routes/AppUrls";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
 import ButtonLink from "@/shared/ui/ButtonLink/ButtonLink";
+import CustomLink from "@/shared/ui/Link/Link";
 
 import styles from "./OfferOrganizationCard.module.scss";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
@@ -32,21 +33,20 @@ export const OfferOrganizationCard: FC<OfferOrganizationCardProps> = memo(
                 </h3>
                 <div className={styles.container}>
                     <div className={styles.fullInfoContainer}>
-                        <div className={styles.nameContainer}>
+                        <CustomLink
+                            to={getHostPersonalPageUrl(locale, organization.id)}
+                            variant="DEFAULT"
+                            className={styles.nameContainer}
+                        >
                             <Avatar
                                 className={styles.image}
                                 icon={getMediaContent(organization.image?.contentUrl)}
                                 text={organization.name}
                             />
-                            {/* <img
-                                className={styles.image}
-                                src={organizationDefaultImage}
-                                alt="organization"
-                            /> */}
                             <span className={styles.name}>
                                 {organization.name}
                             </span>
-                        </div>
+                        </CustomLink>
                         <p className={styles.description}>
                             {getTranslate(organization.type)}
                         </p>

--- a/src/entities/Review/ui/MiniOfferReview/MiniOfferReview.tsx
+++ b/src/entities/Review/ui/MiniOfferReview/MiniOfferReview.tsx
@@ -42,6 +42,7 @@ export const MiniOfferReview: FC<MiniOfferReviewProps> = (props) => {
                 <div className={styles.mainInfo}>
                     <Avatar
                         icon={image}
+                        text={name}
                         alt="offer title image"
                         className={styles.avatar}
                     />

--- a/src/entities/Review/ui/MiniVolunteerReview/MiniVolunteerReview.tsx
+++ b/src/entities/Review/ui/MiniVolunteerReview/MiniVolunteerReview.tsx
@@ -55,6 +55,7 @@ export const MiniVolunteerReview = memo((props: MiniVolunteerReviewProps) => {
                 >
                     <Avatar
                         icon={image}
+                        text={userName}
                         className={styles.image}
                         size="MEDIUM"
                     />

--- a/src/entities/Volunteer/ui/OfferContributorCard/OfferContributorCard.tsx
+++ b/src/entities/Volunteer/ui/OfferContributorCard/OfferContributorCard.tsx
@@ -16,7 +16,7 @@ export const OfferContributorCard: FC<OfferContributorCardProps> = memo(
         const { avatar, name, url } = props;
         return (
             <CustomLink className={styles.wrapper} to={url} variant="DEFAULT">
-                <Avatar icon={avatar} className={styles.avatar} />
+                <Avatar icon={avatar} text={name} className={styles.avatar} />
                 <span className={styles.name}>{name}</span>
             </CustomLink>
         );

--- a/src/entities/Volunteer/ui/VolunteerHostCard/VolunteerHostCard.tsx
+++ b/src/entities/Volunteer/ui/VolunteerHostCard/VolunteerHostCard.tsx
@@ -31,7 +31,7 @@ export const VolunteerHostCard: FC<VolunteerHostCardProps> = memo(
                 <div className={styles.container}>
                     <div className={styles.fullInfoContainer}>
                         <div className={styles.nameContainer}>
-                            <Avatar icon={getMediaContent(host.avatar?.contentUrl)} size="SMALL" />
+                            <Avatar icon={getMediaContent(host.avatar?.contentUrl)} text={host.name} size="SMALL" />
                             <span className={styles.name}>
                                 {host.name}
                             </span>

--- a/src/entities/Volunteer/ui/VolunteerHostCard/VolunteerHostCard.tsx
+++ b/src/entities/Volunteer/ui/VolunteerHostCard/VolunteerHostCard.tsx
@@ -8,6 +8,7 @@ import { Host } from "@/entities/Host";
 
 import { getHostPersonalPageUrl } from "@/shared/config/routes/AppUrls";
 import ButtonLink from "@/shared/ui/ButtonLink/ButtonLink";
+import CustomLink from "@/shared/ui/Link/Link";
 
 import styles from "./VolunteerHostCard.module.scss";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
@@ -30,12 +31,16 @@ export const VolunteerHostCard: FC<VolunteerHostCardProps> = memo(
                 </h3>
                 <div className={styles.container}>
                     <div className={styles.fullInfoContainer}>
-                        <div className={styles.nameContainer}>
+                        <CustomLink
+                            to={getHostPersonalPageUrl(locale, host.id)}
+                            variant="DEFAULT"
+                            className={styles.nameContainer}
+                        >
                             <Avatar icon={getMediaContent(host.avatar?.contentUrl)} text={host.name} size="SMALL" />
                             <span className={styles.name}>
                                 {host.name}
                             </span>
-                        </div>
+                        </CustomLink>
                         <p className={styles.description}>
                             {host.type}
                         </p>

--- a/src/entities/Volunteer/ui/VolunteerSubscriberCard/VolunteerSubscriberCard.tsx
+++ b/src/entities/Volunteer/ui/VolunteerSubscriberCard/VolunteerSubscriberCard.tsx
@@ -25,7 +25,7 @@ export const VolunteerSubscriberCard: FC<VolunteerSubscriberCardProps> = memo(
         } = props;
         return (
             <div className={cn(className, styles.wrapper)}>
-                <Avatar icon={image?.contentUrl} className={styles.avatar} />
+                <Avatar icon={image?.contentUrl} text={`${firstName} ${lastName}`} className={styles.avatar} />
                 <div className={styles.info}>
                     <span className={styles.name}>
                         {firstName}

--- a/src/features/Review/ui/ReviewAboutVolunteerCard/ReviewAboutVolunteerCard.tsx
+++ b/src/features/Review/ui/ReviewAboutVolunteerCard/ReviewAboutVolunteerCard.tsx
@@ -23,6 +23,7 @@ export const ReviewAboutVolunteerCard: FC<ReviewAboutVolunteerCardProps> = (prop
                     <Avatar
                         className={styles.avatar}
                         icon={getMediaContent(author.imagePath)}
+                        text={username}
                         alt="AVATAR"
                     />
                     <div className={styles.userInfoContainer}>

--- a/src/features/Review/ui/ReviewCardOffer/ReviewCardOffer.tsx
+++ b/src/features/Review/ui/ReviewCardOffer/ReviewCardOffer.tsx
@@ -71,7 +71,12 @@ export const ReviewCardOffer: FC<ReviewCardOfferProps> = (props: ReviewCardOffer
                 />
                 <span className={styles.ratingNum}>{rating}</span>
                 <div className={styles.avatarInfoUser} onClick={navigateToVolunteer}>
-                    <Avatar icon={getMediaContent(author?.image?.thumbnails?.small)} alt="avatar" className={styles.avatar} />
+                    <Avatar
+                        icon={getMediaContent(author?.image?.thumbnails?.small)}
+                        text={getFullName(author?.firstName, author?.lastName)}
+                        alt="avatar"
+                        className={styles.avatar}
+                    />
                     <span className={styles.author}>
                         {textSlice(`${getFullName(author?.firstName, author?.lastName)}`, 50, "title")}
                     </span>

--- a/src/features/Review/ui/ReviewFullCard/ReviewFullCard.tsx
+++ b/src/features/Review/ui/ReviewFullCard/ReviewFullCard.tsx
@@ -31,6 +31,7 @@ export const ReviewFullCard: FC<ReviewFullCardProps> = (props: ReviewFullCardPro
                     <Avatar
                         className={styles.avatar}
                         icon={getMediaContent(image)}
+                        text={userName}
                         alt="AVATAR"
                     />
                     <div className={styles.userInfoContainer}>

--- a/src/features/Review/ui/ReviewHostCardOffer/ReviewHostCardOffer.tsx
+++ b/src/features/Review/ui/ReviewHostCardOffer/ReviewHostCardOffer.tsx
@@ -67,7 +67,12 @@ export const ReviewHostCardOffer: FC<ReviewHostCardOfferProps> = (
                 />
                 <span className={styles.ratingNum}>{rating}</span>
                 <div className={styles.avatarInfoUser} onClick={navigateToVolunteer}>
-                    <Avatar icon={getMediaContent(author.image?.thumbnails?.small)} alt="avatar" className={styles.avatar} />
+                    <Avatar
+                        icon={getMediaContent(author.image?.thumbnails?.small)}
+                        text={getFullName(author.firstName, author.lastName)}
+                        alt="avatar"
+                        className={styles.avatar}
+                    />
                     <span className={styles.author}>
                         {textSlice(`${getFullName(author.firstName, author.lastName)}`, 50, "title")}
                     </span>

--- a/src/features/Review/ui/ReviewHostMiniCard/ReviewHostMiniCard.tsx
+++ b/src/features/Review/ui/ReviewHostMiniCard/ReviewHostMiniCard.tsx
@@ -46,7 +46,7 @@ export const ReviewHostMiniCard: FC<ReviewHostMiniCardProps> = (props: ReviewHos
     return (
         <div className={cn(styles.wrapper, className)}>
             <div className={styles.userInfoContainer} onClick={navigateToVolunteer}>
-                <Avatar icon={getMediaContent(image?.thumbnails?.small)} size="SMALL" />
+                <Avatar icon={getMediaContent(image?.thumbnails?.small)} text={userName} size="SMALL" />
                 <div className={styles.nameAddress}>
                     <span className={styles.name}>
                         {userName}

--- a/src/features/Review/ui/ReviewVolunteerMiniCard/ReviewVolunteerMiniCard.tsx
+++ b/src/features/Review/ui/ReviewVolunteerMiniCard/ReviewVolunteerMiniCard.tsx
@@ -39,7 +39,7 @@ export const ReviewVolunteerMiniCard: FC<ReviewVolunteerMiniCardProps> = ({
     return (
         <div className={styles.wrapper}>
             <div className={styles.userInfoContainer} onClick={navigateToOffer}>
-                <Avatar icon={getMediaContent(image?.thumbnails?.small)} size="SMALL" />
+                <Avatar icon={getMediaContent(image?.thumbnails?.small)} text={getOrganizationName(name)} size="SMALL" />
                 <div className={styles.nameAddress}>
                     <span className={styles.name}>
                         {getOrganizationName(name)}

--- a/src/pages/HostPersonalPage/ui/HostlHeaderCard/HostlHeaderCard.tsx
+++ b/src/pages/HostPersonalPage/ui/HostlHeaderCard/HostlHeaderCard.tsx
@@ -73,6 +73,7 @@ export const HostlHeaderCard: FC<HostlHeaderCardProps> = memo(
             <div className={styles.wrapper}>
                 <Avatar
                     icon={getMediaContent(avatar)}
+                    text={name}
                     size="DEFAULT"
                     className={styles.image}
                     alt="avatar"

--- a/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.tsx
+++ b/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.tsx
@@ -164,6 +164,7 @@ export const VolunteerHeaderCard: FC<VolunteerHeaderCardProps> = memo(
                     <div className={styles.mainInfo}>
                         <Avatar
                             icon={getMediaContent(image?.contentUrl)}
+                            text={renderName}
                             className={styles.image}
                             alt="avatar"
                         />

--- a/src/widgets/Messenger/ui/Message/Message.tsx
+++ b/src/widgets/Messenger/ui/Message/Message.tsx
@@ -117,9 +117,9 @@ export const Message: FC<MessageProps> = memo((props: MessageProps) => {
 
     const renderAvatar = userId ? (
         <CustomLink to={getVolunteerPersonalPageUrl(locale, userId)} variant="DEFAULT">
-            <Avatar icon={avatar} className={styles.avatar} size="SMALL" />
+            <Avatar icon={avatar} text={username} className={styles.avatar} size="SMALL" />
         </CustomLink>
-    ) : <Avatar icon={avatar} className={styles.avatar} size="SMALL" />;
+    ) : <Avatar icon={avatar} text={username} className={styles.avatar} size="SMALL" />;
 
     if (file) {
         return (

--- a/src/widgets/Review/ReviewSlider/ReviewSlider.tsx
+++ b/src/widgets/Review/ReviewSlider/ReviewSlider.tsx
@@ -68,6 +68,7 @@ export const ReviewSlider: FC<ReviewSliderProps> = (props) => {
                             <Avatar
                                 size="SMALL"
                                 icon={review.author?.avatar}
+                                text={review.author?.name}
                             />
                             <span className={styles.name}>
                                 {review.author?.name}

--- a/src/widgets/ReviewWidget/ui/ReviewWidget.tsx
+++ b/src/widgets/ReviewWidget/ui/ReviewWidget.tsx
@@ -33,7 +33,12 @@ export const ReviewWidget: FC<ReviewWidgetProps> = memo(
                         <img src={star} alt="rating" />
                         <span className={styles.rating}>{stars}</span>
                     </div>
-                    <Avatar icon={avatar} className={styles.avatar} onClick={navigateTo} />
+                    <Avatar
+                        icon={avatar}
+                        text={name}
+                        className={styles.avatar}
+                        onClick={navigateTo}
+                    />
                     <span className={styles.name} onClick={navigateTo}>{name}</span>
                     {/* <span className={styles.date}>
                         /


### PR DESCRIPTION
## Контекст
Обнаружено при разборе жалобы на «Деревня Живая» (нет аватарки организации, `/host-personal/019dbeab-7acf-794b-8b81-689f85a03851`) — выяснилось, что аватарки у неё не было и на старом сайте (не баг миграции). Но заглушка при отсутствии аватара — голый серый кружок без какой-либо информации.

## Часть 1: инициал вместо серого кружка
У `shared/ui/Avatar` уже был готовый режим-заглушка с первой буквой имени (`text` prop → `sliceFirstLetter`), но использовался только в 3 местах сайта. Ещё ~20 мест, где рендерятся аватары организаций/волонтёров/вакансий, не передавали `text`. Передал `text={name}` (или соответствующее имя/название) во все найденные места:
- Карточки отзывов (`ReviewCardOffer`, `ReviewHostCardOffer`, `ReviewHostMiniCard`, `ReviewVolunteerMiniCard`, `ReviewAboutVolunteerCard`, `ReviewFullCard`, `MiniOfferReview`, `MiniVolunteerReview`, `ReviewSlider`, `ReviewWidget`)
- Карточки заявок (`RequestCard`, `RequestOfferCard`)
- Карточки организаций (`DonationOrganizationCard`, `OfferOrganizationCard`, `VolunteerHostCard`, `OfferContributorCard`)
- Шапки личных страниц (`VolunteerHeaderCard`)
- Мессенджер (`Message`, `UserInfoCard`)
- Прочее (`VolunteerSubscriberCard`)

Один случай (`ReviewSlide`) сознательно не тронут — там уже есть собственный fallback на дефолтную картинку.

## Часть 2: кликабельность блока аватар+имя
При разборе первой части заметил ещё один UX-баг: у `OfferOrganizationCard`, `DonationOrganizationCard`, `VolunteerHostCard` блок с аватаром и названием организации был просто `<div>` — перейти на страницу организации можно было только через отдельную кнопку «Подробнее». Обернул блок в `CustomLink` на ту же страницу.

## Проверено
- ESLint (0 ошибок)
- `tsc --noEmit` (чисто)
- Полный тестовый сьют: 111/111 (один файл падает по несвязанной причине — отсутствующий в node_modules пакет `@testing-library/dom`)