### PR TITLE
fix(ui): масштабировать шрифт инициала аватара под размер кружка

### DIFF
--- a/src/shared/ui/Avatar/Avatar.module.scss
+++ b/src/shared/ui/Avatar/Avatar.module.scss
@@ -1,6 +1,7 @@
 .wrapper {
     display: flex;
     flex-shrink: 0;
+    container-type: inline-size;
 }
 
 .SMALL, .MEDIUM, .LARGE, .DEFAULT {
@@ -45,6 +46,7 @@
     color: var(--bg-primary-1);
     font-weight: 600;
     font-size: 18px;
+    font-size: 40cqw;
     flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Контекст
После #400 (заглушка-инициал вместо серого кружка) обнаружено: буква в крупных аватарах (например, 150×150px в шапке страницы организации) выглядит непропорционально мелкой — `font-size` был захардкожен в 18px независимо от размера кружка.

## Что сделано
`size="DEFAULT"` используется в ~15 разных местах сайта с очень разными фактическими пиксельными размерами (каждый потребитель задаёт свой `width`/`height` через `className`), поэтому один фиксированный `font-size` не может подойти всем. Вместо хардкода под каждый вариант — использовал CSS container query (`container-type: inline-size` на `.wrapper` + `font-size: 40cqw` на букве), чтобы шрифт автоматически масштабировался под фактический размер круга везде, включая уже существующие SMALL/MEDIUM/LARGE.

18px оставлен как fallback-значение для браузеров без поддержки container queries (не удаляется, просто перекрывается более специфичным правилом там, где оно поддерживается).

## Проверено
- `npm run build` — успешно, оба CSS-правила присутствуют в собранном бандле
- ESLint/tsc — не затронуты (только SCSS)