### PR TITLE
Tune offers-map bottom gap without touching flex sizing mechanism

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
@@ -46,7 +46,10 @@
 
 @media (max-width: 1400px) {
     .searchOffersList, .offersMap {
-        height: calc(100vh - 16.125rem);
+        // measured live: at this breakpoint the row's real top offset is
+        // ~13.75rem, not 16.125rem — the old value left a ~38px gap at the
+        // bottom of the viewport.
+        height: calc(100vh - 13.75rem);
     }
 }
 


### PR DESCRIPTION
Conservative redo of #445 (reverted in #446 for breaking the map's initial zoom/center). Keeps the exact same sizing mechanism (explicit `calc(100vh - Nrem)` height + `flex: 1`, no `min-height: 0`) that's known not to break Yandex Maps init — just corrects the magic number for the `<=1400px` breakpoint based on a live measurement (row's real top offset is 13.75rem, not 16.125rem).

Will verify live on staging (gap closed + map still centers correctly) before merging.