### PR TITLE
fix(messenger): linkify проглатывал слово после HTML-сниппета в сообщении

### DIFF
--- a/src/widgets/Messenger/ui/Message/Message.tsx
+++ b/src/widgets/Messenger/ui/Message/Message.tsx
@@ -42,11 +42,22 @@ function escapeHtml(text: string): string {
         .replace(/'/g, "&#39;");
 }
 
-function linkify(text: string): string {
-    return escapeHtml(text).replace(
-        URL_REGEX,
-        (url) => `<a href="${url}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;word-break:break-all;">${url}</a>`,
-    );
+export function linkify(text: string): string {
+    // Регекс должен резать URL по границам ДО экранирования: escapeHtml
+    // превращает "'" и ">" в многосимвольные HTML-сущности (&#39;, &gt;),
+    // и если запускать URL_REGEX после escapeHtml, символьный класс
+    // [^\s<>"'] перестаёт видеть эти сущности как стоп-символы — URL
+    // "прожирает" всё до ближайшего пробела включительно (например,
+    // href='...' из вставленного HTML-сниппета проглатывал следующее
+    // слово текста в ссылку).
+    return text
+        .split(URL_REGEX)
+        .map((part, index) => {
+            const escaped = escapeHtml(part);
+            if (index % 2 === 0) return escaped;
+            return `<a href="${escaped}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;word-break:break-all;">${escaped}</a>`;
+        })
+        .join("");
 }
 
 function renderTextWithEmoji(text: string) {

--- a/src/widgets/Messenger/ui/Message/linkify.test.ts
+++ b/src/widgets/Messenger/ui/Message/linkify.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { linkify } from "./Message";
+
+/**
+ * Хост вставил в сообщение готовый HTML-сниппет (например, код кнопки
+ * "поделиться" из Яндекс.Форм) вместо простой ссылки:
+ * <a target='_blank' href='https://forms.yandex.ru/u/ID/'>Ссылка на опрос</a>
+ *
+ * escapeHtml() превращает "'" в "&#39;" и ">" в "&gt;" — если запускать
+ * URL_REGEX ПОСЛЕ экранирования (как было раньше), символьный класс
+ * [^\s<>"'] перестаёт видеть эти сущности как стоп-символы, и совпадение
+ * "прожирает" всё до ближайшего пробела — слово "Ссылка" утекало внутрь
+ * href/текста ссылки, а остальной HTML-мусор оставался на странице как
+ * видимый текст. linkify() теперь режет URL по границам ДО экранирования.
+ */
+describe("linkify — граница URL при вставленном HTML-сниппете", () => {
+    const RAW = "<a target='_blank' href='https://forms.yandex.ru/u/692e8da3d0468812bcc04afb/'>Ссылка на опрос</a>";
+
+    it("не проглатывает следующее слово после закрывающей кавычки в href", () => {
+        const html = linkify(RAW);
+
+        expect(html).toContain("href=\"https://forms.yandex.ru/u/692e8da3d0468812bcc04afb/\"");
+        // "Ссылка" не должно оказаться внутри текста ссылки — только сам URL.
+        const linkMatch = html.match(/<a href="[^"]*"[^>]*>([^<]*)<\/a>/);
+        expect(linkMatch?.[1]).toBe("https://forms.yandex.ru/u/692e8da3d0468812bcc04afb/");
+    });
+
+    it("исходный HTML-тег остаётся видимым экранированным текстом, а не исполняется как разметка", () => {
+        const html = linkify(RAW);
+
+        expect(html).toContain("&lt;a target=&#39;_blank&#39;");
+        expect(html).not.toContain("<a target=");
+    });
+
+    it("обычный URL без обрамляющего HTML линкуется как раньше", () => {
+        const html = linkify("Смотри https://example.com/path тут");
+
+        expect(html).toBe("Смотри <a href=\"https://example.com/path\" target=\"_blank\" rel=\"noopener noreferrer\" style=\"color:inherit;text-decoration:underline;word-break:break-all;\">https://example.com/path</a> тут");
+    });
+});


### PR DESCRIPTION
## Что и зачем

Разбирал сообщение "ссылка не парсится" на `/messenger/1705`. Хост вставил в сообщение готовый HTML вместо простой ссылки:
```
<a target='_blank' href='https://forms.yandex.ru/u/692e8da3d0468812bcc04afb/'>Ссылка на опрос</a>
```
На экране это выглядело как нечитаемая мешанина сырого текста, где только слово "Ссылка" почему-то было подчёркнуто и являлось частью ссылки.

## Причина

`linkify()` сначала экранировал весь текст (`escapeHtml`: `'` → `&#39;`, `>` → `&gt;`), а затем искал URL регекспом `[^\s<>"']+`. После экранирования эти символы стали многосимвольными HTML-сущностями, а не литеральными символами — регексп перестал видеть в них границу и "прожирал" текст до ближайшего пробела, затягивая внутрь ссылки следующее слово ("Ссылка").

## Фикс
Меняю порядок: сначала режу текст на сегменты по `URL_REGEX` (пока кавычки/скобки ещё литеральные символы, границы находятся правильно), потом каждый сегмент экранирую отдельно. Сам вставленный `<a>`-тег по-прежнему остаётся видимым escaped-текстом, а не исполняется как разметка — это намеренно (иначе это была бы хранимая XSS через чат), отдельно не трогаю.

## Отдельно, не в этом PR
На том же скриншоте виден ещё один визуальный баг — что-то жёлтое наезжает на аватар/лого в списке чатов. Мне нужен более полный/чёткий скриншот, чтобы разобраться — спросил у автора репорта отдельно.

## Тесты
- `linkify.test.ts` — новый: воспроизводит ровно этот кейс (URL не проглатывает следующее слово), плюс проверка что вставленный тег остаётся текстом, плюс sanity-проверка на обычный URL без HTML.
- revert-and-confirm-fails: временно вернул старую реализацию — новый тест поймал регрессию, вернул фикс обратно.
- Полный набор: 215/215.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>