### PR TITLE
Use thumbnails for high-traffic media call sites

### DIFF
--- a/src/entities/Donation/ui/DonationOrganizationCard/DonationOrganizationCard.tsx
+++ b/src/entities/Donation/ui/DonationOrganizationCard/DonationOrganizationCard.tsx
@@ -48,7 +48,7 @@ export const DonationOrganizationCard: FC<DonationOrganizationCardProps> = memo(
                         >
                             <Avatar
                                 className={styles.image}
-                                icon={getMediaContent(image?.contentUrl)}
+                                icon={getMediaContent(image ?? undefined, "SMALL")}
                                 text={name}
                             />
                             <span className={styles.name}>

--- a/src/entities/Host/ui/HostReviewCard/HostReviewCard.tsx
+++ b/src/entities/Host/ui/HostReviewCard/HostReviewCard.tsx
@@ -63,7 +63,7 @@ export const HostReviewCard: FC<HostReviewCardProps> = memo((props: HostReviewCa
     const renderReviews = reviews.map((review) => (
         <ReviewWidget
             name={getFullName(review.firstName, review.lastName)}
-            avatar={getMediaContent(review.image?.thumbnails?.small)}
+            avatar={getMediaContent(review.image ?? undefined, "SMALL")}
             reviewText={review.description}
             stars={review.rating}
             url={getVolunteerPersonalPageUrl(locale, review.id)}

--- a/src/entities/Messenger/ui/UserCard/UserCard.tsx
+++ b/src/entities/Messenger/ui/UserCard/UserCard.tsx
@@ -59,7 +59,7 @@ export const UserCard: FC<UserCardProps> = (props) => {
             )}
         >
             <Avatar
-                icon={getMediaContent(image?.contentUrl)}
+                icon={getMediaContent(image ?? undefined, "SMALL")}
                 isAvatarNoImgActive={id === dataChat.id.toString()}
                 text={firstName ?? undefined}
                 size="MEDIUM"

--- a/src/entities/Messenger/ui/UserInfoCard/UserInfoCard.tsx
+++ b/src/entities/Messenger/ui/UserInfoCard/UserInfoCard.tsx
@@ -86,7 +86,7 @@ export const UserInfoCard: FC<UserInfoCardProps> = (props) => {
         return volunteer.skills.map((item) => (
             <IconTextComponent
                 text={getTranslation(item.name) ?? ""}
-                icon={getMediaContent(item.image.contentUrl) ?? ""}
+                icon={getMediaContent(item.image, "SMALL") ?? ""}
                 alt={item.name}
                 key={item.id}
             />
@@ -137,7 +137,7 @@ export const UserInfoCard: FC<UserInfoCardProps> = (props) => {
                     onClick={() => navigateToVolunteer(user.id)}
                 >
                     <Avatar
-                        icon={getMediaContent(image?.thumbnails?.small)}
+                        icon={getMediaContent(image ?? undefined, "SMALL")}
                         text={getFullName(firstName, lastName)}
                         size="LARGE"
                     />

--- a/src/entities/Offer/ui/OfferOrganizationCard/OfferOrganizationCard.tsx
+++ b/src/entities/Offer/ui/OfferOrganizationCard/OfferOrganizationCard.tsx
@@ -40,7 +40,7 @@ export const OfferOrganizationCard: FC<OfferOrganizationCardProps> = memo(
                         >
                             <Avatar
                                 className={styles.image}
-                                icon={getMediaContent(organization.image?.contentUrl)}
+                                icon={getMediaContent(organization.image ?? undefined, "SMALL")}
                                 text={organization.name}
                             />
                             <span className={styles.name}>

--- a/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
+++ b/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
@@ -97,7 +97,7 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
         const renderReviews = reviews.map((review) => (
             <ReviewWidget
                 name={getFullName(review.author.firstName, review.author.lastName)}
-                avatar={getMediaContent(review.author.image?.thumbnails?.small)}
+                avatar={getMediaContent(review.author.image ?? undefined, "SMALL")}
                 reviewText={review.description}
                 stars={review.rating}
                 url={getVolunteerPersonalPageUrl(locale, review.author.id)}

--- a/src/entities/Offer/ui/OfferTermsCard/ui/OfferTermsCard/OfferTermsCard.tsx
+++ b/src/entities/Offer/ui/OfferTermsCard/ui/OfferTermsCard/OfferTermsCard.tsx
@@ -42,7 +42,7 @@ export const OfferTermsCard: FC<OfferTermsCardProps> = memo(
             housingItems: HouseImageObject[],
         ) => housingItems.map((item) => (
             <TermsCard
-                icon={getMediaContent(item.image.contentUrl) ?? ""}
+                icon={getMediaContent(item.image, "SMALL") ?? ""}
                 text={getTranslation(item.name) ?? ""}
                 key={item.id}
             />
@@ -52,7 +52,7 @@ export const OfferTermsCard: FC<OfferTermsCardProps> = memo(
             paidTravelItems: TransferImageObject[],
         ) => paidTravelItems.map((item) => (
             <TermsCard
-                icon={getMediaContent(item.image.contentUrl) ?? ""}
+                icon={getMediaContent(item.image, "SMALL") ?? ""}
                 text={getTranslation(item.name) ?? ""}
                 key={item.id}
             />
@@ -62,7 +62,7 @@ export const OfferTermsCard: FC<OfferTermsCardProps> = memo(
             nutritionItems: FoodImageObject[],
         ) => nutritionItems.map((item) => (
             <TermsCard
-                icon={getMediaContent(item.image.contentUrl) ?? ""}
+                icon={getMediaContent(item.image, "SMALL") ?? ""}
                 text={getTranslation(item.name) ?? ""}
                 key={item.id}
             />

--- a/src/entities/Offer/ui/OfferWhatToDoCard/OfferWhatToDoCard.tsx
+++ b/src/entities/Offer/ui/OfferWhatToDoCard/OfferWhatToDoCard.tsx
@@ -35,7 +35,7 @@ export const OfferWhatToDoCard: FC<OfferWhatToDoCardProps> = memo(
         const renderSkillsCard = useMemo(() => skills.map((item) => (
             <IconTextComponent
                 text={getTranslation(item.name) ?? ""}
-                icon={getMediaContent(item.image.contentUrl) ?? ""}
+                icon={getMediaContent(item.image, "SMALL") ?? ""}
                 alt={item.name}
                 key={item.id}
             />

--- a/src/entities/Review/ui/HostModalReview/HostModalReview.tsx
+++ b/src/entities/Review/ui/HostModalReview/HostModalReview.tsx
@@ -56,7 +56,7 @@ export const HostModalReview: FC<HostModalReviewProps> = (props) => {
                         volunteerId: review.id,
                         firstName: review.firstName,
                         lastName: review.lastName,
-                        image: getMediaContent(review.image?.thumbnails?.small),
+                        image: getMediaContent(review.image ?? undefined, "SMALL"),
                         city: review.city,
                         country: review.country,
                         applicationStatus: review.statusApplication,

--- a/src/entities/Review/ui/VolunteerModalReview/VolunteerModalReview.tsx
+++ b/src/entities/Review/ui/VolunteerModalReview/VolunteerModalReview.tsx
@@ -52,7 +52,7 @@ export const VolunteerModalReview: FC<VolunteerModalReviewProps> = (props) => {
                     data={{
                         offerId: application.id,
                         name: application.name,
-                        image: getMediaContent(application.image?.contentUrl),
+                        image: getMediaContent(application.image ?? undefined, "MEDIUM"),
                         address: application.address,
                         applicationStatus: application.applicationStatus,
                         categoryName: application.categories[0]?.name,

--- a/src/entities/Volunteer/ui/AchievementModal/AchievementModal.tsx
+++ b/src/entities/Volunteer/ui/AchievementModal/AchievementModal.tsx
@@ -24,7 +24,7 @@ export const AchievementModal: FC<AchievementModalProps> = (props) => {
         <div className={styles.medal} key={medal.id}>
             <img
                 className={styles.medalIcon}
-                src={getMediaContent(medal.image.contentUrl)}
+                src={getMediaContent(medal.image, "SMALL")}
                 alt={medal.name}
             />
             <span>{medal.name}</span>

--- a/src/entities/Volunteer/ui/VolunteerHostCard/VolunteerHostCard.tsx
+++ b/src/entities/Volunteer/ui/VolunteerHostCard/VolunteerHostCard.tsx
@@ -36,7 +36,7 @@ export const VolunteerHostCard: FC<VolunteerHostCardProps> = memo(
                             variant="DEFAULT"
                             className={styles.nameContainer}
                         >
-                            <Avatar icon={getMediaContent(host.avatar?.contentUrl)} text={host.name} size="SMALL" />
+                            <Avatar icon={getMediaContent(host.avatar, "SMALL")} text={host.name} size="SMALL" />
                             <span className={styles.name}>
                                 {host.name}
                             </span>

--- a/src/entities/Volunteer/ui/VolunteerReviewsCard/VolunteerReviewsCard.tsx
+++ b/src/entities/Volunteer/ui/VolunteerReviewsCard/VolunteerReviewsCard.tsx
@@ -68,7 +68,7 @@ export const VolunteerReviewsCard: FC<VolunteerReviewsCardProps> = memo(
         const renderReviews = reviews.map((review) => (
             <ReviewWidget
                 name={review.name}
-                avatar={getMediaContent(review.image?.thumbnails?.small)}
+                avatar={getMediaContent(review.image ?? undefined, "SMALL")}
                 reviewText={review.description}
                 stars={review.rating}
                 url={getHostPersonalPageUrl(locale, review.id)}

--- a/src/entities/Volunteer/ui/VolunteerSkillsCard/VolunteerSkillsCard.tsx
+++ b/src/entities/Volunteer/ui/VolunteerSkillsCard/VolunteerSkillsCard.tsx
@@ -31,7 +31,7 @@ export const VolunteerSkillsCard: FC<VolunteerSkillsCardProps> = memo(
             return skills.map((item) => (
                 <IconTextComponent
                     text={getTranslation(item.name) ?? ""}
-                    icon={getMediaContent(item.image.contentUrl) ?? ""}
+                    icon={getMediaContent(item.image, "SMALL") ?? ""}
                     alt={item.name}
                     key={item.id}
                 />

--- a/src/features/Review/ui/ReviewCardOffer/ReviewCardOffer.tsx
+++ b/src/features/Review/ui/ReviewCardOffer/ReviewCardOffer.tsx
@@ -43,7 +43,7 @@ export const ReviewCardOffer: FC<ReviewCardOfferProps> = (props: ReviewCardOffer
                     {vacancy.image?.thumbnails?.small ? (
                         <img
                             className={styles.img}
-                            src={getMediaContent(vacancy.image?.thumbnails?.small)}
+                            src={getMediaContent(vacancy.image ?? undefined, "SMALL")}
                             alt="offer"
                         />
                     ) : (
@@ -72,7 +72,7 @@ export const ReviewCardOffer: FC<ReviewCardOfferProps> = (props: ReviewCardOffer
                 <span className={styles.ratingNum}>{rating}</span>
                 <div className={styles.avatarInfoUser} onClick={navigateToVolunteer}>
                     <Avatar
-                        icon={getMediaContent(author?.image?.thumbnails?.small)}
+                        icon={getMediaContent(author?.image ?? undefined, "SMALL")}
                         text={getFullName(author?.firstName, author?.lastName)}
                         alt="avatar"
                         className={styles.avatar}

--- a/src/features/Review/ui/ReviewFullCard/ReviewFullCard.tsx
+++ b/src/features/Review/ui/ReviewFullCard/ReviewFullCard.tsx
@@ -21,7 +21,7 @@ export const ReviewFullCard: FC<ReviewFullCardProps> = (props: ReviewFullCardPro
     } = review;
     const { getFullName } = useGetFullName();
     const userName = getFullName(volunteer.firstName, volunteer.lastName);
-    const image = getMediaContent(volunteer.image?.thumbnails?.small);
+    const image = getMediaContent(volunteer.image ?? undefined, "SMALL");
     const fullAddress = getFullAddress(volunteer.city, volunteer.country);
 
     return (

--- a/src/features/Review/ui/ReviewHostCardOffer/ReviewHostCardOffer.tsx
+++ b/src/features/Review/ui/ReviewHostCardOffer/ReviewHostCardOffer.tsx
@@ -42,7 +42,7 @@ export const ReviewHostCardOffer: FC<ReviewHostCardOfferProps> = (
                     <span className={styles.title}>{vacancy.name}</span>
                     <img
                         className={styles.img}
-                        src={getMediaContent(vacancy.image.thumbnails?.small)}
+                        src={getMediaContent(vacancy.image, "SMALL")}
                         alt="offer"
                     />
                 </div>
@@ -68,7 +68,7 @@ export const ReviewHostCardOffer: FC<ReviewHostCardOfferProps> = (
                 <span className={styles.ratingNum}>{rating}</span>
                 <div className={styles.avatarInfoUser} onClick={navigateToVolunteer}>
                     <Avatar
-                        icon={getMediaContent(author.image?.thumbnails?.small)}
+                        icon={getMediaContent(author.image ?? undefined, "SMALL")}
                         text={getFullName(author.firstName, author.lastName)}
                         alt="avatar"
                         className={styles.avatar}

--- a/src/pages/DonationPayPage/ui/DonationPayPage/DonationPayPage.tsx
+++ b/src/pages/DonationPayPage/ui/DonationPayPage/DonationPayPage.tsx
@@ -89,9 +89,7 @@ const DonationPayPage: React.FC = () => {
         );
     }
 
-    const imageUrl = fundraise?.image?.contentUrl
-        ? getMediaContent(fundraise.image.contentUrl)
-        : undefined;
+    const imageUrl = getMediaContent(fundraise?.image ?? undefined, "MEDIUM");
 
     return (
         <MainPageLayout>

--- a/src/pages/DonationPersonalPage/ui/DonationPersonalCard/DonationPersonalCard.tsx
+++ b/src/pages/DonationPersonalPage/ui/DonationPersonalCard/DonationPersonalCard.tsx
@@ -39,7 +39,7 @@ export const DonationPersonalCard = memo((props: DonationPersonalCardProps) => {
         <>
             <HeaderDonationCard
                 donationId={id}
-                image={getMediaContent(donationData.image?.contentUrl)}
+                image={getMediaContent(donationData.image ?? undefined, "LARGE")}
                 title={donationData.name}
                 location={donationData.address}
                 isSuccess={donationData.isSuccess}

--- a/src/pages/HostPersonalPage/ui/HostlHeaderCard/HostlHeaderCard.tsx
+++ b/src/pages/HostPersonalPage/ui/HostlHeaderCard/HostlHeaderCard.tsx
@@ -72,7 +72,7 @@ export const HostlHeaderCard: FC<HostlHeaderCardProps> = memo(
         return (
             <div className={styles.wrapper}>
                 <Avatar
-                    icon={getMediaContent(avatar)}
+                    icon={getMediaContent(avatar, "MEDIUM")}
                     text={name}
                     size="DEFAULT"
                     className={styles.image}

--- a/src/pages/OfferPersonalPage/ui/OfferPersonalCard/OfferPersonalCard.tsx
+++ b/src/pages/OfferPersonalPage/ui/OfferPersonalCard/OfferPersonalCard.tsx
@@ -44,7 +44,7 @@ export const OfferPersonalCard = memo((props: OfferPersonalCardProps) => {
         <>
             <PersonalCard
                 offerId={id}
-                image={getMediaContent(offerData.description?.image?.contentUrl)}
+                image={getMediaContent(offerData.description?.image ?? undefined, "LARGE")}
                 title={offerData.description?.title}
                 location={offerData.where?.address}
                 reviewsCount={offerData.reviewsCount}

--- a/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.tsx
+++ b/src/pages/VolunteerPersonalPage/ui/VolunteerHeaderCard/VolunteerHeaderCard.tsx
@@ -92,7 +92,7 @@ export const VolunteerHeaderCard: FC<VolunteerHeaderCardProps> = memo(
                         <div className={styles.medal} key={medal.id}>
                             <img
                                 className={styles.medalIcon}
-                                src={getMediaContent(medal.image.contentUrl)}
+                                src={getMediaContent(medal.image, "SMALL")}
                                 alt={medal.name}
                             />
                             <span>{medal.name}</span>
@@ -120,7 +120,7 @@ export const VolunteerHeaderCard: FC<VolunteerHeaderCardProps> = memo(
                     <div className={styles.medal} key={medal.id}>
                         <img
                             className={styles.medalIcon}
-                            src={getMediaContent(medal.image.contentUrl)}
+                            src={getMediaContent(medal.image, "SMALL")}
                             alt={medal.name}
                         />
                         <span>{medal.name}</span>
@@ -170,7 +170,7 @@ export const VolunteerHeaderCard: FC<VolunteerHeaderCardProps> = memo(
                 <div className={styles.wrapper}>
                     <div className={styles.mainInfo}>
                         <Avatar
-                            icon={getMediaContent(image?.contentUrl)}
+                            icon={getMediaContent(image ?? undefined, "MEDIUM")}
                             text={renderName}
                             className={styles.image}
                             alt="avatar"

--- a/src/widgets/MainHeader/MainHeaderProfile/MainHeaderProfile.tsx
+++ b/src/widgets/MainHeader/MainHeaderProfile/MainHeaderProfile.tsx
@@ -88,7 +88,7 @@ const MainHeaderProfile: FC<MainHeaderProfileProps> = (props) => {
                 {textSlice(profileData.firstName, 13, "none") || textSlice(profileData.email, 13, "none")}
             </p>
             <Avatar
-                icon={getMediaContent(profileData.image?.contentUrl)}
+                icon={getMediaContent(profileData.image ?? undefined, "SMALL")}
                 text={profileData.firstName}
                 alt="avatar"
                 size="SMALL"

--- a/src/widgets/Messenger/ui/Chat/Chat.tsx
+++ b/src/widgets/Messenger/ui/Chat/Chat.tsx
@@ -251,14 +251,15 @@ export const Chat: FC<ChatProps> = (props) => {
                             effectiveCompanion?.firstName,
                             effectiveCompanion?.lastName,
                         );
-                        userAvatar = getMediaContent(effectiveCompanion?.image?.contentUrl);
+                        userAvatar = getMediaContent(effectiveCompanion?.image ?? undefined, "SMALL");
                     } else {
                         userName = getFullName(
                             myProfileData.firstName,
                             myProfileData.lastName,
                         );
                         userAvatar = getMediaContent(
-                            myProfileData.image?.contentUrl,
+                            myProfileData.image ?? undefined,
+                            "SMALL",
                         );
                     }
 

--- a/src/widgets/Messenger/ui/Message/Message.tsx
+++ b/src/widgets/Messenger/ui/Message/Message.tsx
@@ -177,7 +177,7 @@ export const Message: FC<MessageProps> = memo((props: MessageProps) => {
                     {isUser && <span className={styles.name}>{username}</span>}
                     <img
                         className={styles.image}
-                        src={getMediaContent(image)}
+                        src={getMediaContent(image, "MEDIUM")}
                         alt=""
                         onClick={() => onImageClick?.(getMediaContent(image) ?? "")}
                     />


### PR DESCRIPTION
## Контекст (аналитика медиа)

Из 113 мест вызова `getMediaContent` только 15 запрашивали размер миниатюры; ~51 передавали голую строку `.contentUrl` — для них миниатюры структурно недостижимы (функция достаёт `.thumbnails` только из полного объекта). Реальный пример выигрыша: оригинал 1.16MB → WebP-миниатюра large 9.2KB (~126x).

## Что сделано (батч 1 — самые трафиковые места)

Переведены на полный объект + явный размер (`SMALL` 56×56 / `MEDIUM` 307×222 / `LARGE` 480×360 под фактический размер отображения):

- Аватар профиля в хедере (грузится на каждой странице у залогиненных)
- Хиро-фото вакансии + аватар организации на странице вакансии
- Персональные страницы волонтёра/организации/сбора (аватары, медали, хиро)
- Мессенджер: список диалогов, аватары собеседников, инлайн-картинки в сообщениях
- Все карточки отзывов (7 компонентов)
- Иконки условий/навыков (SVG — внутри `getMediaContent` корректно фолбэчатся на оригинал, т.к. растровых миниатюр у них нет)

## Сознательно НЕ тронуто

- `og:image`/SEO (краулерам нужен оригинал)
- Ссылки на скачивание файлов в чате
- Клик по картинке в чате (лайтбокс открывает оригинал — намеренно)

## Проверка

- typecheck + eslint чистые, 26 существующих тестов в затронутых областях проходят
- Живая проверка через dev-proxy на стейдж-данных: хиро вакансии 7211 теперь грузит `thumbnails/large/*.webp` (200 OK) вместо оригинала
- SVG `ERR_FAILED` в локальной проверке — это CORS-артефакт localhost-origin (проверено curl: со стейдж-origin `access-control-allow-origin` отдаётся, URL иконок моим фиксом не менялся)

## Связанное

Бэкенд-половина: Goodsurfing/gs-backend#276 (перегенерация ~43.5k фейковых легаси-миниатюр, где thumbnails указывают на оригинал). До её прогона легаси-фото так и будут отдаваться оригиналами даже с этим фиксом — фикс двусторонний.
