### PR TITLE
fix(header): sticky-подменю не сливается с плавающей шапкой

### DIFF
--- a/src/pages/HostPersonalPage/ui/HostPersonalPage/HostPersonalPage.module.scss
+++ b/src/pages/HostPersonalPage/ui/HostPersonalPage/HostPersonalPage.module.scss
@@ -14,7 +14,7 @@
 
 .navMenu {
     position: sticky;
-    top: 6.5rem;
+    top: calc(var(--header-offset, 6.5rem) + 12px);
     z-index: 8;
 }
 

--- a/src/pages/VolunteerPersonalPage/ui/VolunteerPersonalPage/VolunteerPersonalPage.module.scss
+++ b/src/pages/VolunteerPersonalPage/ui/VolunteerPersonalPage/VolunteerPersonalPage.module.scss
@@ -23,7 +23,7 @@
 
 .navMenu {
     position: sticky;
-    top: 6.5rem;
+    top: calc(var(--header-offset, 6.5rem) + 12px);
     z-index: 4;
 }
 

--- a/src/widgets/Donation/DonationSubmenu/DonationSubmenu.module.scss
+++ b/src/widgets/Donation/DonationSubmenu/DonationSubmenu.module.scss
@@ -1,7 +1,7 @@
 .navMenu {
     // padding: 26px 50px 16px 50px;
     position: sticky;
-    top: 6.5rem;
+    top: calc(var(--header-offset, 6.5rem) + 12px);
     z-index: 4;
 }
 

--- a/src/widgets/MainHeader/MainHeader.test.tsx
+++ b/src/widgets/MainHeader/MainHeader.test.tsx
@@ -1,0 +1,95 @@
+import {
+    describe, it, expect, vi, beforeEach, afterEach,
+} from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import MainHeader from "./MainHeader";
+
+let bannerDataMock: { url: string; description: string } | undefined;
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ myProfile: null, profileIsLoading: false, isAuth: false }),
+}));
+
+vi.mock("@/entities/Admin", () => ({
+    BannerMarketingType: { UNDER_HEADER_ALL_PAGES: "UNDER_HEADER_ALL_PAGES" },
+    useGetBannerMarketingQuery: () => ({ data: bannerDataMock }),
+}));
+
+vi.mock("@/components/LocaleLink/LocaleLink", () => ({
+    default: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/shared/ui/ButtonLink/ButtonLink", () => ({
+    default: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/widgets/ChangeLanguage", () => ({
+    ChangeLanguage: () => <div />,
+}));
+
+vi.mock("@/widgets/MobileHeader/ui/MobileHeader/MobileHeader", () => ({
+    default: () => <div />,
+}));
+
+vi.mock("./MainHeaderNav/MainHeaderNav", () => ({
+    MainHeaderNav: () => <nav />,
+}));
+
+vi.mock("./MainHeaderProfile/MainHeaderProfile", () => ({
+    default: () => <div />,
+}));
+
+vi.mock("./MessangerInfo/MessangerInfo", () => ({
+    MessangerInfo: () => <div />,
+}));
+
+/**
+ * Регресс-guard: sticky-подменю на других страницах (offer/host/volunteer/
+ * donation) читают CSS-переменную --header-offset, чтобы не заезжать под
+ * плавающую шапку (капсула + опциональный промо-баннер под ней). Раньше у
+ * них был захардкожен top: 6.5rem, который не учитывал появление баннера —
+ * из-за этого подменю визуально сливалось с шапкой в «двойное меню».
+ */
+describe("MainHeader --header-offset", () => {
+    let resizeObserverObserve: ReturnType<typeof vi.fn>;
+    let resizeObserverDisconnect: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bannerDataMock = undefined;
+        resizeObserverObserve = vi.fn();
+        resizeObserverDisconnect = vi.fn();
+        global.ResizeObserver = vi.fn().mockImplementation(() => ({
+            observe: resizeObserverObserve,
+            disconnect: resizeObserverDisconnect,
+        }));
+        document.documentElement.style.removeProperty("--header-offset");
+    });
+
+    afterEach(() => {
+        document.documentElement.style.removeProperty("--header-offset");
+    });
+
+    it("публикует --header-offset на :root после монтирования", async () => {
+        render(<MainHeader />);
+
+        await waitFor(() => {
+            expect(document.documentElement.style.getPropertyValue("--header-offset")).not.toBe("");
+        });
+        expect(resizeObserverObserve).toHaveBeenCalled();
+    });
+
+    it("подписывается на ResizeObserver, чтобы отследить появление баннера", () => {
+        bannerDataMock = { url: "https://example.com", description: "test" };
+        render(<MainHeader />);
+
+        expect(resizeObserverObserve).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/MainHeader/MainHeader.tsx
+++ b/src/widgets/MainHeader/MainHeader.tsx
@@ -1,5 +1,7 @@
 import cn from "classnames";
-import React, { FC, useEffect, useState } from "react";
+import React, {
+    FC, useEffect, useRef, useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import LocaleLink from "@/components/LocaleLink/LocaleLink";
 
@@ -35,6 +37,7 @@ const MainHeader: FC<MainHeaderProps> = ({ variant = "floating" }) => {
     const { t } = useTranslation();
     const { myProfile, profileIsLoading, isAuth } = useAuth();
     const [scrolled, setScrolled] = useState(false);
+    const wrapperRef = useRef<HTMLDivElement>(null);
 
     const { data } = useGetBannerMarketingQuery(
         { type: BannerMarketingType.UNDER_HEADER_ALL_PAGES },
@@ -46,8 +49,42 @@ const MainHeader: FC<MainHeaderProps> = ({ variant = "floating" }) => {
         return () => window.removeEventListener("scroll", onScroll);
     }, []);
 
+    // Публикуем реальную занятую хедером высоту (капсула + опциональный
+    // баннер) как CSS-переменную, чтобы sticky-подменю на других страницах
+    // (offer/host/volunteer/donation) не заезжали под шапку/друг на друга —
+    // раньше у них был захардкожен top: 6.5rem, который не учитывал
+    // появление баннера под шапкой.
+    useEffect(() => {
+        const element = wrapperRef.current;
+        if (!element) {
+            return undefined;
+        }
+
+        const updateHeaderOffset = () => {
+            const { bottom } = element.getBoundingClientRect();
+            document.documentElement.style.setProperty(
+                "--header-offset",
+                `${Math.max(bottom, 0)}px`,
+            );
+        };
+
+        updateHeaderOffset();
+
+        const resizeObserver = new ResizeObserver(updateHeaderOffset);
+        resizeObserver.observe(element);
+        window.addEventListener("resize", updateHeaderOffset);
+
+        return () => {
+            resizeObserver.disconnect();
+            window.removeEventListener("resize", updateHeaderOffset);
+        };
+    }, [data, variant, scrolled]);
+
     return (
-        <div className={cn(styles.wrapper, styles[variant], { [styles.scrolled]: scrolled })}>
+        <div
+            ref={wrapperRef}
+            className={cn(styles.wrapper, styles[variant], { [styles.scrolled]: scrolled })}
+        >
             {data && (
                 <a
                     href={data.url}

--- a/src/widgets/OfferSubmenu/ui/OfferSubmenu.module.scss
+++ b/src/widgets/OfferSubmenu/ui/OfferSubmenu.module.scss
@@ -1,7 +1,7 @@
 .navMenu {
     // padding: 26px 50px 16px 50px;
     position: sticky;
-    top: 6.5rem;
+    top: calc(var(--header-offset, 6.5rem) + 12px);
     z-index: 4;
 }
 


### PR DESCRIPTION
## Что сделано
При скролле страниц вакансии/доната/хоста/волонтёра sticky-подменю (Описание/Что делать/Условия/... + кнопка «Участвовать») визуально сливалось с плавающей шапкой — читалось как «двойное меню».

Причина: `top: 6.5rem` у всех 4 sticky-подменю был захардкожен ещё до появления промо-баннера под шапкой (`UNDER_HEADER_ALL_PAGES`) и не учитывал его высоту — когда баннер показывается, реальная высота шапки больше 6.5rem, и подменю прилипает вплотную без зазора.

Фикс:
- `MainHeader` меряет свою реальную высоту (капсула + баннер, если есть) через `ResizeObserver` и публикует в CSS-переменную `--header-offset` на `:root`.
- Все 4 sticky-подменю (`OfferSubmenu`, `DonationSubmenu`, `VolunteerPersonalPage`, `HostPersonalPage`) используют `top: calc(var(--header-offset, 6.5rem) + 12px)` — с запасным хардкодом, если переменная не установилась.

Тест `MainHeader.test.tsx` (revert-and-confirm-fails пройден).

## Тест-план
- [ ] Открыть /offer-personal/{id} на стейдже с активным баннером под шапкой, проскроллить — подменю должно быть визуально отделено от шапки, без слипания