### PR TITLE
fix(offer-card): hide reviews/went counters when zero

### DIFF
--- a/src/entities/Offer/ui/OfferCard/OfferCard.test.tsx
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ComponentProps } from "react";
+import { renderWithProviders } from "@/test-utils";
+import { OfferCard } from "./OfferCard";
+
+const baseProps = {
+    offerId: 1,
+    isFavorite: false,
+    locale: "ru" as const,
+};
+
+const renderCard = (props: Partial<ComponentProps<typeof OfferCard>>) => renderWithProviders(
+    <MemoryRouter>
+        <OfferCard {...baseProps} {...props} />
+    </MemoryRouter>,
+);
+
+describe("OfferCard", () => {
+    it("скрывает «Отзывов»/«Отправились», если их 0", () => {
+        renderCard({ reviews: 0, went: 0 });
+
+        expect(screen.queryByText(/Отзывов/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Отправились/)).not.toBeInTheDocument();
+    });
+
+    it("показывает только непустой счётчик", () => {
+        renderCard({ reviews: 3, went: 0 });
+
+        expect(screen.getByText(/Отзывов/)).toBeInTheDocument();
+        expect(screen.queryByText(/Отправились/)).not.toBeInTheDocument();
+    });
+
+    it("показывает оба счётчика, если оба ненулевые", () => {
+        renderCard({ reviews: 3, went: 5 });
+
+        expect(screen.getByText(/Отзывов/)).toBeInTheDocument();
+        expect(screen.getByText(/Отправились/)).toBeInTheDocument();
+    });
+});

--- a/src/entities/Offer/ui/OfferCard/OfferCard.tsx
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.tsx
@@ -112,18 +112,22 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
                         )}
                     </div> */}
                     <div className={styles.extraInfo}>
-                        <span className={styles.review}>
-                            {t("Отзывов")}
-                            :
-                            {" "}
-                            {reviews}
-                        </span>
-                        <span className={styles.went}>
-                            {t("Отправились")}
-                            :
-                            {" "}
-                            {went}
-                        </span>
+                        {!!reviews && (
+                            <span className={styles.review}>
+                                {t("Отзывов")}
+                                :
+                                {" "}
+                                {reviews}
+                            </span>
+                        )}
+                        {!!went && (
+                            <span className={styles.went}>
+                                {t("Отправились")}
+                                :
+                                {" "}
+                                {went}
+                            </span>
+                        )}
                     </div>
                 </div>
                 <p className={styles.description}>


### PR DESCRIPTION
## Проблема

Каждая карточка вакансии в списке (`offers-map` и везде, где используется `entities/Offer/ui/OfferCard`) всегда показывала обе строки — «Отзывов: 0» и «Отправились: 0» — даже когда считать было нечего. Чистый шум.

## Фикс

Показывать каждый счётчик независимо, только если значение не 0.

## Тесты

Новый `OfferCard.test.tsx`: оба скрыты при 0/0, только ненулевой показан, оба показаны при обоих ненулевых. Проверено revert-and-confirm-fails — тест корректно падает на старом поведении (2/3 fail).
