### PR TITLE
fix(header): перевести CTA баннера под шапкой

### DIFF
--- a/src/widgets/MainHeader/MainHeader.tsx
+++ b/src/widgets/MainHeader/MainHeader.tsx
@@ -56,7 +56,10 @@ const MainHeader: FC<MainHeaderProps> = ({ variant = "floating" }) => {
                     rel="noopener noreferrer"
                 >
                     <span className={styles.bannerText}>{data.description}</span>
-                    <span className={styles.bannerCta}>Подробнее →</span>
+                    <span className={styles.bannerCta}>
+                        {t("Подробнее")}
+                        {" →"}
+                    </span>
                 </a>
             )}
             <header className={styles.header}>


### PR DESCRIPTION
## Что сделано
Текст «Подробнее →» в баннере под шапкой (виден на всех страницах) был захардкожен на русском.

## Тест-план
- [ ] Открыть любую страницу на es/en с активным баннером, проверить перевод CTA