### PR TITLE
test: покрыть фронт тестами (вакансии, сборы, организации)

### DIFF
--- a/src/features/HostDescription/ui/HostDescriptionForm/HostDescriptionForm.behavior.test.tsx
+++ b/src/features/HostDescription/ui/HostDescriptionForm/HostDescriptionForm.behavior.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { HostDescriptionForm } from "./HostDescriptionForm";
+
+// HostDescriptionFormContent — большая композитная форма (аватар, адрес,
+// соцсети, тип организации), не имеющая отдельной ценности для теста этого
+// компонента — стабим пустым рендером, проверяем именно ветвление
+// create/update + тосты + сброс sessionStorage внутри HostDescriptionForm.
+vi.mock("../HostDescriptionFormContent/HostDescriptionFormContent", () => ({
+    // Пробрасываем host дальше видимым текстом — по нему в тесте дожидаемся,
+    // пока useGetMyHostQuery реально зарезолвится, прежде чем сабмитить форму
+    // (иначе onSubmit уходит в ветку create/update по устаревшему getHost).
+    HostDescriptionFormContent: ({ host }: { host?: { id: string } }) => (
+        <span>{host ? `host-loaded:${host.id}` : "host-loading"}</span>
+    ),
+}));
+
+type FormProps = Partial<React.ComponentProps<typeof HostDescriptionForm>>;
+
+const renderForm = (props: FormProps = {}) => renderWithProviders(
+    <MemoryRouter>
+        <HostDescriptionForm
+            isLoading={false}
+            isError={false}
+            profileRefetch={vi.fn()}
+            {...props}
+        />
+    </MemoryRouter>,
+);
+
+describe("HostDescriptionForm", () => {
+    it("без организации у профиля — сабмит создаёт новую организацию", async () => {
+        let createdBody: unknown;
+        const profileRefetch = vi.fn();
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(ctx.status(404))),
+            rest.post("*/organizations", async (req, res, ctx) => {
+                createdBody = await req.json();
+                return res(ctx.status(201), ctx.json({ id: "h1", name: "", description: "" }));
+            }),
+        );
+
+        renderForm({ host: null, profileRefetch });
+
+        await userEvent.click(screen.getByText("hostDescription.Сохранить"));
+
+        expect(await screen.findByText("hostDescription.Организация создана")).toBeInTheDocument();
+        expect(createdBody).toMatchObject({ isActive: true, type: "ИП" });
+        expect(profileRefetch).toHaveBeenCalled();
+    });
+
+    it("с существующей организацией — сабмит обновляет её по id", async () => {
+        let updatedId: string | undefined;
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({
+                    id: "h1", name: "Волонтёры", type: "НКО", address: "", description: "", shortDescription: "",
+                }),
+            )),
+            rest.patch("*/organizations/:id", (req, res, ctx) => {
+                updatedId = req.params.id as string;
+                return res(ctx.status(200), ctx.json({ id: "h1" }));
+            }),
+        );
+
+        renderForm({ host: "h1" });
+
+        await screen.findByText("host-loaded:h1");
+        await userEvent.click(screen.getByText("hostDescription.Сохранить"));
+
+        expect(await screen.findByText("hostDescription.Данные успешно изменены")).toBeInTheDocument();
+        expect(updatedId).toBe("h1");
+    });
+
+    it("показывает тост об ошибке, если сохранение упало", async () => {
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(ctx.status(404))),
+            rest.post("*/organizations", (req, res, ctx) => res(ctx.status(500))),
+        );
+
+        renderForm({ host: null });
+
+        await userEvent.click(screen.getByText("hostDescription.Сохранить"));
+
+        expect(await screen.findByText("hostDescription.Произошла ошибка")).toBeInTheDocument();
+    });
+
+    it("isError=true — показывает сообщение вместо формы", () => {
+        renderForm({ host: null, isError: true });
+
+        expect(screen.getByText(
+            "hostDescription.Произошла ошибка! Поробуйте перезагрузить страницу",
+        )).toBeInTheDocument();
+        expect(screen.queryByText("hostDescription.Сохранить")).not.toBeInTheDocument();
+    });
+});

--- a/src/features/Notes/ui/NotesHostForm/NotesHostForm.behavior.test.tsx
+++ b/src/features/Notes/ui/NotesHostForm/NotesHostForm.behavior.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { NotesHostForm } from "./NotesHostForm";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+// NotesContainer — канбан-колонка с drag&drop (react-beautiful-dnd), не
+// имеет смысла гонять DnD в юнит-тесте — стабим кнопками accept/cancel по
+// первой заявке колонки, проверяем реальную логику NotesHostForm: смена
+// статуса заявки хостом и обработка ошибки.
+vi.mock("@/widgets/NotesWidget", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/widgets/NotesWidget")>();
+    return {
+        ...actual,
+        NotesContainer: ({
+            status, total, notes, onAcceptClick, onCancelClick,
+        }: any) => (
+            <div>
+                <span>{`column:${status}:${total}`}</span>
+                {notes.map((note: any) => (
+                    <div key={note.id}>
+                        <button type="button" onClick={() => onAcceptClick(note.id)}>
+                            {`accept-${note.id}`}
+                        </button>
+                        <button type="button" onClick={() => onCancelClick(note.id)}>
+                            {`cancel-${note.id}`}
+                        </button>
+                    </div>
+                ))}
+            </div>
+        ),
+    };
+});
+
+const APPLICATIONS_URL = "*/application/list-of-organization";
+
+const mockApplicationsHandler = (status: string, notes: unknown[]) => rest.get(
+    APPLICATIONS_URL,
+    (req, res, ctx) => {
+        if (req.url.searchParams.get("status") !== status) {
+            return res(ctx.status(200), ctx.json({ data: [], pagination: { total: 0 } }));
+        }
+        return res(ctx.status(200), ctx.json({ data: notes, pagination: { total: notes.length } }));
+    },
+);
+
+const renderForm = () => renderWithProviders(
+    <MemoryRouter>
+        <NotesHostForm />
+    </MemoryRouter>,
+);
+
+describe("NotesHostForm", () => {
+    it("принимает заявку волонтёра", async () => {
+        let statusBody: unknown;
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: "h1" }))),
+            rest.get("*/vacancy/list/h1", (req, res, ctx) => res(ctx.status(200), ctx.json({ data: [] }))),
+            mockApplicationsHandler("new", [{ id: 101, status: "new" }]),
+            rest.patch("*/application_forms/101/status", async (req, res, ctx) => {
+                statusBody = await req.json();
+                return res(ctx.status(200), ctx.json({ id: 101, status: "accepted" }));
+            }),
+        );
+
+        renderForm();
+
+        await userEvent.click(await screen.findByText("accept-101"));
+
+        await waitFor(() => expect(statusBody).toEqual({ status: "accepted" }));
+    });
+
+    it("отклоняет заявку волонтёра", async () => {
+        let statusBody: unknown;
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: "h1" }))),
+            rest.get("*/vacancy/list/h1", (req, res, ctx) => res(ctx.status(200), ctx.json({ data: [] }))),
+            mockApplicationsHandler("new", [{ id: 202, status: "new" }]),
+            rest.patch("*/application_forms/202/status", async (req, res, ctx) => {
+                statusBody = await req.json();
+                return res(ctx.status(200), ctx.json({ id: 202, status: "canceled" }));
+            }),
+        );
+
+        renderForm();
+
+        await userEvent.click(await screen.findByText("cancel-202"));
+
+        await waitFor(() => expect(statusBody).toEqual({ status: "canceled" }));
+    });
+
+    it("показывает тост, если смена статуса заявки упала", async () => {
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: "h1" }))),
+            rest.get("*/vacancy/list/h1", (req, res, ctx) => res(ctx.status(200), ctx.json({ data: [] }))),
+            mockApplicationsHandler("new", [{ id: 303, status: "new" }]),
+            rest.patch("*/application_forms/303/status", (req, res, ctx) => res(ctx.status(500))),
+        );
+
+        renderForm();
+
+        await userEvent.click(await screen.findByText("accept-303"));
+
+        expect(await screen.findByText("Не удалось изменить статус заявки")).toBeInTheDocument();
+    });
+
+    it("каждая колонка получает свой total с бэкенда (row 101 regression)", async () => {
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: "h1" }))),
+            rest.get("*/vacancy/list/h1", (req, res, ctx) => res(ctx.status(200), ctx.json({ data: [] }))),
+            rest.get(APPLICATIONS_URL, (req, res, ctx) => {
+                const status = req.url.searchParams.get("status");
+                const totals: Record<string, number> = { new: 3, accepted: 7, canceled: 1 };
+                return res(ctx.status(200), ctx.json({
+                    data: [],
+                    pagination: { total: totals[status ?? ""] ?? 0 },
+                }));
+            }),
+        );
+
+        renderForm();
+
+        expect(await screen.findByText("column:new:3")).toBeInTheDocument();
+        expect(screen.getByText("column:accepted:7")).toBeInTheDocument();
+        expect(screen.getByText("column:canceled:1")).toBeInTheDocument();
+    });
+});

--- a/src/pages/FundraiseStepPage/ui/FundraiseStepPage.behavior.test.tsx
+++ b/src/pages/FundraiseStepPage/ui/FundraiseStepPage.behavior.test.tsx
@@ -1,0 +1,288 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import FundraiseStepPage from "./FundraiseStepPage";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+// "where"/"description" шаги делегируют в тяжёлые общие формы (карта,
+// загрузка галереи) — здесь стабим их, чтобы проверять именно логику
+// виджета (загрузка/сохранение/тост), а не саму форму.
+vi.mock("@/features/Offer", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/features/Offer")>();
+    return {
+        ...actual,
+        OfferWhereForm: ({ onComplete }: any) => (
+            <button
+                type="button"
+                onClick={() => onComplete({
+                    address: {
+                        address: "Москва",
+                        geoObject: { name: "Москва", description: "", Point: { pos: "37.6 55.7" } },
+                    },
+                })}
+            >
+                submit-where
+            </button>
+        ),
+        InviteDescriptionForm: ({ onComplete }: any) => (
+            <button
+                type="button"
+                onClick={() => onComplete({
+                    title: "Заголовок",
+                    shortDescription: "Кратко",
+                    fullDescription: "Полно",
+                    coverImage: { id: "img1" },
+                    category: ["cat1"],
+                })}
+            >
+                submit-description
+            </button>
+        ),
+    };
+});
+
+const renderStep = (step: string, id = "42") => renderWithProviders(
+    <MemoryRouter initialEntries={[`/ru/fundraise/${step}/${id}`]}>
+        <Routes>
+            <Route path="/:locale/fundraise/:step/:id" element={<FundraiseStepPage />} />
+        </Routes>
+    </MemoryRouter>,
+);
+
+// Кнопки/поля на всех шагах задизейблены, пока не отработает GET исходных
+// данных (isLoading*) — ждём разблокировки, иначе клик/ввод по ещё
+// задизейбленному элементу молча ничего не делает.
+const clickWhenEnabled = async (text: string) => {
+    const button = await screen.findByRole("button", { name: text });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    await userEvent.click(button);
+};
+
+describe("FundraiseStepPage — шаг where", () => {
+    it("сохраняет адрес и показывает тост об успехе", async () => {
+        server.use(
+            rest.get("*/fundraise/address/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ address: "", longitude: null, latitude: null }),
+            )),
+            rest.patch("*/fundraise/address/:id", (req, res, ctx) => res(ctx.status(200), ctx.json({}))),
+        );
+
+        renderStep("where");
+        await userEvent.click(await screen.findByText("submit-where"));
+
+        expect(await screen.findByText("Адрес успешно сохранён")).toBeInTheDocument();
+    });
+
+    it("показывает текст ошибки, если сохранение адреса упало", async () => {
+        server.use(
+            rest.get("*/fundraise/address/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ address: "", longitude: null, latitude: null }),
+            )),
+            rest.patch("*/fundraise/address/:id", (req, res, ctx) => res(
+                ctx.status(400),
+                ctx.json({ detail: "Некорректный адрес" }),
+            )),
+        );
+
+        renderStep("where");
+        await userEvent.click(await screen.findByText("submit-where"));
+
+        expect(await screen.findByText(/Некорректный адрес/i)).toBeInTheDocument();
+    });
+});
+
+describe("FundraiseStepPage — шаг when", () => {
+    it("сохраняет дату окончания и переходит дальше по кнопке «Дальше»", async () => {
+        let patchedBody: unknown;
+        server.use(
+            rest.get("*/fundraise/when/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ endDate: null, isUntilAmountCollected: false }),
+            )),
+            rest.patch("*/fundraise/when/:id", async (req, res, ctx) => {
+                patchedBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderStep("when");
+
+        expect(await screen.findByText(
+            "Дата окончания приема пожертвований",
+        )).toBeInTheDocument();
+        await clickWhenEnabled("Сохранить");
+
+        await waitFor(() => expect(screen.getByText(
+            "Настройки срока сбора сохранены",
+        )).toBeInTheDocument());
+        expect(patchedBody).toMatchObject({ isUntilAmountCollected: false });
+    });
+
+    it("при «собирать до достижения минимума» блокирует поле даты", async () => {
+        server.use(
+            rest.get("*/fundraise/when/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ endDate: null, isUntilAmountCollected: false }),
+            )),
+            rest.patch("*/fundraise/when/:id", (req, res, ctx) => res(ctx.status(200), ctx.json({}))),
+        );
+
+        renderStep("when");
+
+        await screen.findByText("Дата окончания приема пожертвований");
+        const untilAmountLabel = screen.getByText(
+            "Принимаю пожертвования до тех пор, пока минимальная сумма не будет собрана",
+        );
+        await waitFor(() => expect(screen.getByRole("button", { name: "Сохранить" })).not.toBeDisabled());
+        await userEvent.click(untilAmountLabel);
+
+        await waitFor(() => expect(
+            screen.getByPlaceholderText("Не задано").className,
+        ).toContain("disabled"));
+    });
+});
+
+describe("FundraiseStepPage — шаг amount", () => {
+    it("сохраняет суммы сбора", async () => {
+        let patchedBody: unknown;
+        server.use(
+            rest.get("*/fundraise/how-many/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ amount: 0, minAmount: 0 }),
+            )),
+            rest.patch("*/fundraise/how-many/:id", async (req, res, ctx) => {
+                patchedBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderStep("amount");
+
+        await screen.findByText("Укажите желаемую сумму в рублях");
+        await waitFor(() => expect(screen.getByRole("button", { name: "Сохранить" })).not.toBeDisabled());
+        const [amountInput, minAmountInput] = screen.getAllByRole("textbox");
+        await userEvent.type(amountInput, "50000");
+        await userEvent.type(minAmountInput, "10000");
+        await clickWhenEnabled("Сохранить");
+
+        await waitFor(() => expect(screen.getByText(
+            "Суммы сбора сохранены",
+        )).toBeInTheDocument());
+        expect(patchedBody).toEqual({ amount: 50000, minAmount: 10000 });
+    });
+
+    it("показывает ошибку бэка при неудачном сохранении суммы", async () => {
+        server.use(
+            rest.get("*/fundraise/how-many/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ amount: 0, minAmount: 0 }),
+            )),
+            rest.patch("*/fundraise/how-many/:id", (req, res, ctx) => res(
+                ctx.status(400),
+                ctx.json({ detail: "amount: должна быть больше 0" }),
+            )),
+        );
+
+        renderStep("amount");
+        await clickWhenEnabled("Сохранить");
+
+        expect(await screen.findByText(/amount: должна быть больше 0/i)).toBeInTheDocument();
+    });
+});
+
+describe("FundraiseStepPage — шаг description", () => {
+    it("сохраняет описание и показывает тост об успехе", async () => {
+        server.use(
+            rest.get("*/fundraise/description/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({
+                    name: "", shortDescription: "", description: "", image: null, categoryIds: [],
+                }),
+            )),
+            rest.patch("*/fundraise/description/:id", (req, res, ctx) => res(ctx.status(200), ctx.json({}))),
+        );
+
+        renderStep("description");
+        await userEvent.click(await screen.findByText("submit-description"));
+
+        expect(await screen.findByText("Описание сбора сохранено")).toBeInTheDocument();
+    });
+});
+
+describe("FundraiseStepPage — шаг auto-messages", () => {
+    it("требует слова благодарности перед публикацией", async () => {
+        server.use(
+            rest.get("*/fundraise/automatic-messages/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ wordsGratitude: "", urlProgressWork: [], status: "draft" }),
+            )),
+        );
+
+        renderStep("auto-messages");
+        await clickWhenEnabled("Опубликовать");
+
+        expect(await screen.findByText(
+            "Данное поле является обязательным",
+        )).toBeInTheDocument();
+    });
+
+    it("публикует сбор при заполненных словах благодарности", async () => {
+        let statusBody: unknown;
+        server.use(
+            rest.get("*/fundraise/automatic-messages/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ wordsGratitude: "", urlProgressWork: [], status: "draft" }),
+            )),
+            rest.patch("*/fundraise/automatic-messages/:id", (req, res, ctx) => res(ctx.status(200), ctx.json({}))),
+            rest.patch("*/fundraise/toggle-status/:id", async (req, res, ctx) => {
+                statusBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderStep("auto-messages");
+        await screen.findByText("Слова благодарности");
+        await waitFor(() => expect(screen.getByRole("button", { name: "Опубликовать" })).not.toBeDisabled());
+        await userEvent.type(screen.getAllByRole("textbox")[0], "Спасибо!");
+        await clickWhenEnabled("Опубликовать");
+
+        await waitFor(() => expect(screen.getByText("Сбор опубликован")).toBeInTheDocument());
+        expect(statusBody).toEqual({ status: "active" });
+    });
+
+    it("сохраняет черновик со статусом draft (не active)", async () => {
+        let statusBody: unknown;
+        server.use(
+            rest.get("*/fundraise/automatic-messages/:id", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ wordsGratitude: "", urlProgressWork: [], status: "draft" }),
+            )),
+            rest.patch("*/fundraise/automatic-messages/:id", (req, res, ctx) => res(ctx.status(200), ctx.json({}))),
+            rest.patch("*/fundraise/toggle-status/:id", async (req, res, ctx) => {
+                statusBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderStep("auto-messages");
+        await screen.findByText("Слова благодарности");
+        await waitFor(() => expect(screen.getByRole("button", { name: "Сохранить в черновики" })).not.toBeDisabled());
+        await userEvent.type(screen.getAllByRole("textbox")[0], "Спасибо!");
+        await clickWhenEnabled("Сохранить в черновики");
+
+        await waitFor(() => expect(screen.getByText("Сбор сохранён в черновики")).toBeInTheDocument());
+        expect(statusBody).toEqual({ status: "draft" });
+    });
+});

--- a/src/widgets/Offer/ui/OfferConditions/OfferConditions.behavior.test.tsx
+++ b/src/widgets/Offer/ui/OfferConditions/OfferConditions.behavior.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OfferConditions } from "./OfferConditions";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/features/OfferConditions", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/features/OfferConditions")>();
+    return {
+        ...actual,
+        OfferConditionsForm: ({ isLoadingGetData, isLoadingUpdateData, onComplete }: any) => (
+            <button
+                type="button"
+                disabled={isLoadingGetData || isLoadingUpdateData}
+                onClick={() => onComplete({
+                    housing: { switchState: true, housing: ["h1"] },
+                    nutrition: { switchState: false, nutrition: [] },
+                    travel: { switchState: false, travel: [] },
+                    facilities: { facilities: [] },
+                    extraFeatures: { extraFeatures: [] },
+                    payment: { currency: "RUB", contribution: 0, reward: 0 },
+                    extraConditions: "",
+                })}
+            >
+                submit-conditions
+            </button>
+        ),
+    };
+});
+
+const renderWidget = (offerId = "42") => renderWithProviders(
+    <MemoryRouter>
+        <OfferConditions offerId={offerId} />
+    </MemoryRouter>,
+);
+
+describe("OfferConditions", () => {
+    it("сохраняет условия вакансии и показывает тост об успехе", async () => {
+        let patchedBody: unknown;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, condition: null }))),
+            rest.patch("*/vacancy/condition/42", async (req, res, ctx) => {
+                patchedBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-conditions");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText("Данные успешно сохранены")).toBeInTheDocument();
+        expect(patchedBody).toMatchObject({ houseIds: ["h1"], currency: "RUB" });
+    });
+
+    it("показывает текст ошибки бэка при неудачном сохранении", async () => {
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, condition: null }))),
+            rest.patch("*/vacancy/condition/42", (req, res, ctx) => res(
+                ctx.status(400),
+                ctx.json({ detail: "currency: недопустимое значение" }),
+            )),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-conditions");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText(/currency: недопустимое значение/i)).toBeInTheDocument();
+    });
+});

--- a/src/widgets/Offer/ui/OfferDescription/OfferDescription.behavior.test.tsx
+++ b/src/widgets/Offer/ui/OfferDescription/OfferDescription.behavior.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OfferDescription } from "./OfferDescription";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/features/Offer", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/features/Offer")>();
+    return {
+        ...actual,
+        InviteDescriptionForm: ({
+            isLoadingGetData, isLoadingUpdateData, onComplete, onUploadImageGallery,
+        }: any) => (
+            <>
+                <button
+                    type="button"
+                    disabled={isLoadingGetData || isLoadingUpdateData}
+                    onClick={() => onComplete({
+                        title: "Помощь на фестивале",
+                        shortDescription: "Кратко",
+                        fullDescription: "Полное описание",
+                        coverImage: { id: "img1" },
+                        category: ["cat1"],
+                    })}
+                >
+                    submit-description
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onUploadImageGallery(["g1", "g2"])}
+                >
+                    upload-gallery
+                </button>
+            </>
+        ),
+    };
+});
+
+const renderWidget = (offerId = "42") => renderWithProviders(
+    <MemoryRouter>
+        <OfferDescription offerId={offerId} />
+    </MemoryRouter>,
+);
+
+describe("OfferDescription", () => {
+    it("сохраняет описание вакансии и показывает тост об успехе", async () => {
+        let patchedBody: unknown;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, description: null }))),
+            rest.patch("*/vacancy/description/42", async (req, res, ctx) => {
+                patchedBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-description");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText("Данные успешно сохранены")).toBeInTheDocument();
+        expect(patchedBody).toMatchObject({ title: "Помощь на фестивале", imageId: "img1" });
+    });
+
+    it("показывает текст ошибки бэка при неудачном сохранении", async () => {
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, description: null }))),
+            rest.patch("*/vacancy/description/42", (req, res, ctx) => res(
+                ctx.status(400),
+                ctx.json({ detail: "name: обязательное поле" }),
+            )),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-description");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText(/name: обязательное поле/i)).toBeInTheDocument();
+    });
+
+    it("обновляет галерею изображений отдельной мутацией", async () => {
+        let galleryBody: unknown;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, description: null }))),
+            rest.patch("*/vacancy/image-gallery/42", async (req, res, ctx) => {
+                galleryBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderWidget();
+        await userEvent.click(await screen.findByText("upload-gallery"));
+
+        expect(await screen.findByText("volunteer-gallery.Галерея успешно обновлена")).toBeInTheDocument();
+        expect(galleryBody).toEqual({ galleryImageIds: ["g1", "g2"] });
+    });
+
+    it("показывает ошибку, если обновление галереи упало", async () => {
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, description: null }))),
+            rest.patch("*/vacancy/image-gallery/42", (req, res, ctx) => res(ctx.status(500))),
+        );
+
+        renderWidget();
+        await userEvent.click(await screen.findByText("upload-gallery"));
+
+        expect(await screen.findByText("volunteer-gallery.Произошла ошибка с обновлением галереи")).toBeInTheDocument();
+    });
+});

--- a/src/widgets/Offer/ui/OfferFinishingTouches/OfferFinishingTouches.behavior.test.tsx
+++ b/src/widgets/Offer/ui/OfferFinishingTouches/OfferFinishingTouches.behavior.test.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OfferFinishingTouches } from "./OfferFinishingTouches";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/features/OfferFinishingTouches", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/features/OfferFinishingTouches")>();
+    return {
+        ...actual,
+        OfferFinishingTouchesForm: ({ isLoadingGetData, isLoadingUpdateData, onComplete }: any) => (
+            <>
+                <button
+                    type="button"
+                    disabled={isLoadingGetData || isLoadingUpdateData}
+                    onClick={() => onComplete({ title: "Вакансия" }, "draft")}
+                >
+                    save-draft
+                </button>
+                <button
+                    type="button"
+                    disabled={isLoadingGetData || isLoadingUpdateData}
+                    onClick={() => onComplete({ title: "Вакансия" }, "active")}
+                >
+                    publish
+                </button>
+            </>
+        ),
+    };
+});
+
+const renderWidget = (offerId = "42") => renderWithProviders(
+    <MemoryRouter initialEntries={["/ru/offer/finishing-touches/42"]}>
+        <Routes>
+            <Route path="/ru/offer/finishing-touches/:id" element={<OfferFinishingTouches offerId={offerId} />} />
+            <Route path="/ru/host/my-offers" element={<div>Мои вакансии</div>} />
+        </Routes>
+    </MemoryRouter>,
+);
+
+describe("OfferFinishingTouches", () => {
+    it("черновик сохраняется сразу, без модалки подтверждения публикации", async () => {
+        let statusCalled = false;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ id: 42, status: "draft", finishingTouche: null }),
+            )),
+            rest.patch("*/vacancies/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42 }))),
+            rest.patch("*/vacancy/toggle-status/42", (req, res, ctx) => {
+                statusCalled = true;
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("save-draft");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        // После успешного сохранения виджет сразу же делает navigate() —
+        // тост от setToast() не успевает отрендериться до размонтирования,
+        // поэтому наблюдаем именно факт перехода на список вакансий.
+        expect(await screen.findByText("Мои вакансии")).toBeInTheDocument();
+        expect(statusCalled).toBe(false);
+    });
+
+    it("публикация черновика требует подтверждения в модалке", async () => {
+        let statusBody: unknown;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ id: 42, status: "draft", finishingTouche: null }),
+            )),
+            rest.patch("*/vacancies/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42 }))),
+            rest.patch("*/vacancy/toggle-status/42", async (req, res, ctx) => {
+                statusBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("publish");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        // Модалка подтверждения открылась, мутация ещё не должна была уйти
+        expect(await screen.findByText(
+            "Вы уверены, что хотите опубликовать это предложение? После публикации его увидят другие пользователи.",
+        )).toBeInTheDocument();
+        expect(statusBody).toBeUndefined();
+
+        await userEvent.click(screen.getByText("Опубликовать"));
+
+        expect(await screen.findByText("Мои вакансии")).toBeInTheDocument();
+        expect(statusBody).toEqual({ status: "active" });
+    });
+
+    it("отмена в модалке не публикует вакансию", async () => {
+        let statusCalled = false;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ id: 42, status: "draft", finishingTouche: null }),
+            )),
+            rest.patch("*/vacancies/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42 }))),
+            rest.patch("*/vacancy/toggle-status/42", (req, res, ctx) => {
+                statusCalled = true;
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("publish");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        await screen.findByText(
+            "Вы уверены, что хотите опубликовать это предложение? После публикации его увидят другие пользователи.",
+        );
+        await userEvent.click(screen.getByText("Отмена"));
+
+        expect(statusCalled).toBe(false);
+    });
+
+    it("для уже опубликованной вакансии повторная публикация не требует модалки", async () => {
+        let statusCalled = false;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ id: 42, status: "active", finishingTouche: null }),
+            )),
+            rest.patch("*/vacancies/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42 }))),
+            rest.patch("*/vacancy/toggle-status/42", (req, res, ctx) => {
+                statusCalled = true;
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("publish");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText("Мои вакансии")).toBeInTheDocument();
+        // currentStatus уже active, повторный toggle-status не требуется
+        expect(statusCalled).toBe(false);
+    });
+});

--- a/src/widgets/Offer/ui/OfferWhatToDo/OfferWhatToDo.behavior.test.tsx
+++ b/src/widgets/Offer/ui/OfferWhatToDo/OfferWhatToDo.behavior.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OfferWhatToDo } from "./OfferWhatToDo";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/features/OfferWhatToDo", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/features/OfferWhatToDo")>();
+    return {
+        ...actual,
+        OfferWhatToDoForm: ({ isLoadingGetData, isLoadingUpdateData, onComplete }: any) => (
+            <button
+                type="button"
+                disabled={isLoadingGetData || isLoadingUpdateData}
+                onClick={() => onComplete({
+                    skills: ["s1"],
+                    additionalSkills: [],
+                    workingHours: { hours: 6, dayOff: 2, timeType: "week" },
+                    extraInfo: "",
+                })}
+            >
+                submit-what-to-do
+            </button>
+        ),
+    };
+});
+
+const renderWidget = (offerId = "42") => renderWithProviders(
+    <MemoryRouter>
+        <OfferWhatToDo offerId={offerId} />
+    </MemoryRouter>,
+);
+
+describe("OfferWhatToDo", () => {
+    it("сохраняет чем предстоит заниматься и показывает тост об успехе", async () => {
+        let patchedBody: unknown;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, whatToDo: null }))),
+            rest.patch("*/vacancy/what-to-do/42", async (req, res, ctx) => {
+                patchedBody = await req.json();
+                return res(ctx.status(200), ctx.json({}));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-what-to-do");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText("Данные успешно сохранены")).toBeInTheDocument();
+        expect(patchedBody).toMatchObject({
+            skillIds: ["s1"], hours: 6, dayOff: 2, timeType: "week",
+        });
+    });
+
+    it("показывает текст ошибки бэка при неудачном сохранении", async () => {
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, whatToDo: null }))),
+            rest.patch("*/vacancy/what-to-do/42", (req, res, ctx) => res(
+                ctx.status(400),
+                ctx.json({ detail: "skillIds: должно быть заполнено" }),
+            )),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-what-to-do");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText(/skillIds: должно быть заполнено/i)).toBeInTheDocument();
+    });
+});

--- a/src/widgets/Offer/ui/OfferWhen/OfferWhen.behavior.test.tsx
+++ b/src/widgets/Offer/ui/OfferWhen/OfferWhen.behavior.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OfferWhen } from "./OfferWhen";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+// OfferWhenForm — составная форма (слайдер периодов/дат/настроек) без
+// самостоятельной ценности для теста виджета — стабим, проверяем логику
+// OfferWhen: загрузка/адаптация данных вакансии, сохранение, тост.
+vi.mock("@/features/Offer", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/features/Offer")>();
+    return {
+        ...actual,
+        OfferWhenForm: ({ isLoadingGetWhenData, isLoadingUpdateWhenData, onComplete }: any) => (
+            <button
+                type="button"
+                disabled={isLoadingGetWhenData || isLoadingUpdateWhenData}
+                onClick={() => onComplete({
+                    periods: [],
+                    participationPeriod: [3, 14],
+                    endSettings: { applicationEndDate: null },
+                    timeSettings: { isFullYearAcceptable: true, isApplicableAtTheEnd: false },
+                })}
+            >
+                submit-when
+            </button>
+        ),
+    };
+});
+
+const renderWidget = (offerId = "42") => renderWithProviders(
+    <MemoryRouter>
+        <OfferWhen offerId={offerId} />
+    </MemoryRouter>,
+);
+
+describe("OfferWhen", () => {
+    it("сохраняет период вакансии и показывает тост об успехе", async () => {
+        let patchedBody: unknown;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, when: null }))),
+            rest.patch("*/vacancies/42", async (req, res, ctx) => {
+                patchedBody = await req.json();
+                return res(ctx.status(200), ctx.json({ id: 42 }));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-when");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText("Данные успешно сохранены")).toBeInTheDocument();
+        expect(patchedBody).toMatchObject({
+            when: { durationMinDays: 3, durationMaxDays: 14, isFullYearAcceptable: true },
+        });
+    });
+
+    it("показывает текст ошибки бэка при неудачном сохранении", async () => {
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, when: null }))),
+            rest.patch("*/vacancies/42", (req, res, ctx) => res(
+                ctx.status(400),
+                ctx.json({ detail: "when.durationMinDays: должно быть меньше durationMaxDays" }),
+            )),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-when");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText(/durationMinDays: должно быть меньше/i)).toBeInTheDocument();
+    });
+});

--- a/src/widgets/Offer/ui/OfferWhere/OfferWhere.behavior.test.tsx
+++ b/src/widgets/Offer/ui/OfferWhere/OfferWhere.behavior.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OfferWhere } from "./OfferWhere";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+// Реальная OfferWhereForm рендерит карту (MapWithAddress), которая делает
+// геокодирование через внешний Yandex API — не имеет смысла гонять это в
+// unit-тесте виджета. Стабим форму, чтобы проверить именно логику
+// OfferWhere: загрузка данных вакансии, сохранение, тост об ошибке/успехе.
+vi.mock("@/features/Offer", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/features/Offer")>();
+    return {
+        ...actual,
+        OfferWhereForm: ({ isLoadingGetData, isLoadingUpdateData, onComplete }: any) => (
+            <button
+                type="button"
+                disabled={isLoadingGetData || isLoadingUpdateData}
+                onClick={() => onComplete({
+                    address: {
+                        address: "Санкт-Петербург",
+                        geoObject: { name: "Санкт-Петербург", description: "", Point: { pos: "30.3 59.9" } },
+                    },
+                })}
+            >
+                submit-where
+            </button>
+        ),
+    };
+});
+
+const renderWidget = (offerId = "42") => renderWithProviders(
+    <MemoryRouter>
+        <OfferWhere offerId={offerId} />
+    </MemoryRouter>,
+);
+
+describe("OfferWhere", () => {
+    it("сохраняет адрес вакансии и показывает тост об успехе", async () => {
+        let patchedBody: unknown;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, where: null }))),
+            rest.patch("*/vacancies/42", async (req, res, ctx) => {
+                patchedBody = await req.json();
+                return res(ctx.status(200), ctx.json({ id: 42 }));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-where");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText("Адрес успешно изменён")).toBeInTheDocument();
+        expect(patchedBody).toMatchObject({
+            where: { address: "Санкт-Петербург", longitude: 30.3, latitude: 59.9 },
+        });
+    });
+
+    it("показывает текст ошибки, если сохранение адреса упало", async () => {
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, where: null }))),
+            rest.patch("*/vacancies/42", (req, res, ctx) => res(
+                ctx.status(400),
+                ctx.json({ detail: "where.address: обязательное поле" }),
+            )),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-where");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText(/where\.address: обязательное поле/i)).toBeInTheDocument();
+    });
+});

--- a/src/widgets/Offer/ui/OfferWhoNeeds/OfferWhoNeeds.behavior.test.tsx
+++ b/src/widgets/Offer/ui/OfferWhoNeeds/OfferWhoNeeds.behavior.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OfferWhoNeeds } from "./OfferWhoNeeds";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/features/OfferWhoNeedsForm", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/features/OfferWhoNeedsForm")>();
+    return {
+        ...actual,
+        WhoNeedsForm: ({ isLoadingGetData, isLoadingUpdateData, onComplete }: any) => (
+            <button
+                type="button"
+                disabled={isLoadingGetData || isLoadingUpdateData}
+                onClick={() => onComplete({
+                    age: { minAge: 18, maxAge: 65 },
+                    gender: ["male", "female"],
+                    languages: ["ru"],
+                    receptionPlace: "airport",
+                    volunteerPlaces: 5,
+                    additionalInfo: "",
+                    needAllLanguages: false,
+                })}
+            >
+                submit-who-needs
+            </button>
+        ),
+    };
+});
+
+const renderWidget = (offerId = "42") => renderWithProviders(
+    <MemoryRouter>
+        <OfferWhoNeeds offerId={offerId} />
+    </MemoryRouter>,
+);
+
+describe("OfferWhoNeeds", () => {
+    it("сохраняет требования к волонтёрам и показывает тост об успехе", async () => {
+        let patchedBody: unknown;
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, howNeed: null }))),
+            rest.patch("*/vacancies/42", async (req, res, ctx) => {
+                patchedBody = await req.json();
+                return res(ctx.status(200), ctx.json({ id: 42 }));
+            }),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-who-needs");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText("Данные успешно сохранены")).toBeInTheDocument();
+        expect(patchedBody).toMatchObject({
+            howNeeds: { ageMin: 18, ageMax: 65, volunteerPlaceCount: 5 },
+        });
+    });
+
+    it("показывает текст ошибки бэка при неудачном сохранении", async () => {
+        server.use(
+            rest.get("*/vacancy/42", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: 42, howNeed: null }))),
+            rest.patch("*/vacancies/42", (req, res, ctx) => res(
+                ctx.status(400),
+                ctx.json({ detail: "howNeeds.ageMin: должно быть меньше ageMax" }),
+            )),
+        );
+
+        renderWidget();
+
+        const button = await screen.findByText("submit-who-needs");
+        await waitFor(() => expect(button).not.toBeDisabled());
+        await userEvent.click(button);
+
+        expect(await screen.findByText(/ageMin: должно быть меньше/i)).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Что

На фронте не было ни одного теста на создание/редактирование вакансии,
сбора (Fundraise) и организации — только бэкенд был покрыт (PR #266/#267
из этой же сессии). Добавлено 36 behavior-тестов на React Testing Library
+ MSW, по образцу уже существующего `PaymentPage.behavior.test.tsx`.

**FundraiseStepPage** (10 тестов) — все 5 шагов сбора: where/when/amount/
description/auto-messages, включая обязательность слов благодарности
перед публикацией и разницу между "сохранить черновик" и "опубликовать".

**widgets/Offer** (18 тестов) — все 7 шагов создания/редактирования
вакансии: Where/When/WhoNeeds/WhatToDo/Conditions/Description/
FinishingTouches. Отдельно проверено ветвление модалки подтверждения
публикации в FinishingTouches (черновик → публикация требует confirm,
уже опубликованная вакансия — нет).

**HostDescriptionForm** (4 теста) — создание организации vs обновление
существующей (ветвление по `host` prop), тост об ошибке.

**NotesHostForm** (4 теста) — приём/отклонение заявок волонтёров хостом.
Изначально планировал `TeamForm` (управление командой), но обнаружил, что
вся его функциональность (`TeamInput`, список участников, удаление)
сейчас полностью закомментирована в проде — рендерится только заглушка
"Функция станет доступна позже". Тестировать там нечего, переключился на
реально активный функционал заявок.

Каждый шаг вакансии/сбора делегирует в тяжёлую переиспользуемую форму
(карта, загрузка галереи, канбан с drag&drop) — их стабил простыми
кнопками, тестирую именно логику виджета (загрузка данных, сохранение,
тосты, обработка ошибок), а не сами формы.

revert-and-confirm-fails прогнан на самом сложном кейсе (ветвление
модалки публикации в FinishingTouches) — тест корректно падает при
временном отключении проверки `currentStatus === "draft"`.

## Побочные находки (не фиксил, вне скоупа этого PR)
- `Input`/`Textarea` без `id` на шаге auto-messages Fundraise — `<label>`
  не связан с полем через `htmlFor`.
- Несколько тостов (`OfferDescription` — обновление галереи,
  `HostDescriptionForm`) используют `t()` без `defaultValue` — если
  бандл перевода не подтянулся, пользователь увидит сырой ключ
  (`hostDescription.Сохранить`) вместо текста.

## Test plan
- [x] `vitest run` — 159/160 (1 упавший тест не связан: sticky-хедер на
      HostPersonalPage, ломался и до этого PR)
- [x] `tsc --noEmit` — чисто
- [x] `eslint` на все новые файлы — чисто
- [x] revert-and-confirm-fails на ветвлении модалки публикации

🤖 Generated with [Claude Code](https://claude.com/claude-code)