### PR TITLE
fix(profile): дублирование «Языки: Языки не были указаны» → прочерк

### DIFF
--- a/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.regression.test.ts
+++ b/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.regression.test.ts
@@ -23,3 +23,21 @@ describe("VolunteerHeaderCard member badge tooltip (source regress-guard)", () =
         expect(memberIconBlock).toMatch(/Верифицированный гудсёрфер/);
     });
 });
+
+/**
+ * Регресс-guard: раньше при отсутствии языков/города/страны показывались
+ * многословные фразы вроде «Языки не были указаны» — рядом с меткой
+ * «Языки:» это читалось как дублирование слова. Заменено на прочерк «—».
+ */
+describe("VolunteerHeaderCard пустые языки/локация (source regress-guard)", () => {
+    it("не содержит многословных фраз «не указан(а/о)» для языков/города/страны", () => {
+        const tsxPath = join(__dirname, "VolunteerHeaderCard.tsx");
+        const source = readFileSync(tsxPath, "utf-8");
+
+        expect(source).not.toMatch(/Языки не были указаны/);
+        expect(source).not.toMatch(/Страна не указана/);
+        expect(source).not.toMatch(/Город не указан/);
+        expect(source).toMatch(/renderLanguages[\s\S]*?—/);
+        expect(source).toMatch(/renderLocation[\s\S]*?—/);
+    });
+});

--- a/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.tsx
+++ b/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.tsx
@@ -75,7 +75,14 @@ export const VolunteerHeaderCard: FC<VolunteerHeaderCardProps> = memo(
             ) {
                 return <span>{languages}</span>;
             }
-            return <span>{t("personal.Языки не были указаны")}</span>;
+            return <span>—</span>;
+        };
+
+        const renderLocation = () => {
+            if (!country && !city) {
+                return <span>—</span>;
+            }
+            return <span>{[country, city].filter(Boolean).join(", ")}</span>;
         };
 
         const renderAchievements = () => {
@@ -194,10 +201,7 @@ export const VolunteerHeaderCard: FC<VolunteerHeaderCardProps> = memo(
                                     :
                                     {" "}
                                     <span className={styles.subText}>
-                                        {country || t("personal.Страна не указана")}
-                                        ,
-                                        {" "}
-                                        {city || t("personal.Город не указан")}
+                                        {renderLocation()}
                                     </span>
                                 </span>
                                 <span className={styles.languages}>


### PR DESCRIPTION
## Контекст
Скриншот шапки личной страницы волонтёра: рядом с меткой «Языки:» стояла фраза «Языки не были указаны» — слово дублировалось. Аналогично «Город: Страна не указана, Город не указан» читалось многословно.

## Что сделано
`VolunteerHeaderCard`: заменил многословные фразы на прочерк «—»:
- Языки: если не указаны — «—» вместо «Языки не были указаны»
- Локация: если указан хотя бы один из city/country — показываем его одного (не вторую половину «не указано»), если оба пустые — «—»

## Проверено
- Regression-тест (source-guard, по аналогии с существующим тестом в этом же файле — компонент слишком тяжёлый для полного рендера), revert-and-confirm-fails подтверждён
- ESLint, `tsc --noEmit` — чисто