### PR TITLE
fix(membership): цвет кнопки «Поддержать проект» под бренд

### DIFF
--- a/src/pages/MembershipPage/ui/DonationSection/DonationSection.module.scss
+++ b/src/pages/MembershipPage/ui/DonationSection/DonationSection.module.scss
@@ -37,17 +37,19 @@
     align-items: center;
     justify-content: center;
     padding: 12px 28px;
-    background-color: #4CAF50;
+    background-color: var(--button-1);
+    border: 1px solid var(--button-1);
     color: white;
     font-size: 1rem;
     font-weight: 600;
     border-radius: 8px;
     text-decoration: none;
-    transition: background-color 0.2s ease;
+    transition: all 0.3s ease;
     text-align: center;
 
     &:hover {
-        background-color: #388E3C;
+        color: var(--button-1);
+        background-color: #fff;
     }
 }
 


### PR DESCRIPTION
## Что сделано
Кнопка «Поддержать проект» в блоке доната на странице Membership использовала хардкод `#4CAF50` вместо `var(--button-1)` — из-за этого выглядела заметно другого оттенка, чем остальные CTA-кнопки (например «Получить членство»).

## Тест-план
- [ ] Визуально сверить цвет кнопки «Поддержать проект» с «Получить членство» на /membership на стейдже