### PR TITLE
fix(ambassadors): medium-превью вместо оригинала фото

### DIFF
--- a/src/pages/GoodsurfingAmbassadorsPage/ui/Ambassador/Ambassador.behavior.test.tsx
+++ b/src/pages/GoodsurfingAmbassadorsPage/ui/Ambassador/Ambassador.behavior.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { Ambassador } from "./Ambassador";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+const AMBASSADOR = {
+    id: "a1",
+    userId: "u1",
+    firstName: "Иван",
+    lastName: "Иванов",
+    description: "Амбассадор",
+    city: "Москва",
+    country: "Россия",
+    image: {
+        id: "img1",
+        contentUrl: "https://storage.yandexcloud.net/gs-media-prod/media/original-4mb.jpg",
+        thumbnails: {
+            small: "https://storage.yandexcloud.net/gs-media-prod/media/original-4mb.small.jpg",
+            medium: "https://storage.yandexcloud.net/gs-media-prod/media/original-4mb.medium.jpg",
+            large: "https://storage.yandexcloud.net/gs-media-prod/media/original-4mb.large.jpg",
+        },
+    },
+};
+
+describe("Ambassador — превью вместо оригинала", () => {
+    it("грузит thumbnails.medium, а не многомегабайтный оригинал", async () => {
+        server.use(
+            rest.get("*/leader/list", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({ data: [AMBASSADOR], pagination: { total: 1 } }),
+            )),
+        );
+
+        renderWithProviders(
+            <MemoryRouter>
+                <Ambassador />
+            </MemoryRouter>,
+        );
+
+        const img = await screen.findByRole("img");
+        expect(img).toHaveAttribute("src", expect.stringContaining("original-4mb.medium.jpg"));
+        expect(img.getAttribute("src")).not.toContain("original-4mb.jpg\"");
+    });
+
+    it("без thumbnails откатывается на оригинал (легаси-фото без миниатюр)", async () => {
+        server.use(
+            rest.get("*/leader/list", (req, res, ctx) => res(
+                ctx.status(200),
+                ctx.json({
+                    data: [{
+                        ...AMBASSADOR,
+                        image: { id: "img2", contentUrl: "https://storage.yandexcloud.net/gs-media-prod/media/legacy.jpg" },
+                    }],
+                    pagination: { total: 1 },
+                }),
+            )),
+        );
+
+        renderWithProviders(
+            <MemoryRouter>
+                <Ambassador />
+            </MemoryRouter>,
+        );
+
+        const img = await screen.findByRole("img");
+        expect(img).toHaveAttribute("src", expect.stringContaining("legacy.jpg"));
+    });
+});

--- a/src/pages/GoodsurfingAmbassadorsPage/ui/Ambassador/Ambassador.tsx
+++ b/src/pages/GoodsurfingAmbassadorsPage/ui/Ambassador/Ambassador.tsx
@@ -25,7 +25,7 @@ export const Ambassador: FC<AmbassadorProps> = memo((props: AmbassadorProps) => 
             if (!data) return null;
             return data.data.map((item, index) => (
                 <TeamItem
-                    image={getMediaContent(item.image.contentUrl)}
+                    image={getMediaContent(item.image, "MEDIUM")}
                     name={getFullName(item.firstName, item.lastName)}
                     description={item.description}
                     address={getFullAddress(item.city, item.country)}


### PR DESCRIPTION
## Что

На `/ru/ambassadors` фото амбассадоров грузятся ощутимо долго. Проверил
живьём: 3 из 4 текущих фото — необработанные оригиналы **3.2–4.7 МБ**
каждое (naturalWidth до 2560px), хотя карточка показывает их в 180×180px.

Причина: `getMediaContent(item.image.contentUrl)` — передаётся голая
строка вместо объекта `image`, из-за чего функция молча скипает логику
миниатюр и возвращает оригинал как есть (см. `getMediaContent.ts`: ветка
`typeof value === "string"` просто конвертит URL в абсолютный, не трогая
`thumbnails`). Тот же класс бага, что чинили в PR #410
(OffersSlider/OffersRecomendationsWidget).

Фикс: `getMediaContent(item.image, "MEDIUM")` — теперь берёт
`thumbnails.medium`, с фолбэком на оригинал для легаси-фото без миниатюр.

## Отдельная находка (не в этом PR)
Тот же паттерн (`getMediaContent(x.contentUrl)` вместо `getMediaContent(x,
size)`) встречается ещё примерно в **50 местах** по фронтенду — часть из
них корректны по смыслу (og:image для шеринга, ссылки на скачивание
документов), но часть — реальные маленькие иконки/аватарки, которые
показывают оригиналы. Это системный технический долг, требует отдельного
прохода с проверкой каждого места (какие из них правда нужен оригинал,
какие — нет), не стал расширять этим текущий PR.

## Test plan
- [x] Новый `Ambassador.behavior.test.tsx` — с миниатюрами и легаси-фолбэк
      без миниатюр
- [x] `vitest run` — 207/208 (1 несвязанный pre-existing фейл)
- [x] `tsc --noEmit`, `eslint` — чисто
- [x] revert-and-confirm-fails — тест ловит регресс

🤖 Generated with [Claude Code](https://claude.com/claude-code)