### PR TITLE
Apply offers filter on Enter, not only via the Применить button

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersFilter/OffersFilter.test.tsx
+++ b/src/pages/OffersMapPage/ui/OffersFilter/OffersFilter.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormProvider, useForm } from "react-hook-form";
+import { renderWithProviders } from "@/test-utils";
+import { OffersFilter } from "./OffersFilter";
+
+vi.mock("@/widgets/OffersMap", () => ({
+    Categories: React.forwardRef((_props: any, ref: any) => <div ref={ref} />),
+    ExtraFilters: () => <div />,
+}));
+vi.mock("@/widgets/OffersMap/ui/ButtonFilter/ButtonFilter", () => ({
+    ButtonFilter: () => <div />,
+}));
+vi.mock("@/widgets/OffersMap/ui/ParticipationPeriod/ParticipationPeriod", () => ({
+    ParticipationPeriod: () => <div />,
+}));
+vi.mock("@/widgets/OffersMap/ui/PeriodsFilter/PeriodsFilter", () => ({
+    PeriodsFilter: ({ onChange }: { onChange: (v: unknown) => void }) => (
+        <input aria-label="Не задано" onChange={() => onChange({ start: undefined, end: undefined })} />
+    ),
+}));
+
+interface WrapperProps {
+    onSubmit: () => void;
+    onResetFilters: () => void;
+}
+
+const Wrapper = ({ onSubmit, onResetFilters }: WrapperProps) => {
+    const form = useForm({
+        defaultValues: { periods: {}, category: [], participationPeriod: [1, 190] },
+    });
+    return (
+        <FormProvider {...form}>
+            <OffersFilter onSubmit={onSubmit} onResetFilters={onResetFilters} />
+        </FormProvider>
+    );
+};
+
+describe("OffersFilter", () => {
+    it("применяет фильтр по нажатию Enter в поле фильтра, не только по кнопке", async () => {
+        const onSubmit = vi.fn();
+        renderWithProviders(<Wrapper onSubmit={onSubmit} onResetFilters={vi.fn()} />);
+
+        const input = screen.getByLabelText("Не задано");
+        input.focus();
+        await userEvent.keyboard("{Enter}");
+
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it("не вызывает onSubmit дважды, когда Enter нажат на самой кнопке Применить", async () => {
+        const onSubmit = vi.fn();
+        renderWithProviders(<Wrapper onSubmit={onSubmit} onResetFilters={vi.fn()} />);
+
+        await userEvent.click(screen.getByText("Применить"));
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+
+        await userEvent.keyboard("{Enter}");
+        expect(onSubmit).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/pages/OffersMapPage/ui/OffersFilter/OffersFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersFilter/OffersFilter.tsx
@@ -88,8 +88,15 @@ export const OffersFilter: FC<OffersFilterProps> = (props) => {
         });
     };
 
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === "Enter" && !(e.target instanceof HTMLButtonElement)) {
+            e.preventDefault();
+            onSubmit();
+        }
+    };
+
     return (
-        <div className={cn(styles.wrapper, className)}>
+        <div className={cn(styles.wrapper, className)} onKeyDown={handleKeyDown}>
             <div className={styles.top}>
                 <Controller
                     name="periods"


### PR DESCRIPTION
## Проблема

В фильтре офферов (Направление деятельности / Срок участия / Доп. фильтры) нажатие Enter ничего не делало — применить можно было только кликом по кнопке "Применить".

## Фикс

Добавлен `onKeyDown` на обёртку `OffersFilter`: Enter вызывает тот же `onSubmit`, что и кнопка. Исключение для `HTMLButtonElement` — иначе Enter на самой кнопке "Применить" (или на чипе категории) вызвал бы `onSubmit` дважды: один раз через нативную активацию кнопки (Enter → click → onClick), второй раз через мой обработчик.

## Живая проверка (стейдж через dev-proxy)

- Выбрал категорию чипом (без клика по "Применить"), сфокусировался на поле даты, нажал Enter → ушёл реальный запрос `vacancy/list?...categoryIds[]=8...` — фильтр применился.
- Клик по "Применить" → один запрос. Затем Enter на той же (ещё сфокусированной) кнопке → ровно ещё один запрос, не два — двойного вызова нет.

## Тесты

Новые unit-тесты на `OffersFilter`: Enter в поле фильтра вызывает `onSubmit`; Enter на самой кнопке "Применить" не вызывает `onSubmit` дважды.
