### PR TITLE
fix(messenger): не просить выбрать даты, если у вакансии они фиксированы

### DIFF
--- a/src/features/Messenger/ui/OfferApplication/OfferApplication.behavior.test.tsx
+++ b/src/features/Messenger/ui/OfferApplication/OfferApplication.behavior.test.tsx
@@ -24,13 +24,17 @@ const OFFER_DATA = {
     categoryName: "",
 };
 
-const renderOfferApplication = (isClosed: boolean) => renderWithProviders(
+const renderOfferApplication = (
+    isClosed: boolean,
+    hasFixedDates: boolean = false,
+) => renderWithProviders(
     <MemoryRouter>
         <OfferApplication
             offerData={OFFER_DATA}
             isHost={false}
             username="Иван Иванов"
             isClosed={isClosed}
+            hasFixedDates={hasFixedDates}
             terms={{ start: undefined, end: undefined }}
             onChange={() => {}}
         />
@@ -56,5 +60,12 @@ describe("OfferApplication — заголовок соответствует р�
 
         expect(screen.getByText((_, el) => el?.textContent === "Иван Иванов подал заявку на вакансию")).toBeInTheDocument();
         expect(screen.queryByText("Укажите даты, чтобы отправить заявку")).not.toBeInTheDocument();
+    });
+
+    it("у вакансии уже есть фиксированные даты — заголовок вообще не показывается", () => {
+        renderOfferApplication(false, true);
+
+        expect(screen.queryByText("Укажите даты, чтобы отправить заявку")).not.toBeInTheDocument();
+        expect(screen.queryByText((_, el) => el?.textContent === "Иван Иванов подал заявку на вакансию")).not.toBeInTheDocument();
     });
 });

--- a/src/features/Messenger/ui/OfferApplication/OfferApplication.tsx
+++ b/src/features/Messenger/ui/OfferApplication/OfferApplication.tsx
@@ -20,6 +20,7 @@ interface OfferApplicationProps {
     isHost: boolean;
     username: string;
     isClosed?: boolean;
+    hasFixedDates?: boolean;
     onSubmit?: () => void;
     terms: DatesType;
     onChange: (terms: DatesType) => void;
@@ -33,7 +34,7 @@ interface DatesType {
 
 export const OfferApplication: FC<OfferApplicationProps> = (props) => {
     const {
-        isHost, username, isClosed, onSubmit, terms, onChange, offerData,
+        isHost, username, isClosed, hasFixedDates, onSubmit, terms, onChange, offerData,
         onApplicationSubmit,
     } = props;
     const {
@@ -65,6 +66,9 @@ export const OfferApplication: FC<OfferApplicationProps> = (props) => {
                     {t("подал заявку на вакансию")}
                 </span>
             );
+        }
+        if (hasFixedDates) {
+            return null;
         }
         return (
             <span className={styles.line}>

--- a/src/features/Messenger/ui/TermsApplication/TermsApplication.pastDates.test.tsx
+++ b/src/features/Messenger/ui/TermsApplication/TermsApplication.pastDates.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { TermsApplication } from "./TermsApplication";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+/**
+ * Row: "явно можно подаваться... на даты в прошлом" — поле «Прибытие»
+ * не получало min ни от вызывающего OfferApplication, ни от самого
+ * TermsApplication, поэтому прошлые даты были доступны для выбора.
+ */
+describe("TermsApplication — дата прибытия не может быть в прошлом по умолчанию", () => {
+    it("вчерашний день недоступен для выбора, если min не передан явно", () => {
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        const dayAfterTomorrow = new Date();
+        dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
+
+        const { container } = renderWithProviders(
+            <MemoryRouter>
+                <TermsApplication
+                    locale="ru"
+                    terms={{ start: dayAfterTomorrow, end: undefined }}
+                    isSuccess={false}
+                    onChange={() => {}}
+                />
+            </MemoryRouter>,
+        );
+
+        const yesterdayLabel = yesterday.toLocaleDateString("ru-RU", {
+            month: "long", day: "numeric", year: "numeric",
+        });
+        const yesterdayAbbr = container.querySelector(`abbr[aria-label="${yesterdayLabel}"]`);
+        expect(yesterdayAbbr).toBeTruthy();
+        expect(yesterdayAbbr?.closest("button")).toBeDisabled();
+    });
+});

--- a/src/features/Messenger/ui/TermsApplication/TermsApplication.tsx
+++ b/src/features/Messenger/ui/TermsApplication/TermsApplication.tsx
@@ -30,8 +30,11 @@ interface TermsApplicationProps {
 
 export const TermsApplication: FC<TermsApplicationProps> = (props) => {
     const {
-        className, onChange, onSubmit, onApplicationSubmit, terms, max, min, isHost,
+        className, onChange, onSubmit, onApplicationSubmit, terms, max, isHost,
         isSuccess = false, locale,
+        // Прибытие не может быть в прошлом, даже если вызывающий компонент
+        // не передал свой min (row: "явно можно подаваться... на даты в прошлом").
+        min = new Date(),
     } = props;
 
     const { t } = useTranslation("messenger");

--- a/src/shared/ui/CalendarComponent/CalendarComponent.test.tsx
+++ b/src/shared/ui/CalendarComponent/CalendarComponent.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import CalendarComponent from "./CalendarComponent";
+
+/**
+ * Row: "явно можно подаваться... на даты в прошлом" — в форме заявки
+ * (TermsApplication → DateInput → DatePickerCalendar) minDate/maxDate
+ * доходили до CalendarComponent, но тот их не прокидывал дальше в
+ * react-calendar (деструктурировались только value/onChange/locale/
+ * className) — календарь визуально не блокировал прошлые даты, и клик
+ * по ним всё равно вызывал onChange.
+ */
+describe("CalendarComponent — прокидывает minDate/maxDate в react-calendar", () => {
+    it("дата до minDate недоступна для выбора (disabled)", () => {
+        const minDate = new Date(2026, 6, 20); // 20 июля 2026
+
+        const { container } = render(
+            <CalendarComponent
+                value={minDate}
+                onChange={() => {}}
+                minDate={minDate}
+            />,
+        );
+
+        const pastDayAbbr = container.querySelector("abbr[aria-label=\"July 15, 2026\"]");
+        expect(pastDayAbbr).toBeTruthy();
+        const pastDayButton = pastDayAbbr?.closest("button");
+        expect(pastDayButton).toBeDisabled();
+
+        const validDayAbbr = container.querySelector("abbr[aria-label=\"July 25, 2026\"]");
+        const validDayButton = validDayAbbr?.closest("button");
+        expect(validDayButton).not.toBeDisabled();
+    });
+});

--- a/src/shared/ui/CalendarComponent/CalendarComponent.tsx
+++ b/src/shared/ui/CalendarComponent/CalendarComponent.tsx
@@ -9,7 +9,7 @@ import { ICalendarComponent } from "./types";
 const CalendarComponent: React.FC<ICalendarComponent> = forwardRef(
     (props: ICalendarComponent, ref) => {
         const {
-            className, value, onChange, locale,
+            className, value, onChange, locale, minDate, maxDate,
         } = props;
         const onDatePick = useCallback(
             (date: Date) => {
@@ -27,6 +27,8 @@ const CalendarComponent: React.FC<ICalendarComponent> = forwardRef(
                 tileClassName={styles.tile}
                 className={cn(className, styles.calendar)}
                 locale={locale}
+                minDate={minDate}
+                maxDate={maxDate}
             />
         );
     },

--- a/src/widgets/Messenger/ui/Chat/Chat.fixedDates.test.tsx
+++ b/src/widgets/Messenger/ui/Chat/Chat.fixedDates.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import {
+    describe, it, expect, vi, beforeEach,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { Profile } from "@/entities/Profile";
+import { Chat } from "./Chat";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ mercureToken: null }),
+}));
+
+vi.mock("@/app/providers/MessengerProvider", () => ({
+    useMessenger: () => ({ onReadMessage: vi.fn() }),
+}));
+
+const MY_PROFILE = {
+    id: "u1", firstName: "Иван", lastName: "Иванов", image: null,
+} as unknown as Profile;
+
+// Точная копия структуры реальной вакансии 7205 (row: "почему кнопка
+// неактивна, если я подал заявку на участие") — у неё ровно один период,
+// совпадающий с допустимой длительностью, то есть даты по факту не выбираются.
+const OFFER_RESPONSE_FIXED_DATES = {
+    id: 7205,
+    status: "active",
+    averageRating: 0,
+    reviewsCount: 0,
+    acceptedApplicationsCount: 0,
+    where: { address: "Республика Алтай" },
+    description: { title: "Школа фотографа", shortDescription: "Кратко", description: "Полное описание" },
+    when: {
+        isFullYearAcceptable: false,
+        isApplicableAtTheEnd: false,
+        durationMinDays: 7,
+        durationMaxDays: 8,
+        applicationEndDate: "09.08.2026",
+        periods: [{ start: "20.09.2026", end: "27.09.2026" }],
+    },
+};
+
+const OFFER_RESPONSE_NO_FIXED_DATES = {
+    ...OFFER_RESPONSE_FIXED_DATES,
+    when: {
+        ...OFFER_RESPONSE_FIXED_DATES.when,
+        isFullYearAcceptable: true,
+        periods: [],
+    },
+};
+
+describe("Chat — заявка на вакансию с фиксированными датами", () => {
+    beforeEach(() => {
+        server.use(
+            rest.get("*/chats/:chatId", (req, res, ctx) => res(ctx.status(404))),
+            rest.get("*/chats/:chatId/messages", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+        );
+    });
+
+    it("даты у вакансии единственно возможные — подставляются сами, строка про выбор дат не показывается", async () => {
+        server.use(
+            rest.get("*/vacancy/:id", (req, res, ctx) => res(ctx.status(200), ctx.json(OFFER_RESPONSE_FIXED_DATES))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter>
+                <Chat
+                    id="create"
+                    offerId="7205"
+                    onBackButton={() => {}}
+                    locale="ru"
+                    myProfileData={MY_PROFILE}
+                />
+            </MemoryRouter>,
+        );
+
+        await screen.findByText("Школа фотографа");
+
+        expect(screen.queryByText("Укажите даты, чтобы отправить заявку")).not.toBeInTheDocument();
+        expect(await screen.findByDisplayValue("20-09-2026")).toBeInTheDocument();
+        expect(await screen.findByDisplayValue("27-09-2026")).toBeInTheDocument();
+    });
+
+    it("у вакансии нет фиксированных дат — просит их выбрать, поля дат пустые", async () => {
+        server.use(
+            rest.get("*/vacancy/:id", (req, res, ctx) => res(ctx.status(200), ctx.json(OFFER_RESPONSE_NO_FIXED_DATES))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter>
+                <Chat
+                    id="create"
+                    offerId="7205"
+                    onBackButton={() => {}}
+                    locale="ru"
+                    myProfileData={MY_PROFILE}
+                />
+            </MemoryRouter>,
+        );
+
+        await screen.findByText("Школа фотографа");
+
+        expect(await screen.findByText("Укажите даты, чтобы отправить заявку")).toBeInTheDocument();
+        expect(screen.queryByDisplayValue("20-09-2026")).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/Messenger/ui/Chat/Chat.tsx
+++ b/src/widgets/Messenger/ui/Chat/Chat.tsx
@@ -29,7 +29,7 @@ import { Profile, ProfileById, useLazyGetProfileInfoByIdQuery } from "@/entities
 import arrowIcon from "@/shared/assets/icons/accordion-arrow.svg";
 import arrowBackIcon from "@/shared/assets/icons/arrow.svg";
 import chatIcon from "@/shared/assets/icons/chat.svg";
-import { formatDate, formatMessageDate } from "@/shared/lib/formatDate";
+import { formatDate, formatMessageDate, parseDateApi } from "@/shared/lib/formatDate";
 import { getErrorText } from "@/shared/lib/getErrorText";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 import HintPopup from "@/shared/ui/HintPopup/HintPopup";
@@ -74,7 +74,9 @@ export const Chat: FC<ChatProps> = (props) => {
         locale, myProfileData, recipientVolunteer, recipientOrganization,
     } = props;
 
-    const { handleSubmit, control, reset } = useForm<ChatFormFields>({
+    const {
+        handleSubmit, control, reset, setValue,
+    } = useForm<ChatFormFields>({
         mode: "onChange",
         defaultValues,
     });
@@ -174,6 +176,25 @@ export const Chat: FC<ChatProps> = (props) => {
         //     fetchOrganization();
         // }
     }, [isChatCreate, offerId, getOfferData]);
+
+    // Если у вакансии ровно один период — даты участия по сути уже заданы
+    // хостом (row: "почему кнопка неактивна, если я подал заявку" — при
+    // единственном возможном периоде просить волонтёра ещё раз выбрать
+    // даты в календаре было лишним и путающим шагом).
+    const fixedPeriod = offerData?.when && !offerData.when.isFullYearAcceptable
+        && offerData.when.periods.length === 1
+        ? offerData.when.periods[0]
+        : undefined;
+
+    const hasPrefilledFixedDatesRef = useRef(false);
+    useEffect(() => {
+        if (!fixedPeriod || hasPrefilledFixedDatesRef.current) return;
+        const start = parseDateApi(fixedPeriod.start);
+        const end = parseDateApi(fixedPeriod.end);
+        if (!start || !end) return;
+        hasPrefilledFixedDatesRef.current = true;
+        setValue("applicationForm", { startDate: start, endDate: end });
+    }, [fixedPeriod, setValue]);
 
     // Ref, а не state: отмечаем последнее уже прочитанное сообщение конкретного
     // чата, чтобы не дёргать readMessage/onReadMessage повторно на каждый
@@ -437,6 +458,7 @@ export const Chat: FC<ChatProps> = (props) => {
                                 isHost={false}
                                 username={username}
                                 isClosed={applicationIsClosed}
+                                hasFixedDates={Boolean(fixedPeriod)}
                                 onSubmit={handleVolunteerSubmitOfferApplication}
                             />
                         )}


### PR DESCRIPTION
## Что не так было

1. Если у вакансии ровно один возможный период участия (даты фактически заданы хостом, выбирать нечего), при подаче заявки волонтёру всё равно показывалась строка «Укажите даты, чтобы отправить заявку» и требовалось вручную выбрать даты в календаре, хотя вариант ровно один. Это и была причина исходного репорта «почему кнопка неактивна, если я подал заявку на участие» на вакансии 7205 — там period 20.09–27.09.2026 и duration 7–8 дней, то есть фактически без выбора.
2. Отдельно: календарь заявки вообще не блокировал прошедшие даты — `CalendarComponent` получал `minDate`/`maxDate`, но не прокидывал их в `react-calendar`, и поле «Прибытие» вообще не получало `min` ни от одного вызывающего компонента.

## Что изменилось

- Если у вакансии `when.periods.length === 1` и `!isFullYearAcceptable` — даты автоматически подставляются в форму заявки, строка «Укажите даты…» не показывается.
- Если периодов нет или вакансия принимает заявки весь год — прежнее поведение (календарь + строка-подсказка) сохраняется без изменений.
- `isClosed` (уже поданная заявка) — поведение не тронуто.
- `CalendarComponent` теперь прокидывает `minDate`/`maxDate` в `react-calendar` — прошедшие даты в любом календаре, использующем этот компонент с ограничениями, физически недоступны для клика.
- `TermsApplication`: поле «Прибытие» по умолчанию не может быть в прошлом, даже если вызывающий компонент не передал свой `min`.

## Тесты

- `Chat.fixedDates.test.tsx` — воспроизводит структуру реальной вакансии 7205: даты подставляются, строка не показывается; контрольный кейс без фиксированных дат — прежнее поведение.
- `OfferApplication.behavior.test.tsx` — добавлен кейс `hasFixedDates`.
- `CalendarComponent.test.tsx` — minDate/maxDate реально блокируют тайлы в react-calendar.
- `TermsApplication.pastDates.test.tsx` — «Прибытие» не даёт выбрать вчерашний день без явного `min`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)