### PR TITLE
test(sticky-header): обновить регресс-тест под новый --header-offset

### DIFF
--- a/src/pages/HostPersonalPage/ui/HostPersonalPage/stickyHeaderOffset.test.ts
+++ b/src/pages/HostPersonalPage/ui/HostPersonalPage/stickyHeaderOffset.test.ts
@@ -8,17 +8,27 @@ import { join } from "path";
  * offer/host/volunteer-personal починили раньше (c2ce9312, 23.06), здесь
  * докатили ещё 2 пропущенные страницы — HostPersonalPage (top 91px → 6.5rem)
  * и DonationPersonalPage (content padding-top 36px → 92px).
+ *
+ * PR gs-frontend#408 (18.07): статичный top: 6.5rem не учитывал появление
+ * промо-баннера под шапкой (UNDER_HEADER_ALL_PAGES) — sticky-подменю снова
+ * наезжало. MainHeader теперь публикует свою реальную высоту в CSS-переменную
+ * --header-offset (ResizeObserver), .navMenu использует
+ * top: calc(var(--header-offset, 6.5rem) + 12px) — 6.5rem остаётся
+ * запасным хардкодом внутри var(), а не самостоятельным значением.
  */
 describe("Наложение шапки при скролле — sticky-офсеты", () => {
-    it("HostPersonalPage: .navMenu top = 6.5rem, а не старые 91px", () => {
+    it("HostPersonalPage: .navMenu top использует динамический --header-offset с фолбэком 6.5rem", () => {
         const scss = readFileSync(
             join(__dirname, "HostPersonalPage.module.scss"),
             "utf-8",
         );
 
         const navMenuBlock = scss.match(/\.navMenu\s*{[^}]*}/)?.[0] ?? "";
-        expect(navMenuBlock).toMatch(/top:\s*6\.5rem/);
+        expect(navMenuBlock).toMatch(/top:\s*calc\(var\(--header-offset,\s*6\.5rem\)/);
         expect(navMenuBlock).not.toMatch(/top:\s*91px/);
+        // Старый статичный top (без var/calc) должен остаться в прошлом —
+        // именно он не учитывал появление промо-баннера (PR #408).
+        expect(navMenuBlock).not.toMatch(/top:\s*6\.5rem\s*;/);
     });
 
     it("DonationPersonalPage: .content padding-top = 92px, а не старые 36px", () => {


### PR DESCRIPTION
## Что и зачем

Уточняю: наложения шапки на сайте нет — вёрстка работает правильно, был сломан только сам regression-тест.

`stickyHeaderOffset.test.ts` проверял, что `.navMenu { top: 6.5rem }` — это было правдой до PR #408 (18.07). Тот PR намеренно заменил статичный `top: 6.5rem` на `top: calc(var(--header-offset, 6.5rem) + 12px)`: `MainHeader` теперь публикует свою реальную высоту (капсула + промо-баннер `UNDER_HEADER_ALL_PAGES`) в CSS-переменную `--header-offset` через `ResizeObserver`, чтобы sticky-подменю не заезжало под шапку, когда появляется баннер. Тест не обновили под новый формат — с тех пор он ложно падал в каждом прогоне (`6.5rem` внутри `calc(var(...))` не матчился голым регекспом `/top:\s*6\.5rem/`).

## Изменения
- `stickyHeaderOffset.test.ts`: обновил регексп под текущий намеренный формат `top: calc(var(--header-offset, 6.5rem)...)`, оставил проверку что старый статичный `top: 6.5rem;` (без var/calc — именно он был багом, не учитывающим баннер) не возвращается.

## Проверка
- Тест зелёный.
- revert-and-confirm-fails: временно вернул старый статичный `top: 6.5rem` в вёрстке — тест поймал регрессию, вернул обратно.

Только тест, вёрстку не трогал.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>