### PR TITLE
fix(offer-card): compact card layout without squeezing the map

### DIFF
--- a/src/entities/Offer/ui/OfferCard/OfferCard.module.scss
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.module.scss
@@ -1,5 +1,5 @@
 .wrapper {
-    padding: 1.25rem;
+    padding: 0.875rem 1.25rem;
     background-color: var(--color-white);
     display: flex;
     gap: 14px;
@@ -17,11 +17,16 @@
     border-left-color: var(--accent-color);
 }
 
+.content {
+    flex: 1;
+    min-width: 0;
+}
+
 .imageWrapper {
     position: relative;
     flex-shrink: 0;
-    width: 180px;
-    height: 140px;
+    width: 160px;
+    height: 110px;
 
     img {
         width: 100%;
@@ -77,37 +82,46 @@
 
 .title {
     font-family: "Lato";
-    font-size: 1.125rem;
+    font-size: 1rem;
     font-weight: 500;
-    line-height: 22px;
+    line-height: 20px;
     letter-spacing: 0px;
     text-align: left;
     color: var(--color-black-primary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .location {
+    display: block;
     font-family: "Lato";
     font-size: 0.875rem;
     font-weight: 500;
-    line-height: 20px;
+    line-height: 18px;
     letter-spacing: 0px;
     text-align: left;
     color: var(--white-theme-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
 }
 
 .subtitle {
-    margin-top: 0.75rem;
+    margin-top: 0.375rem;
     font-family: Lato;
     font-size: 14px;
     font-weight: 500;
-    line-height: 20px;
+    line-height: 18px;
     letter-spacing: 0px;
     text-align: left;
     color: var(--white-theme-color);
 }
 
 .stats {
-    margin-top: 12px;
+    margin-top: 8px;
     display: flex;
     flex-wrap: wrap;
     gap: 1.5rem;
@@ -153,7 +167,7 @@
 }
 
 .description {
-    margin-top: 12px;
+    margin-top: 6px;
     max-width: 100%;
     font-family: "Lato";
     font-size: 14px;
@@ -162,11 +176,15 @@
     letter-spacing: 0px;
     text-align: left;
     color: var(--white-theme-color);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .learnMore {
     display: inline-block;
-    margin-top: 12px;
+    margin-top: 6px;
     font-family: "Lato";
     font-size: 14px;
     font-weight: 700;

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.module.scss
@@ -12,6 +12,12 @@
 
 .searchOffersList, .offersMap {
     flex: 1;
+    // Without this, a flex item's automatic minimum width is its content's
+    // min-content size — and a `white-space: nowrap` node buried inside
+    // (e.g. OfferCard's truncated address) makes that min-content size the
+    // full unwrapped text width. That silently forces this column far wider
+    // than its `flex: 1` share, squeezing the map sibling down to nothing.
+    min-width: 0;
     height: calc(100vh - 12rem);
     // height: 100%;
 }


### PR DESCRIPTION
## Что было не так в #453 (откачен в #454)

`.location { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }` был нужен для однострочного адреса — но `.searchOffersList` (реальный flex-элемент рядом с картой, оба `flex: 1`) не имел `min-width: 0`. Без него браузер считает "автоматический минимум" flex-элемента по min-content размеру содержимого — а `white-space: nowrap` делает этот размер равным полной нераспереносимой ширине текста адреса. В результате список раздувался далеко за свою `flex: 1` долю, а карта (тоже `flex: 1`) схлопывалась почти до нуля.

Перепроверил механику отдельным HTML-репро (без сборки, те же CSS-правила): без `min-width: 0` карта — 35px из 900px контейнера, с `min-width: 0` — ровный сплит 450/450.

## Фикс

- `.searchOffersList, .offersMap` — добавлен `min-width: 0` (это и есть настоящий фикс регрессии).
- Плюс тот же компактный layout карточки из #453 (однострочный адрес, clamp на 2 строки для заголовка/описания, картинка 160×110, более плотные отступы).

## Тесты

`OfferCard.test.tsx`/`OffersSearchFilter.test.tsx` зелёные, `tsc --noEmit` чистый. Отдельно валидировал сам механизм регрессии/фикса статическим repro (описано выше) — прямая демонстрация, что именно чинит `min-width: 0`.
