### PR TITLE
test(offers-map): don't assert toBeVisible() on ground-pane

### DIFF
--- a/e2e/tests/offers-map.spec.ts
+++ b/e2e/tests/offers-map.spec.ts
@@ -16,8 +16,12 @@ test.describe('Карта вакансий — интерактивность', 
         const map = page.locator('.ymaps-2-1-79-map').first();
         await expect(map).toBeVisible();
 
+        // .ymaps-2-1-79-ground-pane сам по себе всегда 0x0 (абсолютно
+        // спозиционирован, реальный размер несут дочерние тайлы с
+        // отрицательными отступами) — toBeVisible() тут не показатель,
+        // читаем transform напрямую.
         const groundPane = page.locator('.ymaps-2-1-79-ground-pane');
-        await expect(groundPane).toBeVisible();
+        await expect(groundPane).toBeAttached();
 
         const transformBefore = await groundPane.evaluate((el) => getComputedStyle(el).transform);
 


### PR DESCRIPTION
Follow-up to #449. `.ymaps-2-1-79-ground-pane` is always a 0x0 absolutely-positioned box (its tiles carry the real size via negative offsets), so `toBeVisible()` on it is flaky/wrong — swap for `toBeAttached()` and read the transform directly, which is what the test actually needs. Verified: all 3 tests in `offers-map.spec.ts` pass against live staging after this change.