### PR TITLE
Redesign preloader around the GoodSurfing logo

### DIFF
--- a/src/shared/ui/Preloader/Preloader.module.scss
+++ b/src/shared/ui/Preloader/Preloader.module.scss
@@ -3,43 +3,43 @@
     top: 0;
     width: 100vw;
     height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .preloader {
-    svg {
-        width: 100%;
-        height: 100%;
-    }
-
-    position: absolute;
-	width: 102px;
-	height: 102px;
-	left: 50%;
-	top: 50%;
-	min-height: 102px;
-	transform: translateX(-50%) translateY(-50%);
-
-    .smallCircle {
-        stroke-dasharray: 210;
-        stroke-dashoffset: 210;
-        transform-origin: 50%;
-        animation: 1s draw-small infinite alternate;
-    }
-
-    .bigCircle {
-        stroke-dasharray: 240;
-        stroke-dashoffset: 240;
-        transform-origin: 50%;
-        animation: 1s draw-big infinite alternate 0.5s;
-    }
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
 }
 
-@keyframes draw-small {
-	0% { stroke-dashoffset: 0; transform: rotate(0deg); }
-	100% { stroke-dashoffset: 210; transform: rotate(360deg); }
+.logo {
+    width: 140px;
+    height: auto;
+    animation: bob 1.6s ease-in-out infinite;
 }
 
-@keyframes draw-big {
-	0% { stroke-dashoffset: 0; transform: rotateY(180deg) rotate(360deg); }
-	100% { stroke-dashoffset: 240; transform: rotateY(180deg) rotate(0deg); }
+.waveViewport {
+    width: 120px;
+    height: 12px;
+    overflow: hidden;
+}
+
+.wave {
+    display: block;
+    width: 240px;
+    height: 12px;
+    animation: scroll-wave 1.6s linear infinite;
+}
+
+@keyframes bob {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-8px); }
+}
+
+@keyframes scroll-wave {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-120px); }
 }

--- a/src/shared/ui/Preloader/Preloader.tsx
+++ b/src/shared/ui/Preloader/Preloader.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import cn from "classnames";
 
+import logoIcon from "@/shared/assets/icons/logo-black.svg";
 import styles from "./Preloader.module.scss";
 
 interface PreloaderProps {
@@ -12,24 +13,23 @@ interface PreloaderProps {
 const Preloader = ({ className, preloader }: PreloaderProps) => (
     <div className={cn(styles.layout, className)}>
         <div className={cn(preloader, styles.preloader)}>
-            <svg
-                viewBox="0 0 102 102"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-            >
-                <path
-                    className={styles.bigCircle}
-                    d="M101 51C101 78.6142 78.6142 101 51 101C23.3858 101 1 78.6142 1 51"
-                    stroke="#252525"
-                    strokeWidth="2"
-                />
-                <path
-                    className={styles.smallCircle}
-                    d="M91 51C91 28.9086 73.0914 11 51 11C28.9086 11 11 28.9086 11 51"
-                    stroke="#252525"
-                    strokeWidth="2"
-                />
-            </svg>
+            <img src={logoIcon} alt="GoodSurfing" className={styles.logo} />
+            <div className={styles.waveViewport}>
+                <svg
+                    className={styles.wave}
+                    viewBox="0 0 240 24"
+                    fill="none"
+                    preserveAspectRatio="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        d="M0 12 C 15 2, 45 2, 60 12 C 75 22, 105 22, 120 12 C 135 2, 165 2, 180 12 C 195 22, 225 22, 240 12"
+                        stroke="#00A0A8"
+                        strokeWidth="2.5"
+                        strokeLinecap="round"
+                    />
+                </svg>
+            </div>
         </div>
     </div>
 );


### PR DESCRIPTION
Заменил generic-спиннер (два вращающихся кольца) на брендированный лоадер: логотип мягко покачивается над бегущей бирюзовой волной (отсылка к "surfing"). Чисто визуальное изменение, `Preloader` используется как есть — API компонента не менялся.

Проверено:
- `tsc --noEmit`, `eslint` — чисто
- `vitest run` — 244/244, без регрессий
- Живой скриншот на dev-сервере (Playwright) — анимация плавная, переход на реальную страницу после лоадера работает штатно
