### PR TITLE
fix(feedback): форма обратной связи была прижата к левому краю

### DIFF
--- a/src/pages/FeedbackPage/ui/FeedbackPage/FeedbackPage.module.scss
+++ b/src/pages/FeedbackPage/ui/FeedbackPage/FeedbackPage.module.scss
@@ -2,10 +2,5 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    padding-bottom: 100px;
-}
-
-.form {
-    margin-left: 20px;
-    margin-right: 20px;
+    padding: 0 20px 100px;
 }

--- a/src/pages/FeedbackPage/ui/FeedbackPage/FeedbackPage.tsx
+++ b/src/pages/FeedbackPage/ui/FeedbackPage/FeedbackPage.tsx
@@ -11,7 +11,7 @@ const FeedbackPage = () => (
     <MainPageLayout>
         <div className={styles.wrapper}>
             <Header />
-            <FeedbackForm className={styles.form} />
+            <FeedbackForm />
         </div>
     </MainPageLayout>
 );


### PR DESCRIPTION
## Что и зачем

Спасибо за замечание — "выглядит недоделанным" было правдой. Визуально проверил (сам этого не сделал в #416, только автотесты гонял) — форма на `/feedback` реально была прижата к левому краю с огромным пустым полем справа, а не по центру, как задумывалось.

## Причина

`FeedbackPage.tsx` передавал в `<FeedbackForm className={styles.form}>`, где `styles.form` = `margin-left/right: 20px`. Эти правила и `margin: 60px auto` из самого `FeedbackForm.module.scss` применялись к одному и тому же div с равной специфичностью — какое побеждает для margin-left/right, зависит от порядка правил в собранном CSS. На проверке (unit-тесты) выигрывал auto-центрирующий вариант, в реальной собранной странице — фиксированные 20px, что убивало центрирование.

## Фикс
- Убрал конфликтующий `className` — `FeedbackForm` теперь сам полностью отвечает за своё позиционирование.
- Safe-отступ от края экрана на узких вьюпортах перенёс с `margin` (спорит с `margin: auto` дочернего элемента) на `padding` родительской обёртки (не спорит).

## Проверка
- Визуально: локальный dev-сервер, десктоп (1200px) и мобильный (375px) вьюпорты — форма по центру, разумный отступ до футера, на мобильном не липнет к краям экрана.
- `npx tsc --noEmit`, `eslint`, `FeedbackForm.test.tsx` (3/3) — зелёные.
- Полный набор: 211/212 (тот самый ранее известный преэкзистентный sticky-header тест, уже почищен в отдельном #417, ещё не влит в эту ветку — не связан с этим PR).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>