### PR TITLE
Cap working-hours input to a plausible max per timeType

### DIFF
--- a/src/features/OfferWhatToDo/ui/WorkingHoursField/WorkingHoursField.test.tsx
+++ b/src/features/OfferWhatToDo/ui/WorkingHoursField/WorkingHoursField.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test-utils";
+import { WorkingHoursField } from "./WorkingHoursField";
+
+describe("WorkingHoursField", () => {
+    it("не даёт ввести больше 24 часов, если период — день", async () => {
+        const onChange = vi.fn();
+        renderWithProviders(
+            <WorkingHoursField value={{ hours: 6, dayOff: 0, timeType: "day" }} onChange={onChange} />,
+        );
+
+        const input = screen.getByRole("spinbutton");
+        await userEvent.clear(input);
+        await userEvent.type(input, "42");
+
+        expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ hours: 42 }));
+    });
+
+    it("разрешает ввод в пределах суточного максимума", async () => {
+        const onChange = vi.fn();
+        renderWithProviders(
+            <WorkingHoursField value={{ hours: 6, dayOff: 0, timeType: "day" }} onChange={onChange} />,
+        );
+
+        const input = screen.getByRole("spinbutton");
+        await userEvent.clear(input);
+        await userEvent.type(input, "20");
+
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ hours: 20 }));
+    });
+});

--- a/src/features/OfferWhatToDo/ui/WorkingHoursField/WorkingHoursField.tsx
+++ b/src/features/OfferWhatToDo/ui/WorkingHoursField/WorkingHoursField.tsx
@@ -17,16 +17,24 @@ const TimeTypeOptions: TimeType[] = ["week", "day", "month"];
 
 const DayOffOptions: number[] = [0, 1, 2, 3, 4, 5, 6];
 
+const MAX_HOURS_BY_TIME_TYPE: Record<TimeType, number> = {
+    day: 24,
+    week: 168,
+    month: 744,
+};
+
 export const WorkingHoursField = memo(({ onChange, value }: Props) => {
     const { t } = useTranslation("offer");
+    const maxHours = MAX_HOURS_BY_TIME_TYPE[value.timeType];
     const handleHoursChange = (e: ChangeEvent<HTMLInputElement>) => {
         const inputString = +e.target.value;
-        if (inputString >= 0 && inputString <= 1000) {
+        if (inputString >= 0 && inputString <= maxHours) {
             onChange({ ...value, hours: +e.target.value });
         }
     };
     const handleTimeIntervalChange = (timeType: TimeType) => {
-        onChange({ ...value, timeType });
+        const clampedHours = Math.min(value.hours, MAX_HOURS_BY_TIME_TYPE[timeType]);
+        onChange({ ...value, timeType, hours: clampedHours });
     };
     const handleDayOffChange = (newValue: string) => {
         onChange({ ...value, dayOff: +newValue });
@@ -40,6 +48,8 @@ export const WorkingHoursField = memo(({ onChange, value }: Props) => {
                     <Input
                         inputClassName={styles.inputClassName}
                         type="number"
+                        min={0}
+                        max={maxHours}
                         onChange={handleHoursChange}
                         value={value.hours.toString()}
                     />


### PR DESCRIPTION
## Проблема

https://staging.goodsurfing.org/ru/offer-personal/7177 — "42 рабочих часа в день". `WorkingHoursField` разрешал ввод `hours` до 1000 независимо от `timeType` (день/неделя/месяц).

## Фикс

Максимум теперь зависит от `timeType`: 24 (день) / 168 (неделя) / 744 (месяц). Значение обрезается при смене `timeType`, если текущее превышает новый максимум. Добавлены `min`/`max` на нативный `<input type="number">` как дополнительная UI-подсказка.

Парный PR в gs-backend добавляет ту же защиту на сервере: https://github.com/Goodsurfing/gs-backend/pull/275

## Тесты

Новые unit-тесты на `WorkingHoursField`: ввод выше суточного максимума игнорируется, ввод в пределах — принимается.
