### PR TITLE
Admin unpublish sets vacancy status to disabled, not draft

### DIFF
--- a/src/widgets/Admin/ui/AdminOffersTable/AdminOffersTable.tsx
+++ b/src/widgets/Admin/ui/AdminOffersTable/AdminOffersTable.tsx
@@ -223,9 +223,13 @@ export const AdminOffersTable = () => {
         if (!offerToPublish) return;
 
         try {
+            // "disabled", а не "draft": перевод в draft бэкенд запрещает
+            // для вакансий с заявками (валидная бизнес-логика для
+            // черновиков), а disabled скрывает вакансию из публичных
+            // списков без этого ограничения
             await publishOffer({
                 id: offerToPublish.id,
-                status: offerToPublish.isActive ? "draft" : "active",
+                status: offerToPublish.isActive ? "disabled" : "active",
             }).unwrap();
             setToast({
                 text: `Вакансия была успешна ${offerToPublish.isActive ? "распубликована" : "опубликована"}`,


### PR DESCRIPTION
## Проблема

"Распубликовать" в админской таблице вакансий отправляла `status=draft`, а бэкенд запрещает перевод в draft для вакансий с заявками — то есть именно те тестовые вакансии, на которые кто-то успел откликнуться, было невозможно скрыть (кнопка падала с ошибкой). Оставалось только жёсткое удаление.

## Фикс

"Распубликовать" теперь ставит `disabled`: без ограничения по заявкам, и в паре с бэкенд-фиксом (Goodsurfing/gs-backend#278 — публичные списки показывают только `active`) вакансия реально исчезает из списка, с карты и из счётчиков категорий. Владелец при этом может открыть её по прямой ссылке (превью), удаление не требуется.
