### PR TITLE
feat: Telegram-уведомление о статусе деплоя

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -75,3 +75,24 @@ jobs:
           done
           echo "Frontend smoke test failed"
           exit 1
+
+  notify:
+    needs: build-and-deploy
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Telegram
+        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
+        continue-on-error: true
+        run: |
+          if [ "${{ needs['build-and-deploy'].result }}" = "success" ]; then
+            STATUS="✅ успешно"
+          else
+            STATUS="🔴 ошибка (${{ needs['build-and-deploy'].result }})"
+          fi
+          TEXT="*gs-frontend* деплой в *prod* — ${STATUS}
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            --data-urlencode chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            --data-urlencode parse_mode="Markdown" \
+            --data-urlencode text="$TEXT"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -73,3 +73,24 @@ jobs:
           done
           echo "Frontend smoke test failed"
           exit 1
+
+  notify:
+    needs: build-and-deploy
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Telegram
+        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
+        continue-on-error: true
+        run: |
+          if [ "${{ needs['build-and-deploy'].result }}" = "success" ]; then
+            STATUS="✅ успешно"
+          else
+            STATUS="🔴 ошибка (${{ needs['build-and-deploy'].result }})"
+          fi
+          TEXT="*gs-frontend* деплой в *staging* — ${STATUS}
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            --data-urlencode chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            --data-urlencode parse_mode="Markdown" \
+            --data-urlencode text="$TEXT"


### PR DESCRIPTION
## Что добавлено

Job `notify` в конце `Deploy to prod`/`Deploy to staging` — шлёт сообщение в Telegram с итогом деплоя (✅/🔴) и ссылкой на ран.

## Как включить

Добавить в Settings → Secrets репозитория:
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_CHAT_ID`

Без этих секретов шаг просто пропускается — деплой не ломается.

Часть задачи по статус-боту (`gs-status-bot`, отдельный репозиторий).

🤖 Generated with [Claude Code](https://claude.com/claude-code)