### PR TITLE
Center offers map zoom control on right edge, shrink map gutter

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
@@ -19,7 +19,7 @@
 // небольшой гаттер от края экрана — без него карта упирается прямо в
 // правую границу viewport, а список слева отступ имеет.
 .offersMap {
-    margin-right: 20px;
+    margin-right: 10px;
 }
 
 .offersMap.close {

--- a/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
@@ -29,3 +29,11 @@
 .ymaps-2-1-79-b-cluster-content__header {
     display: none !important;
 }
+
+// Zoom control (+/- slider): Yandex positions it via an inline `inset`
+// (right/top offsets in px), which only ever anchors it to a corner.
+// Override to vertically center it on the map's right edge instead.
+.ymaps-2-1-79-controls__control:has(.ymaps-2-1-79-zoom) {
+    inset: 50% 10px auto auto !important;
+    transform: translateY(-50%);
+}


### PR DESCRIPTION
Follow-up to the offers-map zoom control repositioning: the control was still anchored top-right instead of vertically centered on the map's right edge, and the 20px right-edge gutter read as too big.

- `.ymaps-2-1-79-controls__control:has(.ymaps-2-1-79-zoom)` — override Yandex's inline `inset` to center vertically (`top: 50%` + `translateY(-50%)`) instead of anchoring to the top.
- `.offersMap` right margin: 20px → 10px.