### PR TITLE
Restructure *-personal routes, match Api/V3 element URL rename

### DIFF
--- a/src/entities/Academy/api/courseApi.ts
+++ b/src/entities/Academy/api/courseApi.ts
@@ -29,7 +29,7 @@ export const courseApi = createApi({
         }),
         getCourseById: build.query<GetCourse, string>({
             query: (courseId) => ({
-                url: `course/element/${courseId}`,
+                url: `course/${courseId}`,
                 method: "GET",
             }),
             providesTags: ["course"],
@@ -44,7 +44,7 @@ export const courseApi = createApi({
         // Review on lessons
         getReviewsLesson: build.query<GetReviewsLessonResponse, GetReviewsLessonRequest>({
             query: ({ videoCourseId, page, limit }) => ({
-                url: `review/video-course/list/${videoCourseId}`,
+                url: `review-video-course/list/${videoCourseId}`,
                 method: "GET",
                 params: { page, limit },
             }),
@@ -52,7 +52,7 @@ export const courseApi = createApi({
         }),
         createReviewLesson: build.mutation<void, CreateReviewLessonRequest>({
             query: (body) => ({
-                url: "review/video-course/create",
+                url: "review-video-course/create",
                 method: "POST",
                 body,
             }),
@@ -69,7 +69,7 @@ export const courseApi = createApi({
         }),
         getCourseLessonById: build.query<GetLesson, string>({
             query: (courseId) => ({
-                url: `video-course/element/${courseId}`,
+                url: `video-course/${courseId}`,
                 method: "GET",
             }),
             providesTags: ["course"],

--- a/src/entities/Admin/api/adminCourseApi.ts
+++ b/src/entities/Admin/api/adminCourseApi.ts
@@ -64,7 +64,7 @@ export const adminCourseApi = createApi({
         getAdminReviewsCourses: build.query<GetAdminReviewsCoursesResponse,
         Partial<GetAdminReviewsCoursesParams>>({
             query: (params) => ({
-                url: "review/video-course/list",
+                url: "review-video-course/list",
                 method: "GET",
                 params,
             }),
@@ -72,14 +72,14 @@ export const adminCourseApi = createApi({
         }),
         getAdminReviewLessonById: build.query<GetAdminReviewLesson, string>({
             query: (reviewId) => ({
-                url: `review/video-course/element/${reviewId}`,
+                url: `review-video-course/element/${reviewId}`,
                 method: "GET",
             }),
             providesTags: ["review"],
         }),
         updateAdminReviewLesson: build.mutation<void, UpdateAdminReviewCourseRequest>({
             query: ({ id, body }) => ({
-                url: `review/video-course/edit/${id}`,
+                url: `review-video-course/edit/${id}`,
                 method: "PATCH",
                 body,
             }),
@@ -87,7 +87,7 @@ export const adminCourseApi = createApi({
         }),
         deleteAdminReviewLesson: build.mutation<void, number>({
             query: (reviewId) => ({
-                url: `review/video-course/${reviewId}`,
+                url: `review-video-course/${reviewId}`,
                 method: "DELETE",
             }),
             invalidatesTags: ["review"],

--- a/src/entities/Blog/api/blogApi.ts
+++ b/src/entities/Blog/api/blogApi.ts
@@ -30,7 +30,7 @@ export const blogApi = createApi({
         }),
         getBlogById: build.query<GetBlog, GetBlogParams>({
             query: ({ id, lang }) => ({
-                url: `blog/element/${id}`,
+                url: `blog/${id}`,
                 method: "GET",
                 params: { lang },
             }),

--- a/src/entities/Donation/api/donationApi.ts
+++ b/src/entities/Donation/api/donationApi.ts
@@ -30,7 +30,7 @@ export const donationApi = createApi({
         }),
         getDonationById: build.query<GetDonation, GetDonationParams>({
             query: ({ id, lang }) => ({
-                url: `fundraise/element/${id}`,
+                url: `fundraise/${id}`,
                 method: "GET",
                 params: { lang },
             }),

--- a/src/entities/Journal/api/journalApi.ts
+++ b/src/entities/Journal/api/journalApi.ts
@@ -20,7 +20,7 @@ export const journalApi = createApi({
         }),
         getJournalById: build.query<GetJournal, string>({
             query: (id) => ({
-                url: `journal/element/${id}`,
+                url: `journal/${id}`,
                 method: "GET",
             }),
             providesTags: ["journal"],

--- a/src/entities/News/api/newsApi.ts
+++ b/src/entities/News/api/newsApi.ts
@@ -22,7 +22,7 @@ export const newsApi = createApi({
         }),
         getNewsById: build.query<GetNewsList, GetNewsParams>({
             query: ({ id, lang }) => ({
-                url: `news/element/${id}`,
+                url: `news/${id}`,
                 method: "GET",
                 params: { lang },
             }),

--- a/src/entities/Video/api/videoApi.ts
+++ b/src/entities/Video/api/videoApi.ts
@@ -24,7 +24,7 @@ export const videoApi = createApi({
         }),
         getVideoById: build.query<GetVideo, GetVideoParams>({
             query: ({ id, lang }) => ({
-                url: `video/element/${id}`,
+                url: `video/${id}`,
                 method: "GET",
                 params: { lang },
             }),

--- a/src/routes/model/config/RoutesConfig.tsx
+++ b/src/routes/model/config/RoutesConfig.tsx
@@ -1,3 +1,4 @@
+import { LegacyIdRedirect } from "@/shared/ui/LegacyIdRedirect/LegacyIdRedirect";
 import { AboutProjectPage } from "@/pages/AboutProjectPage";
 import { CategoriesPage } from "@/pages/CategoriesPage";
 import { ConfirmEmailPage } from "@/pages/ConfirmEmailPage";
@@ -487,6 +488,11 @@ const publicRoutes: RouteType[] = [
         path: (locale: string) => getHostPersonalPageUrl(locale),
     },
     {
+        label: "host-personal-legacy-redirect",
+        element: <LegacyIdRedirect to={getHostPersonalPageUrl} />,
+        path: (locale: string) => `/${locale}/host-personal/:id`,
+    },
+    {
         label: "fundraise-layout",
         element: AuthRoutes.fundraise,
         path: (locale: string) => getFundraisePageUrl(locale),
@@ -556,9 +562,19 @@ const publicRoutes: RouteType[] = [
         path: (locale: string) => getOfferPersonalPageUrl(locale),
     },
     {
+        label: "offer-personal-legacy-redirect",
+        element: <LegacyIdRedirect to={getOfferPersonalPageUrl} />,
+        path: (locale: string) => `/${locale}/offer-personal/:id`,
+    },
+    {
         label: "volunteer-personal",
         element: <VolunteerPersonalPage />,
         path: (locale: string) => getVolunteerPersonalPageUrl(locale),
+    },
+    {
+        label: "volunteer-personal-legacy-redirect",
+        element: <LegacyIdRedirect to={getVolunteerPersonalPageUrl} />,
+        path: (locale: string) => `/${locale}/volunteer-personal/:id`,
     },
     {
         label: "volunteer-layout",
@@ -798,6 +814,11 @@ const publicRoutes: RouteType[] = [
         label: "donation-personal",
         element: <DonationPersonalPage />,
         path: (locale: string) => getDonationPersonalPage(locale),
+    },
+    {
+        label: "donation-personal-legacy-redirect",
+        element: <LegacyIdRedirect to={getDonationPersonalPage} />,
+        path: (locale: string) => `/${locale}/donation-personal/:id`,
     },
     {
         label: "donation-reports",

--- a/src/shared/config/routes/RouterConfig.ts
+++ b/src/shared/config/routes/RouterConfig.ts
@@ -29,8 +29,8 @@ export const RoutePath: Record<AppRoutes, string> = {
     [AppRoutes.PROFILE_RESET_PASSWORD]: "/profile/reset-password",
     [AppRoutes.PROFILE_PRIVACY]: "/profile/privacy",
     [AppRoutes.HOST]: "/host",
-    [AppRoutes.OFFER_PERSONAL]: "/offer-personal", // :id
-    [AppRoutes.HOST_PERSONAL]: "/host-personal", // :id
+    [AppRoutes.OFFER_PERSONAL]: "/offers", // :id — публичная карточка вакансии
+    [AppRoutes.HOST_PERSONAL]: "/organizations", // :id — публичный профиль организации (не путать с /host — это кабинет своей)
     [AppRoutes.HOST_DASHBOARD]: "/host/host-dashboard",
     [AppRoutes.HOST_REGISTER]: "/host/register",
     [AppRoutes.HOST_INFO]: "/host/info",
@@ -64,7 +64,7 @@ export const RoutePath: Record<AppRoutes, string> = {
     [AppRoutes.VOLUNTEER_GALLERY]: "/volunteer/gallery",
     [AppRoutes.VOLUNTEER_CREATE_ARTICLE]: "/volunteer/create-article",
     [AppRoutes.VOLUNTEER_ARTICLES]: "/volunteer/articles",
-    [AppRoutes.VOLUNTEER_PERSONAL]: "/volunteer-personal", // :id
+    [AppRoutes.VOLUNTEER_PERSONAL]: "/volunteers", // :id — публичный профиль волонтёра (не путать с /volunteer — это кабинет своего)
     [AppRoutes.MEMBERSHIP]: "/membership",
     [AppRoutes.PAYMENT]: "/payment",
     [AppRoutes.PAYMENT_SUCCESS]: "/payment/success",
@@ -87,7 +87,7 @@ export const RoutePath: Record<AppRoutes, string> = {
     [AppRoutes.ACADEMY_COURSE]: "/academy-course",
     [AppRoutes.ACADEMY_LESSON]: "/academy-lesson",
     [AppRoutes.DONATION_MAP]: "/donation-map",
-    [AppRoutes.DONATION_PERSONAL]: "/donation-personal",
+    [AppRoutes.DONATION_PERSONAL]: "/fundraise", // :id — публичная карточка сбора (несмотря на имя роута, это Fundraise, не Donation; см. AppUrls.ts)
     [AppRoutes.DONATION_REPORTS]: "/donation-reports",
     [AppRoutes.DONATION_RATING]: "/donation-rating",
     [AppRoutes.DONATION_PAY]: "/donation/pay",

--- a/src/shared/ui/LegacyIdRedirect/LegacyIdRedirect.tsx
+++ b/src/shared/ui/LegacyIdRedirect/LegacyIdRedirect.tsx
@@ -1,0 +1,18 @@
+import { Navigate, useParams } from "react-router-dom";
+import { useLocale } from "@/app/providers/LocaleProvider";
+
+interface LegacyIdRedirectProps {
+    to: (locale: string, id: string) => string;
+}
+
+/**
+ * Роуты вида /offer-personal/:id переехали на вложенные пути (/offers/:id).
+ * Компонент держит старый путь рабочим (уже расшаренные ссылки не должны
+ * ломаться), просто 301-подобно перенаправляя на новый.
+ */
+export const LegacyIdRedirect = ({ to }: LegacyIdRedirectProps) => {
+    const { locale } = useLocale();
+    const { id } = useParams<{ id: string }>();
+
+    return <Navigate to={to(locale, id ?? "")} replace />;
+};


### PR DESCRIPTION
## Что и зачем

Парная часть к gs-backend#283 — готовим URL-схему к разработке мобильного приложения.

1. **API-клиенты**: `element/{id}` → `{id}` для blog/course/fundraise/journal/news/video/video-course, `review/video-course` → `review-video-course` — синхронно с бэкендом.
2. **Реструктуризация публичных detail-страниц**: раньше они жили на отдельных плоских урлах, не вложенных под свой ресурс:
   - `/offer-personal/:id` → `/offers/:id`
   - `/host-personal/:id` → `/organizations/:id` (не `/host/:id` — `/host/*` это кабинет **своей** организации, публичный профиль **чужой** организации не должен жить в том же префиксе)
   - `/volunteer-personal/:id` → `/volunteers/:id` (та же причина: `/volunteer/*` — кабинет своего профиля)
   - `/donation-personal/:id` → `/fundraise/:id` — заодно чиним найденный по пути баг в неймиге: страница всегда принимала `fundraiseId`, а не `donationId`, то есть это карточка сбора, а не пожертвования; переносим под уже существующий `/fundraise`
3. Старые `*-personal` урлы продолжают работать — редиректят на новые через `LegacyIdRedirect` (уже расшаренные ссылки не ломаются).

## Проверено
- `tsc --noEmit`: чисто.
- `eslint` по всем изменённым файлам: чисто.
- `vitest run`: 244/244, 83 файла, без регрессий.
- Живая проверка на dev-сервере (Playwright): все 4 редиректа со старых урлов на новые подтверждены построково, плюс убедился, что соседние роуты (`/offers` — мастер вакансии, `/offers/where/:id`, `/fundraise/welcome/:id`) не задеты — корректно уходят на auth guard, не перехватываются новыми `:id`-роутами.

## Не входит в этот PR
См. gs-backend#283 — миграция v1→v3 write-эндпоинтов и добавление slug'ов для Organization/Fundraise/Video/Course/VideoCourse/Vacancy это отдельные, более крупные проекты.
