### PR TITLE
fix(messenger): не дёргать /chats/create* на странице подачи заявки

### DIFF
--- a/src/entities/Chat/lib/useGetChatMessages.test.tsx
+++ b/src/entities/Chat/lib/useGetChatMessages.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+    describe, it, expect, beforeEach,
+} from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { rest } from "msw";
+import { server } from "@/mocks/server";
+import { setupStore } from "@/store/store";
+import { useGetChatMessages } from "./useGetChatMessages";
+
+/**
+ * Регресс-guard: страница «Вы подали заявку» (`/messenger/create/{offerId}`)
+ * раньше дёргала GET /chats/create/messages с буквальным ID "create" вместо
+ * настоящего chatId — бэкенд падал 500 (Doctrine не мог привести "create" к
+ * int-PK чата). Хук должен пропускать запрос, когда chatId не передан
+ * (Chat.tsx теперь передаёт undefined вместо "create" на этой странице).
+ */
+describe("useGetChatMessages — пропуск запроса для create-заглушки", () => {
+    let requestedUrls: string[] = [];
+
+    beforeEach(() => {
+        requestedUrls = [];
+        server.use(
+            rest.get("*/chats/:chatId/messages", (req, res, ctx) => {
+                requestedUrls.push(req.url.pathname);
+                return res(ctx.status(200), ctx.json([]));
+            }),
+        );
+    });
+
+    const renderWithStore = (chatId: string | undefined) => renderHook(
+        () => useGetChatMessages(chatId, null, "profile-1"),
+        {
+            wrapper: ({ children }) => (
+                <Provider store={setupStore()}>{children}</Provider>
+            ),
+        },
+    );
+
+    it("chatId не передан — запрос к /chats/*/messages не улетает", async () => {
+        renderWithStore(undefined);
+
+        await new Promise((resolve) => { setTimeout(resolve, 50); });
+        expect(requestedUrls).toHaveLength(0);
+    });
+
+    it("реальный chatId — запрос улетает как обычно", async () => {
+        renderWithStore("42");
+
+        await waitFor(() => {
+            expect(requestedUrls).toContain("/api/v1/chats/42/messages");
+        });
+    });
+});

--- a/src/widgets/Messenger/ui/Chat/Chat.behavior.test.tsx
+++ b/src/widgets/Messenger/ui/Chat/Chat.behavior.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import {
+    describe, it, expect, vi, beforeEach,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { Profile } from "@/entities/Profile";
+import { Chat } from "./Chat";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ mercureToken: null }),
+}));
+
+vi.mock("@/app/providers/MessengerProvider", () => ({
+    useMessenger: () => ({ onReadMessage: vi.fn() }),
+}));
+
+const MY_PROFILE = {
+    id: "u1", firstName: "Иван", lastName: "Иванов", image: null,
+} as unknown as Profile;
+
+const OFFER_RESPONSE = {
+    id: 7182,
+    status: "active",
+    averageRating: 0,
+    reviewsCount: 0,
+    acceptedApplicationsCount: 0,
+    where: { address: "Мурманская область" },
+    description: { title: "Тестовая вакансия", shortDescription: "Кратко", description: "Полное описание" },
+};
+
+/**
+ * Регресс-guard: страница «Вы подали заявку» (`isChatCreate`, id === "create")
+ * дёргала GET /chats/create и GET /chats/create/messages с буквальным
+ * "create" вместо настоящего chatId — второй запрос ронял бэкенд 500-кой
+ * (Doctrine не мог привести "create" к int-PK чата). Chat.tsx теперь
+ * передаёт в оба хука `undefined` вместо строкового id, пока заявка не
+ * подтверждена.
+ */
+describe("Chat — не дёргает /chats/create* пока заявка не подтверждена", () => {
+    let chatRequestPaths: string[] = [];
+
+    beforeEach(() => {
+        chatRequestPaths = [];
+        server.use(
+            rest.get("*/vacancy/:id", (req, res, ctx) => res(ctx.status(200), ctx.json(OFFER_RESPONSE))),
+            rest.get("*/chats/:chatId", (req, res, ctx) => {
+                chatRequestPaths.push(req.url.pathname);
+                return res(ctx.status(404));
+            }),
+            rest.get("*/chats/:chatId/messages", (req, res, ctx) => {
+                chatRequestPaths.push(req.url.pathname);
+                return res(ctx.status(200), ctx.json([]));
+            }),
+        );
+    });
+
+    it("не отправляет GET /chats/create и /chats/create/messages", async () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <Chat
+                    id="create"
+                    offerId="7182"
+                    onBackButton={() => {}}
+                    locale="ru"
+                    myProfileData={MY_PROFILE}
+                />
+            </MemoryRouter>,
+        );
+
+        await screen.findByText("Тестовая вакансия");
+
+        expect(chatRequestPaths).toHaveLength(0);
+    });
+});

--- a/src/widgets/Messenger/ui/Chat/Chat.tsx
+++ b/src/widgets/Messenger/ui/Chat/Chat.tsx
@@ -101,7 +101,7 @@ export const Chat: FC<ChatProps> = (props) => {
     const {
         messages, fetchMoreMessages, hasMore,
     } = useGetChatMessages(
-        id,
+        isChatCreate ? undefined : id,
         mercureToken,
         myProfileData?.id,
     );
@@ -109,7 +109,7 @@ export const Chat: FC<ChatProps> = (props) => {
     const [updateApplicationStatus] = useUpdateApplicationFormStatusByIdMutation();
     const [readMessage] = useReadMessageMutation();
     const [getApplicationData] = useLazyGetApplicationFormByIdQuery();
-    const { data: chatData } = useGetChatQuery(id ?? "");
+    const { data: chatData } = useGetChatQuery(id ?? "", { skip: isChatCreate || !id });
     const [getProfileData] = useLazyGetProfileInfoByIdQuery();
 
     useEffect(() => {


### PR DESCRIPTION
## Что и зачем

Разбирал жалобу пользователя на странице «Вы подали заявку» (`/messenger/create/{offerId}`, до подтверждения заявки на вакансию — chat ещё не создан). Воспроизвести именно видимую красную ошибку не удалось (см. предыдущую переписку), но нашёл и подтвердил реальный баг в консоли/сети.

`Chat.tsx` использует специальное значение `id === "create"` как маркер «мы ещё не в реальном чате», но при этом:
- `useGetChatQuery(id ?? "")` вызывался вообще без `skip` — всегда бил `GET /chats/create`.
- `useGetChatMessages(id, ...)` внутри пропускает запрос только по `skip: !chatId`, а строка `"create"` truthy — бил `GET /chats/create/messages`.

Асимметрия в ответах:
- `GET /chats/create` → честный **404**: авто-роут `Get` для `Chat` (int PK) требует `\d+`, `"create"` не матчится.
- `GET /chats/create/messages` → **500**: у `Message` кастомный `uriTemplate: '/chats/{chatId}/messages'` с `Link`-параметром — числового ограничения нет, роут матчится, API Platform лезет в `EntityManager->find(Chat::class, "create")`, Doctrine подставляет `"create"` как int-параметр в SQL к Postgres → `invalid input syntax for type integer` → необработанное исключение → 500. Проверено напрямую на стейдже.

Эта 500-ошибка нигде не подключена к UI (нет глобального обработчика ошибок RTK Query, `error` не деструктурируется ни в `Chat.tsx`, ни в `useGetChatMessages`) — падает тихо в консоль, не показывает пользователю тост. Но это грязный, реальный баг: лишние обречённые запросы и honest 500 в логах бэкенда на ровном месте, для каждого визита на страницу подачи заявки.

## Фикс
- `Chat.tsx`: `useGetChatMessages` теперь получает `isChatCreate ? undefined : id` (внутренний `skip: !chatId` хука отработает как надо).
- `Chat.tsx`: `useGetChatQuery(id ?? "", { skip: isChatCreate || !id })`.

Бэкенд не трогаю — фронтового фикса достаточно, чтобы полностью убрать триггер (в норме "create" как ID чата никогда не должен долетать до бэкенда).

## Тесты
- `useGetChatMessages.test.tsx` — хук не шлёт запрос, когда `chatId` не передан; шлёт как обычно с реальным ID.
- `Chat.behavior.test.tsx` — сам компонент в режиме `id="create"` не отправляет ни одного запроса на `/chats/create` или `/chats/create/messages`.
- revert-and-confirm-fails: временно вернул старое поведение — `Chat.behavior.test.tsx` поймал регрессию (2 запроса вместо 0), вернул фикс обратно.
- Полный набор: 210/211 (1 фейл — преэкзистентный, sticky-header тест, не связан с этим PR).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>