### PR TITLE
Don't append empty ?search= from homepage search box

### DIFF
--- a/src/pages/MainPage/ui/WelcomeContainer/InfoSide/InfoSide.tsx
+++ b/src/pages/MainPage/ui/WelcomeContainer/InfoSide/InfoSide.tsx
@@ -19,7 +19,8 @@ const InfoSide: FC = memo(() => {
     const searchRef = useRef<SearchOffersRef>(null);
 
     const onApplySearch = useCallback(async (search: string) => {
-        navigate(`/${locale}/offers-map?search=${encodeURIComponent(search)}`);
+        const query = search ? `?search=${encodeURIComponent(search)}` : "";
+        navigate(`/${locale}/offers-map${query}`);
     }, [navigate, locale]);
 
     const onResetFilters = useCallback(async () => {


### PR DESCRIPTION
Investigating a "что за херь в урле" report about `/offers-map?search=` — traced it to the homepage's hero search widget (`InfoSide.tsx`), which always appended `?search=<value>` on submit, even for an empty input. The offers-map page's own search already guards against this (`if (search) { params.set(...) }`); this mirrors that.

Also investigated a reported "empty space at the bottom of the offers-map page" — checked prod (untouched by any recent map/list changes) with real data: the list panel fills its full height correctly and pagination sits flush at the bottom, no structural bug found there.