### PR TITLE
fix(avatar): текст последнего сообщения в списке чатов наезжал на аватар

### DIFF
--- a/src/shared/ui/Avatar/Avatar.test.tsx
+++ b/src/shared/ui/Avatar/Avatar.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Avatar } from "./Avatar";
+import styles from "./Avatar.module.scss";
+
+/**
+ * Row: в списке чатов текст последнего сообщения наезжал на аватар вместо
+ * того, чтобы идти отдельной строкой справа. Причина — .wrapper в
+ * Avatar.module.scss имеет container-type: inline-size (нужен для
+ * font-size: 40cqw у буквы-заглушки), но сам не имел явной ширины/высоты.
+ * Containment без явного размера схлопывает инлайн-размер элемента в 0 —
+ * картинка внутри рисовалась на 56px, а сам flex-item в раскладке родителя
+ * занимал 0px, и соседний блок с текстом наезжал поверх неё.
+ * Фикс: класс размера (SMALL/MEDIUM/...) применяется не только к
+ * содержимому, но и к самой обёртке — тогда у неё есть явный width/height,
+ * и containment больше не схлопывает бокс.
+ */
+describe("Avatar — обёртка не схлопывается в 0 при container-type: inline-size", () => {
+    it("получает класс размера на себе, а не только на содержимом", () => {
+        const { container } = render(<Avatar icon="/test.jpg" size="MEDIUM" />);
+        const wrapper = container.firstElementChild;
+
+        expect(wrapper?.className).toContain(styles.wrapper);
+        expect(wrapper?.className).toContain(styles.MEDIUM);
+    });
+
+    it("работает и для аватара-заглушки без иконки (буква вместо фото)", () => {
+        const { container } = render(<Avatar text="Иван" size="SMALL" />);
+        const wrapper = container.firstElementChild;
+
+        expect(wrapper?.className).toContain(styles.wrapper);
+        expect(wrapper?.className).toContain(styles.SMALL);
+    });
+});

--- a/src/shared/ui/Avatar/Avatar.tsx
+++ b/src/shared/ui/Avatar/Avatar.tsx
@@ -31,7 +31,7 @@ export const Avatar = memo((props: AvatarProps) => {
     } = props;
 
     return (
-        <div className={cn(styles.wrapper, className)} onClick={onClick}>
+        <div className={cn(styles.wrapper, styles[size], className)} onClick={onClick}>
             {icon && <img src={icon} alt={alt} className={styles[size]} />}
             {!icon
                 && (text ? (


### PR DESCRIPTION
## Что и зачем

Второй репорт из того же скриншота (`/messenger/1705` на проде) — "лого наехало". Полный скриншот показал: это не лого, а превью последнего сообщения ("привет") рендерится поверх аватарки в списке чатов вместо отдельной строки справа.

## Причина

`Avatar.module.scss .wrapper` использует `container-type: inline-size` (нужен для `font-size: 40cqw` у буквы-заглушки, когда фото нет), но сам `.wrapper` не получал явную ширину/высоту — размерные классы (`SMALL`/`MEDIUM`/...) применялись только к содержимому (img/буква), не к самой обёртке.

CSS containment (`container-type: inline-size` включает `contain: inline-size`) без явного размера контейнера схлопывает инлайн-размер элемента в 0: картинка внутри рисуется на полные 56px, а сам flex-item в раскладке родителя (`UserCard`, `display:flex`) занимает 0px по ширине — соседний блок с именем/последним сообщением сдвигается на место, где "по документу" аватарки нет, и накладывается прямо на неё.

Воспроизвёл вживую на стейдже (зарегистрировал тестового волонтёра, откликнулся на вакансию организации с загруженным лого, отправил сообщение "привет") — баг 1-в-1 совпал со скриншотом. Через devtools подтвердил: явный `width`/`height` на обёртке чинит проблему.

## Фикс
Применяю `styles[size]` не только к содержимому, но и к самой обёртке `Avatar` — теперь у неё есть явный размер (30/56/70px в зависимости от `size`), и containment больше не схлопывает бокс.

## Тесты
- `Avatar.test.tsx` — новый: обёртка получает класс размера (для фото и для буквы-заглушки).
- revert-and-confirm-fails: временно убрал класс размера с обёртки — тест поймал регрессию, вернул фикс обратно.
- Визуально проверил на локальном dev-сервере (тот же живой стейджинговый бэкенд) — превью сообщения теперь в отдельной строке, аватарка чистая.
- Полный набор: 216/216.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>