### PR TITLE
hotfix: деплой сломан — secrets запрещён в if шага

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -82,9 +82,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Telegram
-        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
         continue-on-error: true
         run: |
+          if [ -z "${{ secrets.TELEGRAM_BOT_TOKEN }}" ] || [ -z "${{ secrets.TELEGRAM_CHAT_ID }}" ]; then
+            echo "Telegram secrets not set, skipping notification"
+            exit 0
+          fi
           if [ "${{ needs['build-and-deploy'].result }}" = "success" ]; then
             STATUS="✅ успешно"
           else

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -80,9 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Telegram
-        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
         continue-on-error: true
         run: |
+          if [ -z "${{ secrets.TELEGRAM_BOT_TOKEN }}" ] || [ -z "${{ secrets.TELEGRAM_CHAT_ID }}" ]; then
+            echo "Telegram secrets not set, skipping notification"
+            exit 0
+          fi
           if [ "${{ needs['build-and-deploy'].result }}" = "success" ]; then
             STATUS="✅ успешно"
           else


### PR DESCRIPTION
## Инцидент

С момента мержа #424 (~19:00 22.07) деплой в staging и prod **полностью не запускался** — GitHub Actions не может распарсить `deploy-staging.yml`/`deploy-prod.yml` целиком (0 successful runs с этого момента, каждый ран падает за 0с с "workflow file issue").

## Причина

```yaml
- name: Notify Telegram
  if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
```

Контекст `secrets` не разрешён в `if:` на уровне step (см. [context availability](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) — доступны только env/github/inputs/job/matrix/needs/runner/steps/strategy/vars). Найдено через `actionlint`.

## Фикс

Убрал `if:` с секретами, проверка на пустые секреты перенесена в начало bash-скрипта (`exit 0` если не заданы).

## Test plan

- [x] `actionlint .github/workflows/deploy-staging.yml .github/workflows/deploy-prod.yml` — чисто
- [ ] После мержа — дождаться реального ранa deploy-staging.yml, убедиться что деплой прошёл