### PR TITLE
Fix category filter multi-select and URL/history hygiene on offers map

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -101,7 +101,7 @@ export const OffersSearchFilter = () => {
                         updated.delete("category");
                     }
                     return updated;
-                });
+                }, { replace: true });
             }
         });
         return () => subscription.unsubscribe();
@@ -122,7 +122,11 @@ export const OffersSearchFilter = () => {
 
     const onApplySearch = useCallback(async (search: string) => {
         currentSearchRef.current = search;
-        setSearchParams(new URLSearchParams());
+        const params = new URLSearchParams();
+        if (search) {
+            params.set("search", search);
+        }
+        setSearchParams(params);
         fetchOffers({
             sort: OfferSort.UpdatedDesc, search, limit: OFFERS_PER_PAGE, page: 1,
         });
@@ -137,7 +141,11 @@ export const OffersSearchFilter = () => {
             onApplySearch(searchParam);
             setInitialSearchValue(searchParam);
         }
-    }, [searchParams, onApplySearch]);
+        // Only restore search from the URL on initial load — onApplySearch itself
+        // keeps the URL in sync afterwards, so re-running this on every
+        // searchParams change would re-trigger the same search and push
+        // duplicate history entries.
+    }, []);
 
     const onApplyFilters = useCallback(handleSubmit(async (data: OffersFilterFields) => {
         currentSearchRef.current = "";

--- a/src/widgets/OffersMap/ui/Categories/Categories.test.tsx
+++ b/src/widgets/OffersMap/ui/Categories/Categories.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { Categories } from "./Categories";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+const mockCategories = () => server.use(
+    rest.get(`*${API_BASE_URL_V3}category/list`, (req, res, ctx) => res(ctx.status(200), ctx.json([
+        { id: 10, name: "Археология", color: "#fff" },
+        { id: 8, name: "Спорт", color: "#fff" },
+    ]))),
+);
+
+describe("Categories", () => {
+    it("выбирает первое направление, не сбрасывая остальные (не exclusive)", async () => {
+        mockCategories();
+
+        const onChange = vi.fn();
+        renderWithProviders(
+            <Categories value={[]} onChange={onChange} onClick={vi.fn()} isOpen />,
+        );
+
+        await waitFor(() => expect(screen.getByText("Археология")).toBeInTheDocument());
+        await userEvent.click(screen.getByText("Археология"));
+
+        expect(onChange).toHaveBeenLastCalledWith([10]);
+    });
+
+    it("добавляет второе направление к уже выбранному, а не заменяет его", async () => {
+        mockCategories();
+
+        const onChange = vi.fn();
+        renderWithProviders(
+            <Categories value={[10]} onChange={onChange} onClick={vi.fn()} isOpen />,
+        );
+
+        await waitFor(() => expect(screen.getByText("Спорт")).toBeInTheDocument());
+        await userEvent.click(screen.getByText("Спорт"));
+
+        expect(onChange).toHaveBeenLastCalledWith(expect.arrayContaining([10, 8]));
+        expect(onChange.mock.calls.at(-1)?.[0]).toHaveLength(2);
+    });
+});

--- a/src/widgets/OffersMap/ui/Categories/Categories.tsx
+++ b/src/widgets/OffersMap/ui/Categories/Categories.tsx
@@ -45,7 +45,7 @@ export const Categories = forwardRef<HTMLDivElement, CategoriesProps>((props, re
                 isOpen={isOpen}
             >
                 <div className={styles.popupContainer}>
-                    <OfferCategories value={value} onChange={onChange} locale={locale} exclusive />
+                    <OfferCategories value={value} onChange={onChange} locale={locale} />
                 </div>
             </Popup>
         </div>


### PR DESCRIPTION
## Проблема

Попросили тщательно проверить фильтр "Направление деятельности" (мультивыбор) и в целом урлы/поведение браузера на странице офферов.

1. **Мультивыбор не работал**: `Categories.tsx` передавал `exclusive` в `OfferCategories`/MUI `ToggleButtonGroup`, хотя вся остальная архитектура (форма `category: number[]`, URL-синк через `getCategoryUrlParamFromIds`, адаптер в API-запрос) уже полностью рассчитана на массив — можно было выбрать только одно направление одновременно.
2. **История браузера засорялась**: каждый клик по чипу категории пушил новую запись в history (проверено вживую: 2 клика → `history.length` вырос с 2 до 4). Кнопка "Назад" вместо выхода со страницы просто отменяла последний тоггл.
3. **Поиск не попадал в URL**: submit поискового запроса вообще не писал `?search=...` в адресную строку — результаты поиска нельзя было забукмаркать/переслать, обновление страницы сбрасывало поиск.

## Фикс

1. Убрал `exclusive` в `Categories.tsx` — мультивыбор работает, статус живо проверен (клик по двум чипам → `?category=10,8`, оба выбраны одновременно).
2. URL-синк категорий теперь через `{ replace: true }` — тоггл чипов больше не растит историю (проверено: `history.length` не меняется на протяжении нескольких тогглов), "Назад" теперь реально уводит со страницы.
3. `onApplySearch` теперь пишет `?search=...` в URL; эффект, читающий `search` из URL при монтировании, переведён на выполнение только один раз (иначе после того как он сам начинает писать в URL, он же реагирует на это изменение и создаёт цикл) — проверено вживую, что при прямом заходе по `?search=...` результаты восстанавливаются и `history.length` не растёт бесконечно.

## Тесты

Новые unit-тесты на `Categories`: выбор первого направления не exclusive, выбор второго добавляется к первому, а не заменяет его.

## Живая проверка (стейдж через dev-proxy)

- Мультивыбор: клик по двум чипам → оба выбраны, `?category=10,8`.
- History: 2 тоггла → `history.length` не изменился (было бы +2 до фикса).
- Back после тоглов: уходит со страницы целиком, а не отменяет последний клик.
- Search: submit → `?search=Ладожск` в URL; прямой заход по этому URL восстанавливает "6 вариантов", без цикла реюча.
