### PR TITLE
Revert "Fix growing gap at bottom of offers-map page (#445)"

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
@@ -1,26 +1,19 @@
 .wrapper {
     height: 100%;
-    display: flex;
-    flex-direction: column;
 }
 
 .filter {
     position: relative;
 }
 
-// flex:1 + min-height:0 fills exactly whatever height .filter/.searchWrapper
-// leave over — no magic number to keep in sync with the header's real height
-// (a fixed calc(100vh - Nrem) here previously left a growing gap at the
-// bottom whenever the header/filter bar's actual height drifted from N).
 .wrapperOffersMap {
     display: flex;
-    flex: 1;
-    min-height: 0;
 }
 
 .searchOffersList, .offersMap {
     flex: 1;
-    height: 100%;
+    height: calc(100vh - 12rem);
+    // height: 100%;
 }
 
 // небольшой гаттер от края экрана — без него карта упирается прямо в
@@ -49,6 +42,12 @@
 
 .searchWrapper {
     padding: 12px 30px;
+}
+
+@media (max-width: 1400px) {
+    .searchOffersList, .offersMap {
+        height: calc(100vh - 16.125rem);
+    }
 }
 
 @media (max-width: 992px) {


### PR DESCRIPTION
#445's `min-height: 0` on `.wrapperOffersMap` let the map container measure as 0/near-0 height at the moment Yandex Maps JS reads it for initial center/zoom — the map now loads permanently zoomed into a random spot (Земля Франца-Иосифа) instead of the world view. Reverting immediately; will redo the bottom-gap fix without touching the map's height availability during init.