### PR TITLE
fix: галереи грузят webp-миниатюры вместо оригиналов

### DIFF
--- a/src/entities/Donation/ui/DonationGalleryCard/DonationGalleryCard.tsx
+++ b/src/entities/Donation/ui/DonationGalleryCard/DonationGalleryCard.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ImageGallerySlider } from "@/shared/ui/ImageGallerySlider/ImageGallerySlider";
 import { Text } from "@/shared/ui/Text/Text";
 import { Image } from "@/types/media";
-import { getMediaContentsArray } from "@/shared/lib/getMediaContent";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 import styles from "./DonationGalleryCard.module.scss";
 
 interface DonationGalleryCardProps {
@@ -17,7 +17,9 @@ export const DonationGalleryCard: FC<DonationGalleryCardProps> = memo(
     (props: DonationGalleryCardProps) => {
         const { galleryImages = [], className } = props;
         const { t } = useTranslation("donation");
-        const formatGallery = getMediaContentsArray(galleryImages);
+        const formatGallery = galleryImages
+            .map((image) => getMediaContent(image, "LARGE"))
+            .filter((url): url is string => Boolean(url));
 
         if (galleryImages.length === 0) {
             return (

--- a/src/entities/Host/ui/HostInfoCard/HostInfoCard.tsx
+++ b/src/entities/Host/ui/HostInfoCard/HostInfoCard.tsx
@@ -8,7 +8,7 @@ import { HostOffersCard } from "../HostOffersCard/HostOffersCard";
 // import { HostTeamCard } from "../HostTeamCard/HostTeamCard";
 import styles from "./HostInfoCard.module.scss";
 import { HostGalleryCard } from "../HostGalleryCard/HostGalleryCard";
-import { getMediaContentsArray } from "@/shared/lib/getMediaContent";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 import { HostVideoGalleryCard } from "../HostVideoGalleryCard/HostVideoGalleryCard";
 import { HostReviewCard } from "../HostReviewCard/HostReviewCard";
 import { useLocale } from "@/app/providers/LocaleProvider";
@@ -35,7 +35,9 @@ export const HostInfoCard: FC<HostInfoCardProps> = memo(
                     locale={locale}
                 />
                 <HostGalleryCard
-                    images={getMediaContentsArray(host.galleryImages)}
+                    images={host.galleryImages
+                        .map((image) => getMediaContent(image, "LARGE"))
+                        .filter((url): url is string => Boolean(url))}
                     className={styles.container}
                 />
                 <HostVideoGalleryCard

--- a/src/entities/Offer/ui/OfferGalleryCard/OfferGalleryCard.tsx
+++ b/src/entities/Offer/ui/OfferGalleryCard/OfferGalleryCard.tsx
@@ -6,7 +6,7 @@ import styles from "./OfferGalleryCard.module.scss";
 import { ImageGallerySlider } from "@/shared/ui/ImageGallerySlider/ImageGallerySlider";
 import { Text } from "@/shared/ui/Text/Text";
 import { Image } from "@/types/media";
-import { getMediaContentsArray } from "@/shared/lib/getMediaContent";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 
 interface OfferGalleryCardProps {
     galleryImages?: Image[];
@@ -17,7 +17,11 @@ export const OfferGalleryCard: FC<OfferGalleryCardProps> = memo(
     (props: OfferGalleryCardProps) => {
         const { galleryImages = [], className } = props;
         const { t } = useTranslation("offer");
-        const formatGallery = getMediaContentsArray(galleryImages);
+        // "large"-thumbnail вместо оригинала — тут отдаётся ~1MB PNG на слайдер
+        // шириной 264px, при том что бэкенд уже готовит webp-миниатюры.
+        const formatGallery = galleryImages
+            .map((image) => getMediaContent(image, "LARGE"))
+            .filter((url): url is string => Boolean(url));
 
         if (galleryImages.length === 0) {
             return null;

--- a/src/entities/Volunteer/ui/VolunteerInfoCard/VolunteerInfoCard.tsx
+++ b/src/entities/Volunteer/ui/VolunteerInfoCard/VolunteerInfoCard.tsx
@@ -4,7 +4,7 @@ import React, {
 } from "react";
 
 import { useTranslation } from "react-i18next";
-import { getMediaContentsArray } from "@/shared/lib/getMediaContent";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 
 import { VolunteerDesctiptionCard } from "../VolunteerDesctiptionCard/VolunteerDesctiptionCard";
 import { VolunteerGalleryCard } from "../VolunteerGalleryCard/VolunteerGalleryCard";
@@ -97,9 +97,9 @@ export const VolunteerInfoCard: FC<VolunteerInfoCardProps> = memo(
                 />
                 {showImageGallery && (
                     <VolunteerGalleryCard
-                        images={getMediaContentsArray(
-                            galleryImages,
-                        )}
+                        images={galleryImages
+                            .map((image) => getMediaContent(image, "LARGE"))
+                            .filter((url): url is string => Boolean(url))}
                         className={styles.container}
                     />
                 )}

--- a/src/pages/AboutProjectPage/ui/Gallery/Gallery.tsx
+++ b/src/pages/AboutProjectPage/ui/Gallery/Gallery.tsx
@@ -7,7 +7,7 @@ import "swiper/swiper.min.css";
 
 import { ImageGallerySlider } from "@/shared/ui/ImageGallerySlider/ImageGallerySlider";
 import { Image } from "@/types/media";
-import { getMediaContentsArray } from "@/shared/lib/getMediaContent";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 import styles from "./Gallery.module.scss";
 
 interface GalleryProps {
@@ -25,7 +25,9 @@ export const Gallery: FC<GalleryProps> = (props: GalleryProps) => {
                 {t("Фото со встреч и командной работы")}
             </h2>
             <ImageGallerySlider
-                images={getMediaContentsArray(gallery)}
+                images={gallery
+                    .map((image) => getMediaContent(image, "LARGE"))
+                    .filter((url): url is string => Boolean(url))}
                 className={styles.gallery}
             />
         </section>

--- a/src/pages/DonationPersonalPage/ui/DonationPersonalCard/DonationPersonalCard.tsx
+++ b/src/pages/DonationPersonalPage/ui/DonationPersonalCard/DonationPersonalCard.tsx
@@ -1,12 +1,14 @@
 import { memo, useCallback, useState } from "react";
-import {
-    getMediaContent,
-    getMediaContentsArray,
-} from "@/shared/lib/getMediaContent";
+import { getMediaContent } from "@/shared/lib/getMediaContent";
 import { ModalGallery } from "@/shared/ui/ModalGallery/ModalGallery";
 import { OfferPersonalCardImageBlock } from "../OfferPersonalCardImageBlock/OfferPersonalCardImageBlock";
 import { GetDonation, HeaderDonationCard } from "@/entities/Donation";
 import { DonationPersonalCardCategory } from "../DonationPersonalCardCategory/DonationPersonalCardCategory";
+import { Image } from "@/types/media";
+
+const getGalleryThumbnails = (images: Image[]) => images
+    .map((image) => getMediaContent(image, "LARGE"))
+    .filter((url): url is string => Boolean(url));
 
 interface DonationPersonalCardProps {
     id: string;
@@ -29,7 +31,7 @@ export const DonationPersonalCard = memo((props: DonationPersonalCardProps) => {
     const showImageBlock = donationData.galleryImages.length > 0 ? (
         <OfferPersonalCardImageBlock
             onImagesClick={onImagesClick}
-            images={getMediaContentsArray(donationData.galleryImages)}
+            images={getGalleryThumbnails(donationData.galleryImages)}
         />
     ) : null;
 
@@ -59,7 +61,7 @@ export const DonationPersonalCard = memo((props: DonationPersonalCardProps) => {
                 <ModalGallery
                     isOpen={isModalOpen}
                     onClose={handleModalClose}
-                    images={getMediaContentsArray(donationData.galleryImages)}
+                    images={getGalleryThumbnails(donationData.galleryImages)}
                 />
             )}
         </>


### PR DESCRIPTION
## Что было
Репортнули медленную загрузку фото на странице вакансии (`/ru/offer-personal/7202`, вкладка «Фото»). Проверил: фото грузится оригиналом — 1049331 байт (1MB) PNG при отображении на слайдере шириной ~264px.

## Причина
`getMediaContentsArray` во всех read-only галереях всегда отдаёт `contentUrl` (оригинал). При этом бэкенд **уже** готовит и отдаёт `thumbnails: {large, medium, small}` в webp для каждого `MediaObject` — просто фронт их не использовал. `getMediaContent(image, size)` этот механизм уже поддерживает (использовался только в паре мест).

## Фикс
Переключил все read-only галереи на `getMediaContent(image, "LARGE")` (480×360 webp):
- OfferGalleryCard (страница вакансии)
- DonationGalleryCard (страница сбора)
- HostInfoCard / VolunteerInfoCard (галереи организации и волонтёра)
- DonationPersonalCard (превью + модалка)
- AboutProjectPage/Gallery (фото со встреч)

Аплоад-флоу (`ImagesUploader` и т.п.) не трогал — там нужны оригиналы для редактирования.

## Результат
На конкретном примере с прода: **1049331 байт → 11134 байта** (~94x меньше).

## Test plan
- [x] tsc/eslint чисто
- [x] Живой прогон на реальном офере с прода (`/ru/offer-personal/7202`) через локальный dev-прокси — подтверждено по DOM: `img src` теперь ведёт на `.../thumbnails/large/....webp`