### PR TITLE
fix: карта вакансий не синхронизирована со списком + отсутствующий API-ключ Яндекс.Карт

### DIFF
--- a/src/entities/Map/ui/YMap/YMap.tsx
+++ b/src/entities/Map/ui/YMap/YMap.tsx
@@ -67,7 +67,10 @@ export const YMap: FC<MapProps> = ({
     }, [mapLoaded, onClick]);
 
     return (
-        <YMaps key={locale} query={{ lang: languageList[locale] }}>
+        <YMaps
+            key={locale}
+            query={{ apikey: import.meta.env.VITE_API_YANDEX_KEY, lang: languageList[locale] }}
+        >
             <Map
                 instanceRef={(instance) => {
                     mapRef.current = instance;

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -178,6 +178,7 @@ export const OffersSearchFilter = () => {
                             limit: OFFERS_PER_PAGE,
                             page: currentPage,
                         });
+                        fetchAllOffersMap({ ...preparedData, search: currentSearchRef.current });
                     } else {
                         fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: currentPage });
                         fetchAllOffersMap({ ...preparedData });

--- a/src/widgets/Donation/DonationsMap/DonationsMap.tsx
+++ b/src/widgets/Donation/DonationsMap/DonationsMap.tsx
@@ -91,7 +91,7 @@ export const DonationsMap: FC<DonationsMapProps> = memo((props: DonationsMapProp
 
     return (
         <div className={cn(className, styles.wrapper)}>
-            <YMaps query={{ load: "package.full" }}>
+            <YMaps query={{ apikey: import.meta.env.VITE_API_YANDEX_KEY, load: "package.full" }}>
                 <Map
                     defaultState={{
                         center: [50, 50], zoom: 2.05, controls: [],

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -102,7 +102,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
 
     return (
         <div className={cn(className, styles.wrapper)}>
-            <YMaps query={{ load: "package.full" }}>
+            <YMaps query={{ apikey: import.meta.env.VITE_API_YANDEX_KEY, load: "package.full" }}>
                 <Map
                     defaultState={{
                         center: [50, 50], zoom: 2.05, controls: [],


### PR DESCRIPTION
## Что было

1. **Карта не обновлялась при активном поиске.** В `OffersSearchFilter.tsx` обработчик смены «Показать прошедшие»/сортировки при активном поисковом запросе вызывал только `fetchOffers` (список), но не `fetchAllOffersMap` (карту). Список корректно фильтровался, карта продолжала показывать устаревшие данные, включая просроченные вакансии.
2. **Дублирующая загрузка Yandex Maps JS API без ключа.** `OffersMap`, `DonationsMap` и `entities/Map/YMap` создавали собственные `<YMaps>`-провайдеры без `apikey`, хотя глобальный провайдер в `App.tsx` его уже передаёт. В консоли — `Invalid API key`, лишний сетевой запрос, риск упереться в лимиты бесключевого режима в проде.

## Что сделано

- Добавлен недостающий вызов `fetchAllOffersMap` в ветку с активным поиском.
- Все локальные `<YMaps>`-обёртки теперь передают тот же `import.meta.env.VITE_API_YANDEX_KEY`, что и глобальная в `App.tsx`.

## Test plan

- [x] `npx tsc --noEmit` — чисто
- [x] `npx eslint` на изменённые файлы — чисто
- [x] Живой прогон на реальных staging-данных (локальный dev-сервер + прокси на `api-staging.goodsurfing.org` с IAP-bypass токеном): поиск → выключение «Показать прошедшие» → список и карта теперь синхронно показывают 0 результатов (было: список 0, карта — старые кластеры)
- [ ] Смотрю CI на PR