### PR TITLE
Actually vertically center the offers-map zoom control

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
@@ -31,8 +31,14 @@
 }
 
 // Zoom control (+/- slider): Yandex positions it via an inline `inset`
-// (right/top offsets in px), which only ever anchors it to a corner.
-// Override to vertically center it on the map's right edge instead.
+// (right/top offsets in px), which only ever anchors it to a corner — and
+// its own positioning parent, .controls-pane, is collapsed to 0 height via
+// an inline `bottom` offset, so `top: 50%` on the control alone resolves
+// against a 0px box (no-op). Give the pane real height first, then center.
+.ymaps-2-1-79-controls-pane {
+    bottom: 0 !important;
+}
+
 .ymaps-2-1-79-controls__control:has(.ymaps-2-1-79-zoom) {
     inset: 50% 10px auto auto !important;
     transform: translateY(-50%);


### PR DESCRIPTION
The earlier centering attempt (#443) set `top: 50%` on `.ymaps-2-1-79-controls__control`, but its positioning parent (`.ymaps-2-1-79-controls-pane`) is collapsed to 0 height by an inline `bottom` offset Yandex sets equal to the map's pixel height — so `50%` resolved against 0 and the control rendered pinned near the top instead of centered.

Forces `.controls-pane` to `bottom: 0` (giving it the map's real height) before centering the control against it.

Verified live on staging by injecting the exact CSS via Playwright before writing this PR (no deploy-and-pray this time): zoom control's vertical center now matches the map's vertical center pixel-for-pixel, and the map still renders the normal world view (not broken).