### PR TITLE
Reset stale results when navigating to offers-map without filters

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.test.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+    MemoryRouter, Routes, Route, useNavigate,
+} from "react-router-dom";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OffersSearchFilter } from "./OffersSearchFilter";
+
+vi.mock("@/widgets/OffersMap", () => ({
+    OffersList: () => <div />,
+    OffersMap: () => <div />,
+}));
+vi.mock("../OffersFilter/OffersFilter", () => ({
+    OffersFilter: () => <div />,
+}));
+vi.mock("../OffersSearchFilterMobile/OffersSearchFilterMobile", () => ({
+    OffersSearchFilterMobile: () => <div />,
+}));
+vi.mock("@/widgets/OffersMap/ui/SearchOffers/SearchOffers", () => ({
+    SearchOffers: React.forwardRef(
+        (_props: unknown, ref: React.Ref<HTMLDivElement>) => <div ref={ref} />,
+    ),
+}));
+
+const NavigateToCleanOffersMap = () => {
+    const navigate = useNavigate();
+    return (
+        <button type="button" onClick={() => navigate("/ru/offers-map")}>
+            Все вакансии
+        </button>
+    );
+};
+
+describe("OffersSearchFilter", () => {
+    it("сбрасывает выбранную категорию при внешней навигации на чистый урл (\"Все вакансии\")", async () => {
+        const requestedUrls: string[] = [];
+        server.use(
+            rest.get("*/vacancy/list", (req, res, ctx) => {
+                requestedUrls.push(req.url.toString());
+                return res(ctx.status(200), ctx.json({ data: [], pagination: { total: 0 } }));
+            }),
+            rest.get("*/vacancy/for-map/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+            rest.get("*/category/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/offers-map?category=8"]}>
+                <Routes>
+                    <Route
+                        path="/ru/offers-map"
+                        element={(
+                            <>
+                                <OffersSearchFilter />
+                                <NavigateToCleanOffersMap />
+                            </>
+                        )}
+                    />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(requestedUrls.some((url) => url.includes("categoryIds"))).toBe(true));
+
+        await userEvent.click(screen.getByText("Все вакансии"));
+
+        await waitFor(() => {
+            const last = requestedUrls.at(-1);
+            expect(last).toBeDefined();
+            expect(last).not.toContain("categoryIds");
+        });
+    });
+});

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -66,6 +66,8 @@ export const OffersSearchFilter = () => {
     } = offerFilterForm;
 
     const isSyncingRef = useRef(false);
+    const isInternalCategoryPushRef = useRef(false);
+    const previousCategoryParamRef = useRef(searchParams.get("category"));
     const currentSearchRef = useRef<string>("");
 
     useEffect(() => {
@@ -93,6 +95,7 @@ export const OffersSearchFilter = () => {
         const subscription = watch((value, { name }) => {
             if (!isSyncingRef.current && name === "category") {
                 const newCategory = getCategoryUrlParamFromIds(value.category);
+                isInternalCategoryPushRef.current = true;
                 setSearchParams((prev) => {
                     const updated = new URLSearchParams(prev);
                     if (newCategory) {
@@ -110,9 +113,29 @@ export const OffersSearchFilter = () => {
     useEffect(() => {
         isSyncingRef.current = true;
 
-        const parsedCategories = getCategoryIdsFromUrlParam(searchParams.get("category") ?? "");
-
+        const categoryParam = searchParams.get("category");
+        const parsedCategories = getCategoryIdsFromUrlParam(categoryParam ?? "");
         setValue("category", parsedCategories);
+
+        const categoryParamChanged = categoryParam !== previousCategoryParamRef.current;
+        previousCategoryParamRef.current = categoryParam;
+
+        // A category change that we didn't push ourselves (e.g. the "Все вакансии"
+        // nav link, a Back/Forward navigation, or a shared URL) means the visible
+        // list needs to be re-applied immediately, same as clicking "Применить" —
+        // otherwise the URL/form reset but the displayed results stay stale.
+        const isExternalCategoryChange = categoryParamChanged
+            && !isInternalCategoryPushRef.current
+            && !currentSearchRef.current;
+
+        if (isExternalCategoryChange) {
+            const preparedData = offersFilterApiAdapter({ ...watch(), category: parsedCategories });
+            fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: 1 });
+            fetchAllOffersMap({ ...preparedData });
+            setCurrentPage(1);
+        }
+        isInternalCategoryPushRef.current = false;
+
         isSyncingRef.current = false;
     }, [searchParams, setValue]);
 


### PR DESCRIPTION
## Проблема

Выбрал категорию → применил → кликнул "Все вакансии" в хедере → URL и форма сбрасываются на чистые, но список вакансий продолжает показывать старые (категорийные) результаты. `handleNavigateOfferPage` в хедере просто делает `navigate("/ru/offers-map")` (чистый URL) — на странице офферов это меняет `searchParams`, но раньше ничего не слушало это изменение, кроме синка формы (сам список никогда не перезапрашивался).

## Фикс

Эффект, который синкает `category` из URL в форму, теперь ещё различает: если это изменение URL пришло НЕ от самого компонента (не тоггл чипа перед "Применить", а внешняя навигация — хедер, Back/Forward, шаренная ссылка) — сразу переприменяет фильтр (как клик по "Применить"). Тоггл чипа в дропдауне по-прежнему НЕ применяется мгновенно — ждёт "Применить"/Enter, как и раньше.

## Живая проверка (стейдж через dev-proxy)

- Выбрал "Спорт" → "Применить" → 29 вариантов, `?category=8`.
- Клик "Все вакансии" в хедере → URL чистый, список сразу показывает 1738 вариантов (не завис на 29).
- Тоггл чипа в дропдауне (без "Применить") — сеть не дёргается, как и раньше (не сломал существующее поведение).
- Bonus: браузерная кнопка "Назад" после этого тоже корректно восстанавливает список под `?category=8` (раньше не восстанавливала).

## Тесты

Новый тест на `OffersSearchFilter`: рендер с `?category=8`, внешняя навигация (`navigate()`, как в хедере) на чистый URL → следующий запрос к `vacancy/list` не содержит `categoryIds`.
