### PR TITLE
fix(offer-card): compact layout so more than one card fits per screen

### DIFF
--- a/src/entities/Offer/ui/OfferCard/OfferCard.module.scss
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.module.scss
@@ -1,5 +1,5 @@
 .wrapper {
-    padding: 1.25rem;
+    padding: 0.875rem 1.25rem;
     background-color: var(--color-white);
     display: flex;
     gap: 14px;
@@ -17,11 +17,16 @@
     border-left-color: var(--accent-color);
 }
 
+.content {
+    flex: 1;
+    min-width: 0;
+}
+
 .imageWrapper {
     position: relative;
     flex-shrink: 0;
-    width: 180px;
-    height: 140px;
+    width: 160px;
+    height: 110px;
 
     img {
         width: 100%;
@@ -77,37 +82,46 @@
 
 .title {
     font-family: "Lato";
-    font-size: 1.125rem;
+    font-size: 1rem;
     font-weight: 500;
-    line-height: 22px;
+    line-height: 20px;
     letter-spacing: 0px;
     text-align: left;
     color: var(--color-black-primary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .location {
+    display: block;
     font-family: "Lato";
     font-size: 0.875rem;
     font-weight: 500;
-    line-height: 20px;
+    line-height: 18px;
     letter-spacing: 0px;
     text-align: left;
     color: var(--white-theme-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
 }
 
 .subtitle {
-    margin-top: 0.75rem;
+    margin-top: 0.375rem;
     font-family: Lato;
     font-size: 14px;
     font-weight: 500;
-    line-height: 20px;
+    line-height: 18px;
     letter-spacing: 0px;
     text-align: left;
     color: var(--white-theme-color);
 }
 
 .stats {
-    margin-top: 12px;
+    margin-top: 8px;
     display: flex;
     flex-wrap: wrap;
     gap: 1.5rem;
@@ -153,7 +167,7 @@
 }
 
 .description {
-    margin-top: 12px;
+    margin-top: 6px;
     max-width: 100%;
     font-family: "Lato";
     font-size: 14px;
@@ -162,11 +176,15 @@
     letter-spacing: 0px;
     text-align: left;
     color: var(--white-theme-color);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .learnMore {
     display: inline-block;
-    margin-top: 12px;
+    margin-top: 6px;
     font-family: "Lato";
     font-size: 14px;
     font-weight: 700;


### PR DESCRIPTION
## Проблема

На обычном ноутбучном экране в список `offers-map` помещалась ровно одна карточка (см. скрин от пользователя). Причина — `address` может быть очень длинным («Пинежский муниципальный округ, Архангельская область, Россия, Пинежский государственный природный заповедник федерального значения»), а `.location` никак не обрезался и разворачивался на 3 строки, плюс щедрые паддинги/отступы вокруг всего остального.

## Фикс (только SCSS, без изменения разметки/логики)

- `.location` — однострочный ellipsis вместо 3-строчного переноса (главный источник экономии высоты).
- `.title`/`.description` — clamp на 2 строки как доп. подстраховка (текст и так усечён через `textSlice`, но длинные слова/близкие к лимиту случаи раньше могли вылезти на 3-ю строку).
- Картинка 180×140 → 160×110.
- Паддинги/отступы карточки и внутренних блоков подтянуты (0.875rem вместо 1.25rem, 6-8px вместо 12px и т.д.).
- `.content { flex: 1; min-width: 0; }` — без этого `text-overflow: ellipsis` во флекс-контейнере не работает.

## Тесты

Существующие тесты `OfferCard.test.tsx`/`OffersSearchFilter.test.tsx` зелёные, `tsc --noEmit` чистый. Чисто визуальный фикс — приложу скрин со стейджа после деплоя.
