### PR TITLE
Rename gudserfing -> about-project API calls

### DIFF
--- a/src/entities/Admin/api/adminApi.ts
+++ b/src/entities/Admin/api/adminApi.ts
@@ -719,14 +719,14 @@ export const adminApi = createApi({
         }),
         getAdminVacancyWhoNeeds: build.query<AdminVacancyWhoNeeds, string>({
             query: (offerId) => ({
-                url: `vacancy/how-need/${offerId}`,
+                url: `vacancy/who-needs/${offerId}`,
                 method: "GET",
             }),
             providesTags: ["offer"],
         }),
         updateAdminVacancyWhoNeeds: build.mutation<void, UpdateAdminVacancyWhoNeedsRequest>({
             query: ({ offerId, body }) => ({
-                url: `vacancy/how-need/${offerId}`,
+                url: `vacancy/who-needs/${offerId}`,
                 method: "PATCH",
                 body,
             }),
@@ -787,7 +787,7 @@ export const adminApi = createApi({
         }),
         getAdminVacancyFinishingTouches: build.query<AdminVacancyFinishingTouches, string>({
             query: (offerId) => ({
-                url: `vacancy/finish-touche/${offerId}`,
+                url: `vacancy/finishing-touches/${offerId}`,
                 method: "GET",
             }),
             providesTags: ["offer"],
@@ -795,7 +795,7 @@ export const adminApi = createApi({
         updateAdminVacancyFinishingTouches: build.mutation<void,
         UpdateAdminVacancyFinishingTouchesRequest>({
             query: ({ offerId, body }) => ({
-                url: `vacancy/finish-touche/${offerId}`,
+                url: `vacancy/finishing-touches/${offerId}`,
                 method: "PATCH",
                 body,
             }),

--- a/src/entities/Admin/api/adminApi.ts
+++ b/src/entities/Admin/api/adminApi.ts
@@ -870,14 +870,14 @@ export const adminApi = createApi({
         // About project
         getAbouProjectPageInfo: build.query<GetAboutProjectInfo, void>({
             query: () => ({
-                url: `${API_BASE_URL_V3}gudserfing/element`,
+                url: `${API_BASE_URL_V3}about-project/element`,
                 method: "GET",
             }),
             providesTags: ["about"],
         }),
         getAdminAbouProjectPageInfo: build.query<GetAdminAboutProjectInfo, void>({
             query: () => ({
-                url: "gudserfing/element",
+                url: "about-project/element",
                 method: "GET",
             }),
             providesTags: ["about"],
@@ -885,7 +885,7 @@ export const adminApi = createApi({
         updateAdminAbouProjectPageInfo: build.mutation<void,
         UpdateAdminAboutProjectInfo>({
             query: (body) => ({
-                url: "gudserfing/edit",
+                url: "about-project/edit",
                 method: "PATCH",
                 body,
             }),


### PR DESCRIPTION
Парный PR к gs-backend#285. `gudserfing/element`, `gudserfing/edit` → `about-project/element`, `about-project/edit` в `adminApi.ts` — синхронно с бэкендом.

Проверено: `tsc --noEmit` и `eslint` чистые.