### PR TITLE
Fix growing gap at bottom of offers-map page

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
@@ -1,19 +1,26 @@
 .wrapper {
     height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 .filter {
     position: relative;
 }
 
+// flex:1 + min-height:0 fills exactly whatever height .filter/.searchWrapper
+// leave over — no magic number to keep in sync with the header's real height
+// (a fixed calc(100vh - Nrem) here previously left a growing gap at the
+// bottom whenever the header/filter bar's actual height drifted from N).
 .wrapperOffersMap {
     display: flex;
+    flex: 1;
+    min-height: 0;
 }
 
 .searchOffersList, .offersMap {
     flex: 1;
-    height: calc(100vh - 12rem);
-    // height: 100%;
+    height: 100%;
 }
 
 // небольшой гаттер от края экрана — без него карта упирается прямо в
@@ -42,12 +49,6 @@
 
 .searchWrapper {
     padding: 12px 30px;
-}
-
-@media (max-width: 1400px) {
-    .searchOffersList, .offersMap {
-        height: calc(100vh - 16.125rem);
-    }
 }
 
 @media (max-width: 992px) {


### PR DESCRIPTION
Confirmed via direct DOM measurement on staging: `.searchOffersList`/`.offersMap`'s `height: calc(100vh - 12rem)` hardcodes an assumption about how tall everything above them is. Measured a ~38px unaccounted gap between the list/map row and the true viewport bottom (row height 642px vs the calc's expected 708px on a 900px viewport — no scroll, just dead space).

Replaced the magic-number calc with `flex: 1` on the row (`.wrapperOffersMap`) inside a flex-column `.wrapper`, so it fills exactly whatever space `.filter`/search box leave above it — no number to keep in sync with the header's real height. Also drops the now-redundant `@media (max-width: 1400px)` override that carried a second, different magic number for the same problem.

Confirmed via `git diff` that this calc predates all of today's offers-map PRs (#442/#443/#444) — not a regression from those, just a latent bug that's now fixed properly instead of patched around.