### PR TITLE
fix: правый отступ карте вакансий

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
@@ -16,6 +16,12 @@
     // height: 100%;
 }
 
+// такой же гаттер, как у .top в OffersFilter (padding: 20px 50px) — без него
+// карта упирается прямо в край экрана, а список слева отступ имеет.
+.offersMap {
+    margin-right: 50px;
+}
+
 .offersMap.close {
     display: none;
 }


### PR DESCRIPTION
## Что было
\`.offersMap\` не имел отступа справа — карта упиралась прямо в правую границу viewport, в отличие от списка вакансий, у которого есть свой гаттер слева.

## Фикс
\`margin-right: 50px\` — тот же гаттер, что уже используется на этой странице (\`.top\` в OffersFilter: \`padding: 20px 50px\`).

## Test plan
- [x] tsc чисто
- [x] Живой прогон: подтверждено через getBoundingClientRect — карта заканчивается на 50px раньше правого края viewport на 1920px