### PR TITLE
fix(offer): «Не указано» вместо 0 для минимума/максимума дней участия

### DIFF
--- a/src/entities/Offer/ui/OfferWhenCard/OfferWhenCard.test.tsx
+++ b/src/entities/Offer/ui/OfferWhenCard/OfferWhenCard.test.tsx
@@ -1,0 +1,49 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test-utils";
+import { OfferWhenCard } from "./OfferWhenCard";
+import { OfferWhen } from "../../model/types/offerWhen";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const baseOfferWhen: OfferWhen = {
+    periods: [],
+    isFullYearAcceptable: false,
+    isApplicableAtTheEnd: false,
+    durationMinDays: 0,
+    durationMaxDays: 0,
+    applicationEndDate: null,
+};
+
+/**
+ * Регресс-guard: durationMinDays/durationMaxDays = 0 у вакансии обычно
+ * означает "не указано" (не заполнено при создании/переносе), а не то,
+ * что минимальный/максимальный срок участия — буквально ноль дней.
+ * Раньше карточка молча выводила "0", что выглядело как баг.
+ */
+describe("OfferWhenCard", () => {
+    it("показывает 'не указано' вместо 0 для минимума/максимума дней", () => {
+        renderWithProviders(
+            <OfferWhenCard offerWhen={baseOfferWhen} />,
+        );
+
+        expect(screen.getAllByText("personalOffer.notSpecified")).toHaveLength(2);
+        expect(screen.queryByText("0")).not.toBeInTheDocument();
+    });
+
+    it("показывает реальные значения дней, если они больше нуля", () => {
+        renderWithProviders(
+            <OfferWhenCard
+                offerWhen={{ ...baseOfferWhen, durationMinDays: 7, durationMaxDays: 30 }}
+            />,
+        );
+
+        expect(screen.getByText("7")).toBeInTheDocument();
+        expect(screen.getByText("30")).toBeInTheDocument();
+        expect(screen.queryByText("personalOffer.notSpecified")).not.toBeInTheDocument();
+    });
+});

--- a/src/entities/Offer/ui/OfferWhenCard/OfferWhenCard.tsx
+++ b/src/entities/Offer/ui/OfferWhenCard/OfferWhenCard.tsx
@@ -24,12 +24,14 @@ export const OfferWhenCard = memo((props: OfferWhenProps) => {
     } = props;
     const { t } = useTranslation("offer");
     const emptyMessage = t("personalOffer.Точная дата не указана");
+    const notSpecified = t("personalOffer.notSpecified");
     const offerPeriodEnd = () => {
         if (!applicationEndDate) {
             return t("personalOffer.Не имеет даты окончания");
         }
         return applicationEndDate || emptyMessage;
     };
+    const formatDurationDays = (days: number) => (days > 0 ? days : notSpecified);
 
     const isHavePeriods = periods.length > 0;
     const isRenderGridPeriods = periods.length > 3;
@@ -62,11 +64,11 @@ export const OfferWhenCard = memo((props: OfferWhenProps) => {
                 <div className={styles.right}>
                     <InfoCardItem
                         title={t("personalOffer.Минимум дней")}
-                        text={durationMinDays}
+                        text={formatDurationDays(durationMinDays)}
                     />
                     <InfoCardItem
                         title={t("personalOffer.Максимум дней")}
-                        text={durationMaxDays}
+                        text={formatDurationDays(durationMaxDays)}
                     />
                     <InfoCardItem
                         title={t("personalOffer.Прием заявок до")}


### PR DESCRIPTION
## Контекст
Скриншот с публичной страницы вакансии: блок «Когда» показывает «Минимум дней: 0» / «Максимум дней: 0». Разобрался — `durationMinDays`/`durationMaxDays` рендерились как есть без обработки нулевого/незаполненного значения.

## Что сделано
`OfferWhenCard`: 0 в этих полях означает «не заполнено при создании вакансии», а не буквально «ноль дней участия». Добавил `formatDurationDays()` — при значении `0` показывает `t("personalOffer.notSpecified")` («Не указано», ключ уже существовал и использовался для похожего случая в `useFormatGenders`), иначе показывает число как есть.

## Проверено
- Regression-тест (`OfferWhenCard.test.tsx`), revert-and-confirm-fails подтверждён
- ESLint, `tsc --noEmit` — чисто