### PR TITLE
feat(offers-map): "Подробнее" button + click-to-focus list item

### DIFF
--- a/src/entities/Offer/ui/OfferCard/OfferCard.module.scss
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.module.scss
@@ -7,6 +7,14 @@
     box-shadow: 0px 5px 20px 0px #2121210d;
     text-decoration: none;
     color: inherit;
+    cursor: pointer;
+    border-left: 3px solid transparent;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.wrapper.selected {
+    background-color: var(--bg-accent);
+    border-left-color: var(--accent-color);
 }
 
 .imageWrapper {
@@ -154,6 +162,21 @@
     letter-spacing: 0px;
     text-align: left;
     color: var(--white-theme-color);
+}
+
+.learnMore {
+    display: inline-block;
+    margin-top: 12px;
+    font-family: "Lato";
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 20px;
+    color: var(--accent-color);
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
 }
 
 @media (max-width: 480px) {

--- a/src/entities/Offer/ui/OfferCard/OfferCard.test.tsx
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.test.tsx
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { screen } from "@testing-library/react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { ComponentProps } from "react";
 import { renderWithProviders } from "@/test-utils";
@@ -37,5 +39,29 @@ describe("OfferCard", () => {
 
         expect(screen.getByText(/Отзывов/)).toBeInTheDocument();
         expect(screen.getByText(/Отправились/)).toBeInTheDocument();
+    });
+
+    it("клик по карточке вызывает onSelect, а не переход по ссылке", () => {
+        const onSelect = vi.fn();
+        renderCard({ onSelect });
+
+        fireEvent.click(screen.getByRole("button"));
+
+        expect(onSelect).toHaveBeenCalledWith(1);
+    });
+
+    it("клик по «Подробнее» не вызывает onSelect (переход по ссылке отдельно)", () => {
+        const onSelect = vi.fn();
+        renderCard({ onSelect, link: "/ru/offer-personal/1" });
+
+        fireEvent.click(screen.getByText("Подробнее"));
+
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("подсвечивает карточку, если isSelected=true", () => {
+        const { container } = renderCard({ isSelected: true });
+
+        expect(container.querySelector("[role=\"button\"]")?.className).toMatch(/selected/);
     });
 });

--- a/src/entities/Offer/ui/OfferCard/OfferCard.tsx
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.tsx
@@ -29,7 +29,9 @@ interface OfferCardProps {
     isImageShow?: boolean;
     isFavoriteIconShow?: boolean;
     isFavorite: boolean;
+    isSelected?: boolean;
     handleFavoriteClick?: (offerId: number) => void;
+    onSelect?: (offerId: number) => void;
     locale: Locale;
 }
 
@@ -49,15 +51,25 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
         isImageShow = true,
         isFavoriteIconShow = false,
         isFavorite,
+        isSelected = false,
         locale,
         handleFavoriteClick,
+        onSelect,
     } = props;
     const { t } = useTranslation();
 
     return (
-        <Link
-            to={link ?? getMainPageUrl(locale)}
-            className={cn(styles.wrapper, className)}
+        <div
+            role="button"
+            tabIndex={0}
+            onClick={() => onSelect?.(offerId)}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelect?.(offerId);
+                }
+            }}
+            className={cn(styles.wrapper, className, { [styles.selected]: isSelected })}
         >
             {isImageShow && (
                 <div className={styles.imageWrapper}>
@@ -133,7 +145,14 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
                 <p className={styles.description}>
                     {textSlice(description, 110, "description")}
                 </p>
+                <Link
+                    to={link ?? getMainPageUrl(locale)}
+                    onClick={(e) => e.stopPropagation()}
+                    className={styles.learnMore}
+                >
+                    {t("Подробнее")}
+                </Link>
             </div>
-        </Link>
+        </div>
     );
 });

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -50,6 +50,7 @@ export const OffersSearchFilter = () => {
 
     const [currentPage, setCurrentPage] = useState<number>(1);
     const [initialSearchValue, setInitialSearchValue] = useState<string>();
+    const [selectedOfferId, setSelectedOfferId] = useState<number>();
 
     const initialCategories = getCategoryIdsFromUrlParam(searchParams.get("category") ?? "");
 
@@ -193,6 +194,10 @@ export const OffersSearchFilter = () => {
         setMapOpened((prev) => !prev);
     }, []);
 
+    const handleSelectOffer = useCallback((offerId: number) => {
+        setSelectedOfferId(offerId);
+    }, []);
+
     useEffect(() => {
         const subscription = watch((value, { name, type }) => {
             if ((name === "offersSort.showClosedOffers" || name === "offersSort.sortValue") && type === "change") {
@@ -258,6 +263,8 @@ export const OffersSearchFilter = () => {
                             offersPerPage={OFFERS_PER_PAGE}
                             onChangePage={onChangePage}
                             total={offersData?.pagination.total ?? 0}
+                            selectedOfferId={selectedOfferId}
+                            onSelectOffer={handleSelectOffer}
                         />
                     </div>
                     {isMapOpened && (
@@ -266,6 +273,7 @@ export const OffersSearchFilter = () => {
                             isOffersLoading={isAllOffersMapLoading || isAllOffersMapFetching}
                             className={styles.offersMap}
                             classNameMap={styles.offersMap}
+                            selectedOfferId={selectedOfferId}
                         />
                     )}
                 </div>

--- a/src/widgets/OffersMap/ui/OfferCard/OfferCard.tsx
+++ b/src/widgets/OffersMap/ui/OfferCard/OfferCard.tsx
@@ -34,6 +34,8 @@ interface OfferCardProps {
     className?: string;
     classNameCard?: string;
     // isFavoriteIconShow: boolean;
+    isSelected?: boolean;
+    onSelect?: (offerId: number) => void;
     locale: Locale;
 }
 
@@ -48,6 +50,8 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
         status,
         className,
         classNameCard,
+        isSelected,
+        onSelect,
         locale,
     } = props;
 
@@ -79,6 +83,8 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
                 className={classNameCard}
                 isFavoriteIconShow={false}
                 isFavorite={isFavorite}
+                isSelected={isSelected}
+                onSelect={onSelect}
                 locale={locale}
                 handleFavoriteClick={onFavoriteClick}
             />

--- a/src/widgets/OffersMap/ui/OffersList/OffersList.tsx
+++ b/src/widgets/OffersMap/ui/OffersList/OffersList.tsx
@@ -27,6 +27,8 @@ interface OffersListProps {
     offersPerPage: number;
     total: number;
     onChangePage: (pageItem: number) => void;
+    selectedOfferId?: number;
+    onSelectOffer?: (offerId: number) => void;
 }
 
 export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
@@ -40,6 +42,8 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
         total,
         onChangePage,
         isLoading,
+        selectedOfferId,
+        onSelectOffer,
     } = props;
 
     const { locale } = useLocale();
@@ -93,6 +97,8 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
                         reviewsCount: offer.reviewsCount,
                     }}
                     key={offer.id}
+                    isSelected={offer.id === selectedOfferId}
+                    onSelect={onSelectOffer}
                     // isFavoriteIconShow={!!isAuth}
                 />
             ));
@@ -105,7 +111,7 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
             />
         );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [data, isLoading, locale, mapOpenValue, t]);
+    }, [data, isLoading, locale, mapOpenValue, t, selectedOfferId, onSelectOffer]);
 
     const totalPages = Math.ceil(total / offersPerPage);
 

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -3,7 +3,7 @@ import {
 } from "@pbe/react-yandex-maps";
 import cn from "classnames";
 import React, {
-    FC, memo, useMemo, useRef, useState,
+    FC, memo, useEffect, useMemo, useRef, useState,
 } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -19,17 +19,20 @@ import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 import { getOfferPersonalPageUrl } from "@/shared/config/routes/AppUrls";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 
+const FOCUS_ZOOM = 10;
+
 interface OffersMapProps {
     className?: string;
     classNameMap?: string;
     offersData: OfferMap[];
     isOffersLoading: boolean;
+    selectedOfferId?: number;
 }
 
 export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const {
         className, classNameMap, isOffersLoading,
-        offersData,
+        offersData, selectedOfferId,
     } = props;
     const { locale } = useLocale();
     const { t } = useTranslation();
@@ -89,6 +92,22 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         isOffersLoading, offersData, locale, ymapState?.templateLayoutFactory,
         noTitle, noCategory, offerWithoutName, learnMore,
     ]);
+
+    useEffect(() => {
+        if (!selectedOfferId || !mapRef.current) return;
+
+        const selectedOffer = offersData.find((offer) => offer.id === selectedOfferId);
+        if (!selectedOffer
+            || typeof selectedOffer.latitude !== "number"
+            || typeof selectedOffer.longitude !== "number") return;
+
+        const currentZoom = mapRef.current.getZoom();
+        mapRef.current.setCenter(
+            [selectedOffer.latitude, selectedOffer.longitude],
+            Math.max(currentZoom, FOCUS_ZOOM),
+            { duration: 400 },
+        );
+    }, [selectedOfferId, offersData]);
 
     if (isOffersLoading) {
         return (


### PR DESCRIPTION
## Проблема

Карточка вакансии в списке `offers-map` целиком была одной `<Link>` — любой клик по ней сразу уводил на страницу вакансии. Не было способа просто посмотреть, где она на карте, не покидая список.

## Что меняется

- Карточка (`entities/Offer/ui/OfferCard`) больше не `<Link>` целиком — это кликабельный `div` (`role="button"`, доступен с клавиатуры), клик по нему вызывает `onSelect(offerId)`.
- Добавлена явная кнопка **«Подробнее»** — только она теперь ведёт на страницу вакансии (`stopPropagation`, чтобы не триггерить заодно выбор).
- Выбранная карточка подсвечивается цветом (`--bg-accent` фон + акцентная левая полоса).
- `OffersMap` получил `selectedOfferId` — при выборе карта плавно панится/зумит (`setCenter` с `duration: 400`, зум не ниже 10) к вакансии с соответствующими координатами.
- Состояние выбора живёт в `OffersSearchFilter` (десктопный layout, где список и карта видны одновременно). Мобильный layout не трогал — там список и карта в разных табах, фокусировка карты в момент клика не имеет смысла.

## Тесты

`OfferCard.test.tsx`: клик по карточке → `onSelect`, клик по «Подробнее» → `onSelect` НЕ вызывается, `isSelected` → подсветка. Revert-and-confirm-fails: 3/6 тестов падают на старом коде (ровно то поведение, которое чинится).

Прогнаны smoke-тесты соседних `OffersSearchFilter`/`OffersFilter`/`Categories`/`ButtonClose` — без регрессий. `tsc --noEmit` и `eslint` чистые.
