### PR TITLE
fix(i18n): добить недостающие переводы en/es

### DIFF
--- a/public/locales/en/donation.json
+++ b/public/locales/en/donation.json
@@ -34,7 +34,12 @@
         "Описание не было заполнено": "Description was not filled in",
         "Подробнее": "More details",
         "Поделиться сбором": "Share collection",
-        "Фотографии не были добавлены": "Photos were not added"
+        "Фотографии не были добавлены": "Photos were not added",
+        "Участники сбора": "Fundraiser participants",
+        "Пока нет пожертвований": "No donations yet",
+        "Аноним": "Anonymous",
+        "Всего": "Total",
+        "Собрано": "Raised"
     },
     "donationRecommendation": {
         "Поддержать другие проекты": "Support other projects",

--- a/public/locales/en/host.json
+++ b/public/locales/en/host.json
@@ -20,7 +20,8 @@
         "Напишите ваш отзыв": "Write your review",
         "На данный момент заявки отсутствуют": "There are no requests at the moment",
         "Ваш отзыв был отправлен": "Your review has been submitted",
-        "Поставьте оценку, чтобы оставить отзыв": "Rate the project to leave a review"
+        "Поставьте оценку, чтобы оставить отзыв": "Rate the project to leave a review",
+        "На данный момент заявки отсутсвуют": "There are no requests at the moment"
     },
     "hostOffers": {
         "Мои вакансии": "My Offers",
@@ -45,7 +46,9 @@
         "Оставить отзыв": "Leave a review",
         "Напишите ваш отзыв": "Write your review",
         "На данный момент заявки отсутствуют": "There are no requests at the moment",
-        "Ваш отзыв был отправлен": "Your review has been submitted"
+        "Ваш отзыв был отправлен": "Your review has been submitted",
+        "Основная информация": "Main information",
+        "На данный момент заявки отсутсвуют": "There are no requests at the moment"
     },
     "hostFundraises": {
         "Мои сборы": "My Fundraises",
@@ -131,7 +134,8 @@
         "Расскажите о вас, вашей команде и почему волонтёры должны выбрать вас для участия": "Tell us about you, your team, and why volunteers should choose you to participate",
         "Это поле является обязательным": "This field is required",
         "Не более 200 знаков": "No more than 200 characters",
-        "Не более 1000 знаков": "No more than 1000 characters"
+        "Не более 1000 знаков": "No more than 1000 characters",
+        "Сохранить": "Save"
     },
     "hostGallery": {
         "Фотогалерея организации": "Organization photo gallery",

--- a/public/locales/en/membership.json
+++ b/public/locales/en/membership.json
@@ -15,7 +15,8 @@
         "desc1": "GoodSurfing is a membership organization powered by the people who support it.",
         "desc2": "Membership is a way not just to use the project, but to help it live and grow.",
         "cta-main": "Get membership",
-        "cta-secondary": "Support without membership"
+        "cta-secondary": "Support without membership",
+        "title": "Become part of the GoodSurfing community, travel with meaning, and support the project that makes it possible."
     },
     "how-it-works": {
         "Как это работает": "How It Works",
@@ -65,7 +66,17 @@
         "Получение статуса амбассадора (при выполнении условий)": "Obtaining ambassador status (subject to conditions)",
         "Участие в офлайн-мероприятиях «Гудсёрфинг»": "Participation in offline events of GoodSurfing",
         "Повышенное доверие организатора волонтёрского проекта при отборе участников (специальная метка в профиле)": "Increased trust of the organizer of the volunteer project in the selection of participants (special label in the profile)",
-        "Получить членство": "Get membership"
+        "Получить членство": "Get membership",
+        "section-title": "If you're a traveler who wants to change the world",
+        "free-feature-2": "Participate in GoodSurfing's online events",
+        "free-feature-3": "Browse materials in the GoodSurfing Academy",
+        "paid-feature-1": "Unlimited access to volunteer projects and unlimited applications",
+        "paid-feature-2": "Priority when hosts choose project participants",
+        "paid-feature-3": "Access to closed educational materials and events",
+        "paid-feature-4": "Media support for volunteers",
+        "paid-feature-5": "Increased trust from hosts (special badge on your profile)",
+        "paid-feature-6": "Ability to publish in the Community",
+        "price-unit": "RUB/year"
     },
     "for-host": {
         "Для организатора": "For Host",
@@ -78,17 +89,26 @@
         "Доступ к Академии «Гудсёрфинг»": "Access to the GoodSurfing Academy",
         "Доступ к блогу «Гудсёрфинг»": "Access to the GoodSurfing blog",
         "Зарегистрироваться": "Register",
-        "Количество бесплатных объявлений на платформе «Гудсёрфинг»": "Number of free ads on the GoodSurfing platform",
         "не ограничено": "unlimited",
         "Доступ к уникальным чатам платформы «Гудсёрфинг»": "Access to unique chats of the GoodSurfing platform",
-        "Доступ к Академии «Гудсёрфинг»": "Access to the GoodSurfing Academy",
         "Получение статуса амбассадора (при выполнении условий)": "Obtaining ambassador status (subject to conditions)",
-        "Участие в онлайн-мероприятиях «Гудсёрфинг»": "Participation in online events of GoodSurfing",
         "Участие в офлайн-мероприятиях «Гудсёрфинг»": "Participation in offline events of GoodSurfing",
         "Повышенное доверие волонтёров при выборе проекта для участия (специальная метка в профиле)": "Increased trust of volunteers when choosing a project to participate in (special label in the profile)",
-        "Доступ к блогу «Гудсёрфинг»": "Access to the GoodSurfing blog",
         "Скидка для размещения рекламы и объявлений по платным тарифам на платформе «Гудсёрфинг»": "Discount for placing ads and announcements on paid tariffs on the GoodSurfing platform",
-        "Получить членство": "Get membership"
+        "Получить членство": "Get membership",
+        "section-title": "If you're a host who creates opportunities",
+        "free-feature-2": "Participate in GoodSurfing's online events",
+        "free-feature-3": "Browse materials in the GoodSurfing Academy",
+        "paid-feature-1": "Publish an unlimited number of volunteer listings",
+        "paid-feature-2": "Direct access to active, verified volunteers",
+        "paid-feature-3": "Media support for your projects",
+        "paid-feature-4": "Increased trust and GoodSurfing Partner status",
+        "paid-feature-5": "Participation in closed events and access to training programs",
+        "paid-feature-6": "Letters of recommendation from GoodSurfing for your projects",
+        "paid-feature-7": "Personal support",
+        "paid-feature-8": "Promotion consultations",
+        "paid-feature-9": "Ability to launch fundraisers",
+        "price-unit": "RUB/year"
     },
     "what-is-goodsurfing": {
         "Что делает Гудсёрфинг и как он помогает развиваться сообществу": "What GoodSurfing does and how it helps the community develop",
@@ -130,5 +150,33 @@
         "keywords": "GoodSurfing, membership, volunteering, travel with meaning, community, support project",
         "ogTitle": "GoodSurfing membership",
         "ogDescription": "Join the GoodSurfing community and support the development of meaningful travel."
+    },
+    "why-membership": {
+        "title": "Why membership matters",
+        "p1": "GoodSurfing was born from the idea that travel can be not only exciting but also useful. Inspired by the idea of mutual aid, we created a platform that makes outbound volunteering accessible, clear, and safe. Today we're an international community bringing together thousands of people ready to help others and make themselves and the world around them better.",
+        "p2": "For GoodSurfing to remain a living project, it needs support — and that support comes from the community members themselves.",
+        "p3": "Your membership is a contribution toward making sure meaningful travel and volunteer projects continue to exist."
+    },
+    "donation": {
+        "title": "Support GoodSurfing",
+        "subtitle": "A one-time contribution of any size helps the project live and grow.",
+        "cta": "Support the project",
+        "funds-title": "Where the funds go",
+        "funds-intro": "We are a non-profit organization, and our main goal is not to make a profit but to develop outbound volunteering. Every ruble of membership fees goes toward:",
+        "funds-1": "Supporting and developing the technical side of the service: the website and technical infrastructure",
+        "funds-2": "Creating useful content and educational programs",
+        "funds-3": "Running events and supporting the community",
+        "funds-4": "Launching new useful initiatives for volunteers and hosts",
+        "funds-5": "The organization's operating costs",
+        "why-p1": "Many people want useful social projects to exist. But such projects don't run on their own — behind them is always a team's work, digital infrastructure, and constant development.",
+        "why-p2": "Your support makes GoodSurfing sustainable, not just a one-time enthusiast project.",
+        "reports-link": "Public reports →",
+        "help-title": "Other ways you can help",
+        "help-1-title": "Spread the word",
+        "help-1-text": "Share information about our project on your social media — it helps us reach more people.",
+        "help-2-title": "Corporate partnership",
+        "help-2-text": "If your company cares about social responsibility, consider becoming our partner.",
+        "help-3-title": "Become a volunteer",
+        "help-3-text": "We're always glad to welcome people ready to support us with their actions. Joining the team is simple — just message us on social media."
     }
 }

--- a/public/locales/es/conditions.json
+++ b/public/locales/es/conditions.json
@@ -1,0 +1,15 @@
+{
+    "Чем вы готовы обеспечить волонтёра": "¿Qué está dispuesto a ofrecer al voluntario?",
+    "Волонтёр помогает вам и будет делать это лучше, если ему будет комфортно. Создавая лучшие условия вы привлекаете лучших волонтёров.": "El voluntario le ayuda y lo hará mejor si se siente cómodo. Al crear mejores condiciones, atrae a los mejores voluntarios.",
+    "Жилье": "Alojamiento",
+    "Да": "Sí",
+    "Нет": "No",
+    "Питание": "Alimentación",
+    "Оплачиваемый проезд": "Transporte pagado",
+    "Удобства": "Comodidades",
+    "Дополнительные возможности": "Funciones adicionales",
+    "Оплата": "Pago",
+    "Взносы волонтера": "Contribuciones del voluntario",
+    "Вознаграждение труда": "Remuneración del trabajo",
+    "Дополнительные условия": "Condiciones adicionales"
+}

--- a/public/locales/es/donation.json
+++ b/public/locales/es/donation.json
@@ -34,7 +34,12 @@
         "Описание не было заполнено": "La descripción no se completó",
         "Подробнее": "Más detalles",
         "Поделиться сбором": "Compartir colección",
-        "Фотографии не были добавлены": ""
+        "Фотографии не были добавлены": "No se agregaron fotos",
+        "Участники сбора": "Participantes de la colecta",
+        "Пока нет пожертвований": "Aún no hay donaciones",
+        "Аноним": "Anónimo",
+        "Всего": "Total",
+        "Собрано": "Recaudado"
     },
     "donationRecommendation": {
         "Поддержать другие проекты": "Apoyar otros proyectos",

--- a/public/locales/es/host.json
+++ b/public/locales/es/host.json
@@ -20,7 +20,8 @@
         "Напишите ваш отзыв": "Escriba su reseña",
         "На данный момент заявки отсутствуют": "No hay solicitudes en este momento",
         "Ваш отзыв был отправлен": "Su reseña ha sido enviada",
-        "Поставьте оценку, чтобы оставить отзыв": "Califica el proyecto para dejar una reseña"
+        "Поставьте оценку, чтобы оставить отзыв": "Califica el proyecto para dejar una reseña",
+        "На данный момент заявки отсутсвуют": "No hay solicitudes en este momento"
     },
     "hostOffers": {
         "Мои вакансии": "Mis ofertas de trabajo",
@@ -45,7 +46,9 @@
         "Оставить отзыв": "Dejar una reseña",
         "Напишите ваш отзыв": "Escriba su reseña",
         "На данный момент заявки отсутствуют": "No hay solicitudes en este momento",
-        "Ваш отзыв был отправлен": "Su reseña ha sido enviada"
+        "Ваш отзыв был отправлен": "Su reseña ha sido enviada",
+        "Основная информация": "Información principal",
+        "На данный момент заявки отсутсвуют": "No hay solicitudes en este momento"
     },
     "hostFundraises": {
         "Мои сборы": "Mis recaudaciones",
@@ -154,7 +157,8 @@
         "Расскажите о вас, вашей команде и почему волонтёры должны выбрать вас для участия": "Cuéntanos sobre ti, tu equipo y por qué los voluntarios deberían elegirte para participar",
         "Не более 200 знаков": "No más de 200 caracteres",
         "Не более 1000 знаков": "No más de 1000 caracteres",
-        "Это поле является обязательным": "Este campo es obligatorio"
+        "Это поле является обязательным": "Este campo es obligatorio",
+        "Сохранить": "Guardar"
     },
     "hostReviews": {
         "Отзывы": "Reseñas",

--- a/public/locales/es/membership.json
+++ b/public/locales/es/membership.json
@@ -15,7 +15,8 @@
         "desc1": "GoodSurfing es una organización de membresía que funciona gracias a las personas que la apoyan.",
         "desc2": "La membresía no es solo una forma de usar el proyecto, sino de ayudarlo a vivir y crecer.",
         "cta-main": "Obtener membresía",
-        "cta-secondary": "Apoyar sin membresía"
+        "cta-secondary": "Apoyar sin membresía",
+        "title": "Forma parte de la comunidad GoodSurfing, viaja con sentido y apoya el proyecto que lo hace posible."
     },
     "how-it-works": {
         "Как это работает": "Cómo funciona",
@@ -27,7 +28,7 @@
         "5. При необходимости пользуетесь чатом поддержки для планирования своего путешествия": "5. Si es necesario, utiliza el chat de soporte para planificar tu viaje",
         "6. Делаете доброе дело и получаете незабываемые впечатления": "6. Haz una buena acción y obtén experiencias inolvidables"
     },
-     "international-club": {
+    "international-club": {
         "title": "Club Internacional GoodSurfing",
         "subtitle": "Para quienes quieren ir más allá de un solo país.",
         "description": "La membresía internacional está creada para quienes desean conectar con organizaciones de voluntariado de todo el mundo, participar en proyectos internacionales y apoyar el desarrollo de la comunidad global de GoodSurfing.",
@@ -65,7 +66,17 @@
         "Получение статуса амбассадора (при выполнении условий)": "Obtención del estatus de embajador (cumpliendo con condiciones)",
         "Участие в офлайн-мероприятиях «Гудсёрфинг»": "Participación en eventos fuera de línea de GoodSurfing",
         "Повышенное доверие организатора волонтёрского проекта при отборе участников (специальная метка в профиле)": "Mayor confianza del organizador del proyecto de voluntariado al seleccionar participantes (etiqueta especial en el perfil)",
-        "Получить членство": "Obtener membresía"
+        "Получить членство": "Obtener membresía",
+        "section-title": "Si eres un viajero que quiere cambiar el mundo",
+        "free-feature-2": "Participar en los eventos en línea de GoodSurfing",
+        "free-feature-3": "Explorar los materiales de la Academia GoodSurfing",
+        "paid-feature-1": "Acceso ilimitado a proyectos de voluntariado y número ilimitado de postulaciones",
+        "paid-feature-2": "Prioridad al ser elegido como participante del proyecto",
+        "paid-feature-3": "Acceso a materiales educativos y eventos exclusivos",
+        "paid-feature-4": "Apoyo mediático para voluntarios",
+        "paid-feature-5": "Mayor confianza por parte del anfitrión (etiqueta especial en el perfil)",
+        "paid-feature-6": "Posibilidad de publicar en la Comunidad",
+        "price-unit": "RUB/año"
     },
     "for-host": {
         "Для организатора": "Para el anfitrión",
@@ -78,17 +89,26 @@
         "Доступ к Академии «Гудсёрфинг»": "Acceso a la Academia GoodSurfing",
         "Доступ к блогу «Гудсёрфинг»": "Acceso al blog de GoodSurfing",
         "Зарегистрироваться": "Registrarse",
-        "Количество бесплатных объявлений на платформе «Гудсёрфинг»": "Número de anuncios gratuitos en la plataforma GoodSurfing",
         "не ограничено": "sin restricciones",
         "Доступ к уникальным чатам платформы «Гудсёрфинг»": "Acceso a chats exclusivos de la plataforma GoodSurfing",
-        "Доступ к Академии «Гудсёрфинг»": "Acceso a la Academia GoodSurfing",
         "Получение статуса амбассадора (при выполнении условий)": "Obtención del estatus de embajador (cumpliendo con condiciones)",
-        "Участие в онлайн-мероприятиях «Гудсёрфинг»": "Participación en eventos en línea de GoodSurfing",
         "Участие в офлайн-мероприятиях «Гудсёрфинг»": "Participación en eventos fuera de línea de GoodSurfing",
         "Повышенное доверие волонтёров при выборе проекта для участия (специальная метка в профиле)": "Mayor confianza de los voluntarios al elegir un proyecto para participar (etiqueta especial en el perfil)",
-        "Доступ к блогу «Гудсёрфинг»": "Acceso al blog de GoodSurfing",
         "Скидка для размещения рекламы и объявлений по платным тарифам на платформе «Гудсёрфинг»": "Descuento para colocar publicidad y anuncios en tarifas pagadas en la plataforma GoodSurfing",
-        "Получить членство": "Obtener membresía"
+        "Получить членство": "Obtener membresía",
+        "section-title": "Si eres un anfitrión que crea oportunidades",
+        "free-feature-2": "Participar en los eventos en línea de GoodSurfing",
+        "free-feature-3": "Explorar los materiales de la Academia GoodSurfing",
+        "paid-feature-1": "Posibilidad de publicar un número ilimitado de vacantes de voluntariado",
+        "paid-feature-2": "Acceso directo a voluntarios activos y verificados",
+        "paid-feature-3": "Apoyo mediático para tus proyectos",
+        "paid-feature-4": "Mayor confianza y estatus de Socio de GoodSurfing",
+        "paid-feature-5": "Participación en eventos exclusivos y acceso a programas de formación",
+        "paid-feature-6": "Cartas de recomendación de GoodSurfing para tus proyectos",
+        "paid-feature-7": "Soporte personalizado",
+        "paid-feature-8": "Asesoramiento en promoción",
+        "paid-feature-9": "Posibilidad de abrir colectas de donaciones",
+        "price-unit": "RUB/año"
     },
     "what-is-goodsurfing": {
         "Что делает Гудсёрфинг и как он помогает развиваться сообществу": "Qué hace GoodSurfing y cómo ayuda al desarrollo de la comunidad",
@@ -130,5 +150,33 @@
         "keywords": "GoodSurfing, membresía, voluntariado, viajes con sentido, comunidad, apoyar proyecto",
         "ogTitle": "Membresía GoodSurfing",
         "ogDescription": "Únete a la comunidad GoodSurfing y apoya el desarrollo de viajes con sentido."
+    },
+    "why-membership": {
+        "title": "Por qué es importante la membresía",
+        "p1": "GoodSurfing nació de la idea de que viajar puede ser no solo emocionante, sino también útil. Inspirados por la idea de la ayuda mutua, creamos una plataforma que hace que el voluntariado itinerante sea accesible, claro y seguro. Hoy somos una comunidad internacional que reúne a miles de personas dispuestas a ayudar a otros y hacer de sí mismas y del mundo que las rodea un lugar mejor.",
+        "p2": "Para que GoodSurfing siga siendo un proyecto vivo, necesita un apoyo: ese apoyo son los propios miembros de la comunidad.",
+        "p3": "Tu membresía es una contribución para que los viajes solidarios y los proyectos de voluntariado sigan existiendo."
+    },
+    "donation": {
+        "title": "Apoya a GoodSurfing",
+        "subtitle": "Una contribución única de cualquier tamaño ayuda al proyecto a vivir y crecer.",
+        "cta": "Apoyar el proyecto",
+        "funds-title": "En qué se invierten los fondos",
+        "funds-intro": "Somos una organización sin fines de lucro, y nuestro objetivo principal no es obtener ganancias, sino desarrollar el voluntariado itinerante. Cada rublo de las cuotas de membresía se destina a:",
+        "funds-1": "El soporte y desarrollo de la parte tecnológica del servicio: el funcionamiento del sitio web y la infraestructura técnica",
+        "funds-2": "La creación de contenido útil y programas educativos",
+        "funds-3": "La organización de eventos y el apoyo a la comunidad",
+        "funds-4": "El lanzamiento de nuevas iniciativas útiles para voluntarios y anfitriones",
+        "funds-5": "El trabajo operativo de la organización",
+        "why-p1": "Muchas personas quieren que existan proyectos sociales útiles. Pero esos proyectos no funcionan por sí solos: detrás de ellos siempre hay el trabajo de un equipo, infraestructura digital y desarrollo constante.",
+        "why-p2": "Tu ayuda hace que GoodSurfing sea sostenible, y no solo un proyecto entusiasta puntual.",
+        "reports-link": "Informes públicos →",
+        "help-title": "Otras formas de ayudar",
+        "help-1-title": "Difundir información",
+        "help-1-text": "Comparte información sobre nuestro proyecto en tus redes sociales; esto nos ayuda a llegar a más personas.",
+        "help-2-title": "Alianza corporativa",
+        "help-2-text": "Si tu empresa está interesada en la responsabilidad social, considera la posibilidad de convertirte en nuestro socio.",
+        "help-3-title": "Conviértete en voluntario",
+        "help-3-text": "Siempre nos alegra recibir a personas dispuestas a apoyarnos con sus acciones. Unirte al equipo es muy sencillo: escríbenos sobre tu interés en nuestras redes sociales."
     }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -123,7 +123,8 @@
                 "exit": "Salida",
                 "membership": "Membresía",
                 "expeditions": "Expediciones",
-                "international-volunteering": "Voluntariado Internacional"
+                "international-volunteering": "Voluntariado Internacional",
+                "messages": "Mensajes"
             },
             "title": "Encontrar el viaje soñado",
             "offers-btn": "Todas las ofertas",

--- a/src/shared/config/i18n/localesCompleteness.test.ts
+++ b/src/shared/config/i18n/localesCompleteness.test.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import path from "path";
+import { describe, it, expect } from "vitest";
+
+// Регресс-тест на row 107: "При смене языка сайт переводится очень
+// выборочно" — причиной оказались целые секции (например membership.json),
+// у которых в en/es отсутствовали десятки ключей, присутствующих в ru.
+// i18next в этом случае молча возвращает русский текст как фолбэк
+// (fallbackLng: "ru"), поэтому визуально это выглядит как "местами не
+// перевелось", а не как явная ошибка — без этого теста регресс невидим.
+
+const LOCALES_DIR = path.resolve(__dirname, "../../../../public/locales");
+const SOURCE_LOCALE = "ru";
+const TARGET_LOCALES = ["en", "es"];
+
+type LocaleTree = { [key: string]: string | LocaleTree };
+
+function flatten(tree: LocaleTree, prefix = ""): Record<string, string> {
+    return Object.entries(tree).reduce<Record<string, string>>((acc, [key, value]) => {
+        const fullKey = prefix ? `${prefix}.${key}` : key;
+        if (typeof value === "string") {
+            acc[fullKey] = value;
+        } else {
+            Object.assign(acc, flatten(value, fullKey));
+        }
+        return acc;
+    }, {});
+}
+
+const sourceNamespaces = fs.readdirSync(path.join(LOCALES_DIR, SOURCE_LOCALE))
+    .filter((f) => f.endsWith(".json"));
+
+describe("i18n locales completeness (ru → en/es)", () => {
+    TARGET_LOCALES.forEach((locale) => {
+        sourceNamespaces.forEach((namespace) => {
+            it(`${locale}/${namespace} содержит все ключи и непустые значения из ru/${namespace}`, () => {
+                const sourcePath = path.join(LOCALES_DIR, SOURCE_LOCALE, namespace);
+                const targetPath = path.join(LOCALES_DIR, locale, namespace);
+
+                const sourceFlat = flatten(JSON.parse(fs.readFileSync(sourcePath, "utf-8")));
+
+                expect(fs.existsSync(targetPath), `файл ${locale}/${namespace} отсутствует целиком`).toBe(true);
+
+                const targetFlat = flatten(JSON.parse(fs.readFileSync(targetPath, "utf-8")));
+
+                const missing = Object.keys(sourceFlat).filter(
+                    (key) => !(key in targetFlat) || targetFlat[key] === "",
+                );
+
+                expect(missing, `пропущенные или пустые ключи в ${locale}/${namespace}`).toEqual([]);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Что

Row 107 из таблицы: «При смене языка сайт переводится очень выборочно.
Большие блоки текста, кнопки и тд остаются без перевода». Причина —
несколько namespace-файлов в `en`/`es` отставали от `ru` на десятки
ключей. i18next тихо фолбэчится на русский (`fallbackLng: "ru"`), поэтому
баг незаметен в коде — просто часть текста на странице остаётся
русской при переключении языка.

Прогнал полный аудит по всем 22 namespace × 2 языка (`en`, `es`) —
сравнил множества ключей `ru` vs `en`/`es` плюс отдельно проверил пустые
значения (тоже эффективно "не переведено"). Нашёл:

- **membership.json** — 48 ключей отсутствовали в EN и ES: весь блок
  "донат"/"почему членство важно" + часть `for-host`/`for-volunteer`.
  Самый заметный разрыв — страница `/membership` реально показывала
  смешанный русский/английский текст.
- **conditions.json** — файл целиком отсутствовал в ES.
- **donation.json** — 5 ключей карточки сбора + одно пустое значение в ES.
- **host.json** — 4 ключа, включая опечаточный вариант "отсутсвуют"
  (реальный ключ в коде, отдельный от уже переведённого "отсутствуют" —
  опечатку в исходнике не трогал, вне скоупа).
- **translation.json** — 1 ключ в ES.

Каждый перевод сверен по терминологии с уже существующими соседними
ключами в тех же файлах (бренд "GoodSurfing", "membership"/"membresía" и
т.д.), не машинный перевод "в лоб".

Добавлен регресс-тест `localesCompleteness.test.ts` — сверяет полноту
всех 22 namespace на каждый язык (44 теста), чтобы такой регресс
больше не проходил незаметно.

## Test plan
- [x] `vitest run` — 203/204 (1 несвязанный pre-existing фейл,
      sticky-хедер на HostPersonalPage)
- [x] `tsc --noEmit` — чисто
- [x] `eslint` — чисто
- [x] `npm run build` — чисто
- [x] revert-and-confirm-fails на новом тесте — подтверждён

🤖 Generated with [Claude Code](https://claude.com/claude-code)