### PR TITLE
fix: вернуть zoom-контрол на карты вакансий и сборов

### DIFF
--- a/src/widgets/Donation/DonationsMap/DonationsMap.tsx
+++ b/src/widgets/Donation/DonationsMap/DonationsMap.tsx
@@ -94,7 +94,7 @@ export const DonationsMap: FC<DonationsMapProps> = memo((props: DonationsMapProp
             <YMaps query={{ apikey: import.meta.env.VITE_API_YANDEX_KEY, load: "package.full" }}>
                 <Map
                     defaultState={{
-                        center: [50, 50], zoom: 2.05, controls: [],
+                        center: [50, 50], zoom: 2.05, controls: ["zoomControl"],
                     }}
                     width="100%"
                     height="100%"

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -105,7 +105,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
             <YMaps query={{ apikey: import.meta.env.VITE_API_YANDEX_KEY, load: "package.full" }}>
                 <Map
                     defaultState={{
-                        center: [50, 50], zoom: 2.05, controls: [],
+                        center: [50, 50], zoom: 2.05, controls: ["zoomControl"],
                     }}
                     width="100%"
                     height="100%"


### PR DESCRIPTION
## Что было
\`controls: []\` в \`defaultState\` карты (OffersMap, DonationsMap) отключал вообще все контролы, включая +/- зум.

## Фикс
Включил \`control: ["zoomControl"]\`.

Пробовал добавить и линейку масштаба (scaleLine), но в Yandex Maps JS API нет встроенного ScaleLine-контрола (в отличие от Leaflet/Google Maps) — попытка `ymap.control.ScaleLine` роняет карту рантайм-ошибкой ("is not a constructor"). Это отдельная задача на кастомный компонент, не тривиальный фикс, оставил как есть.

## Test plan
- [x] tsc/eslint чисто
- [x] Живой прогон на реальных staging-данных (локальный dev-сервер + прокси на api-staging): зум-контрол появился, карта рендерится и кластеризуется как раньше