### PR TITLE
fix(perf): medium-превью в карточках вакансий вместо оригиналов

### DIFF
--- a/src/widgets/OffersRecomendationsWidget/ui/OffersRecomendationsWidget.tsx
+++ b/src/widgets/OffersRecomendationsWidget/ui/OffersRecomendationsWidget.tsx
@@ -66,7 +66,7 @@ export const OffersRecomendationsWidget: FC<OffersRecomendationsWidgetProps> = m
                             id: offer.id,
                             title: offer.title,
                             shortDescription: offer.shortDescription,
-                            imagePath: offer.image?.contentUrl,
+                            imagePath: offer.image?.thumbnails?.medium ?? offer.image?.contentUrl,
                             categories: offer.categories.map((cat) => cat.name),
                             address: offer.address,
                             acceptedApplicationsCount: offer.acceptedApplicationsCount,

--- a/src/widgets/OffersSlider/ui/Offer/Offer.tsx
+++ b/src/widgets/OffersSlider/ui/Offer/Offer.tsx
@@ -39,7 +39,7 @@ const Offer: FC<OfferProps> = (props) => {
     return (
         <Link to={getOfferPersonalPageUrl(locale, id.toString())} className={styles.item}>
             <img
-                src={image ? getMediaContent(image?.contentUrl) : defaultImage}
+                src={image ? getMediaContent(image, "MEDIUM") : defaultImage}
                 className={styles.image}
                 alt={title}
                 loading="lazy"


### PR DESCRIPTION
## Что

`OffersSlider` (карусель на главной странице) и `OffersRecomendationsWidget`
(рекомендации в личном кабинете волонтёра) грузили `image.contentUrl` —
полноразмерный оригинал изображения — вместо `thumbnails.medium`, хотя
карточка рисует картинку в маленьком размере. Тот же класс бага уже чинили
на `/offers-map` (`getOfferImagePath.ts`, PR #337/#338) — здесь применён
тот же паттерн с фолбэком на `contentUrl` для легаси-вакансий без thumbnails.

## Почему не тронут сплиттинг чанков

Отдельно пробовал уменьшить число чанков (`experimentalMinChunkSize`,
затем ручная группировка `src/pages/*` по семействам в `manualChunks`).
Оказалось:
- `experimentalMinChunkSize` в Vite 8 не долетает до Rollup — валидатор
  конфига молча отбрасывает ключ (warning "Invalid key: Expected never but
  received experimentalMinChunkSize" в логе сборки), поэтому чанки не
  менялись вообще.
- Ручная группировка страниц по семействам (Admin/Host/Volunteer/...)
  действительно сократила число чанков (316 → 190), но задела эвристику
  Rollup по автоматическому вынесению общих зависимостей: в одной сборке
  `react-player`+`hls.js`, а следом ещё и `redux-toolkit`/`axios`/
  `i18next`/`swiper` неожиданно осели целиком в чанке `pages.academy`
  (3 текстовые страницы академии внезапно тянули 770kB+).

Baseline-замеры (TTFB ~20ms, load 300-470ms на всех проверенных страницах)
и так были в норме — 172 запроса на визит не были узким местом, а риск
регресса от пересборки чанков перевешивал гипотетическую выгоду. Оставил
исходный `manualChunks` как есть.

## Test plan
- [x] `npm run build` — чисто
- [x] `tsc --noEmit` — чисто
- [x] `eslint` на изменённые файлы — чисто
- [x] `vitest run` — 119/120 (1 упавший тест и 1 упавший suite не связаны
      с изменениями: отсутствующий `@testing-library/dom` в node_modules и
      несвязанный тест sticky-хедера на `HostPersonalPage`)
- [ ] Живой замер на стейдже после мержа

🤖 Generated with [Claude Code](https://claude.com/claude-code)