### PR TITLE
fix(offers-map): don't let the zoom-control pane intercept map drags

### DIFF
--- a/e2e/tests/offers-map.spec.ts
+++ b/e2e/tests/offers-map.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+// Регрессионный тест на баг: CSS-фикс центрирования зум-контрола растянул
+// .ymaps-2-1-79-controls-pane на всю карту с pointer-events: auto — этот
+// прозрачный слой перехватывал все клики/драг, и карту вообще нельзя было
+// подвинуть мышью (зум-кнопки при этом продолжали работать, что маскировало
+// проблему при беглой проверке).
+test.describe('Карта вакансий — интерактивность', () => {
+    test.use({ storageState: 'e2e/.auth/vol.json' });
+
+    test('карту можно подвинуть мышью (drag/pan)', async ({ page }) => {
+        await page.goto('/ru/offers-map');
+
+        // .ymaps-2-1-79-map matches both an outer wrapper and Yandex's inner
+        // map element — .first() is the outer one, whose box we want anyway.
+        const map = page.locator('.ymaps-2-1-79-map').first();
+        await expect(map).toBeVisible();
+
+        const groundPane = page.locator('.ymaps-2-1-79-ground-pane');
+        await expect(groundPane).toBeVisible();
+
+        const transformBefore = await groundPane.evaluate((el) => getComputedStyle(el).transform);
+
+        const box = await map.boundingBox();
+        if (!box) throw new Error('Не удалось получить размеры карты');
+        const centerX = box.x + box.width / 2;
+        const centerY = box.y + box.height / 2;
+
+        await page.mouse.move(centerX, centerY);
+        await page.mouse.down();
+        await page.mouse.move(centerX - 150, centerY - 80, { steps: 10 });
+        await page.mouse.up();
+        await page.waitForTimeout(300);
+
+        const transformAfter = await groundPane.evaluate((el) => getComputedStyle(el).transform);
+
+        // если карта не сдвинулась — значит, что-то поверх неё перехватывает mousedown/move
+        expect(transformAfter).not.toBe(transformBefore);
+    });
+
+    test('в центре карты нет прозрачного слоя поверх неё', async ({ page }) => {
+        await page.goto('/ru/offers-map');
+
+        // .ymaps-2-1-79-map matches both an outer wrapper and Yandex's inner
+        // map element — .first() is the outer one, whose box we want anyway.
+        const map = page.locator('.ymaps-2-1-79-map').first();
+        const box = await map.boundingBox();
+        if (!box) throw new Error('Не удалось получить размеры карты');
+
+        const hitClassName = await page.evaluate(
+            ({ x, y }) => document.elementFromPoint(x, y)?.className ?? null,
+            { x: box.x + box.width / 2, y: box.y + box.height / 2 },
+        );
+
+        expect(hitClassName).not.toContain('controls-pane');
+    });
+
+    test('зум-контрол остаётся кликабельным', async ({ page }) => {
+        await page.goto('/ru/offers-map');
+
+        const zoomPlus = page.locator('.ymaps-2-1-79-zoom__plus');
+        await expect(zoomPlus).toBeVisible();
+        // .click() сам провалится, если кнопку перекрывает другой элемент
+        await zoomPlus.click();
+    });
+});

--- a/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
@@ -35,11 +35,19 @@
 // its own positioning parent, .controls-pane, is collapsed to 0 height via
 // an inline `bottom` offset, so `top: 50%` on the control alone resolves
 // against a 0px box (no-op). Give the pane real height first, then center.
+//
+// Stretching the pane to the full map height turns it into a full-size
+// overlay that (by default) intercepts mouse events — silently breaking
+// map dragging/panning, since drags landing on the pane never reach the
+// map's own drag layer underneath. Make the pane click-through and opt
+// only the actual control back in.
 .ymaps-2-1-79-controls-pane {
     bottom: 0 !important;
+    pointer-events: none;
 }
 
 .ymaps-2-1-79-controls__control:has(.ymaps-2-1-79-zoom) {
     inset: 50% 10px auto auto !important;
     transform: translateY(-50%);
+    pointer-events: auto;
 }


### PR DESCRIPTION
## Проблема

#448 центрировал зум-контрол, растянув `.ymaps-2-1-79-controls-pane` на всю высоту карты (`bottom: 0 !important`). Из-за этого пейн стал прозрачным слоем поверх всей карты, а по умолчанию `pointer-events: auto` — он перехватывал все клики/драги. Карту нельзя было подвинуть мышью; зум-кнопки при этом продолжали работать, что маскировало баг при беглой проверке.

## Фикс

`pointer-events: none` на пейне + `pointer-events: auto` только на обёртке зум-контрола — пейн остаётся кликтру, но сам контрол интерактивен.

## Тесты

Новый `e2e/tests/offers-map.spec.ts`:
- драг карты действительно двигает `.ymaps-2-1-79-ground-pane` (transform меняется)
- в центре карты нет `controls-pane` под курсором (`elementFromPoint`)
- зум-кнопка остаётся кликабельной

Проверено против текущего (сломанного) стейджа — тесты 1 и 2 падают ровно так, как ожидается, тест 3 проходит (зум работает). Фикс проверен live через инъекцию CSS на стейдж: драг снова двигает карту, зум-кнопка кликабельна.
