### PR TITLE
fix(offers-map): show a notice when a selected offer has no map location

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
@@ -95,3 +95,20 @@
 .loadingPlaceholder {
     margin-top: 30px;
 }
+
+.noLocationNotice {
+    position: absolute;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    background-color: var(--color-white);
+    box-shadow: 0px 5px 20px 0px #2121210d;
+    border-radius: var(--radius);
+    padding: 10px 16px;
+    font-family: "Lato";
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--color-black-primary);
+    white-space: nowrap;
+}

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -1,0 +1,73 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import { OffersMap } from "./OffersMap";
+import { OfferMap } from "@/entities/Offer";
+
+const setCenter = vi.fn();
+const getZoom = vi.fn(() => 5);
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@pbe/react-yandex-maps", () => ({
+    YMaps: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    // eslint-disable-next-line react/no-unused-prop-types
+    Map: (
+        { children, instanceRef }: { children: React.ReactNode; instanceRef: { current: unknown } },
+    ) => {
+        instanceRef.current = { setCenter, getZoom };
+        return <div>{children}</div>;
+    },
+    ZoomControl: () => null,
+    ObjectManager: () => null,
+}));
+
+const offer = (overrides: Partial<OfferMap> = {}): OfferMap => ({
+    id: 1,
+    latitude: 55.75,
+    longitude: 37.61,
+    name: "Test offer",
+    image: { id: "1", contentUrl: "" },
+    categories: [],
+    ...overrides,
+} as OfferMap);
+
+describe("OffersMap", () => {
+    beforeEach(() => {
+        setCenter.mockClear();
+        getZoom.mockClear();
+    });
+
+    it("фокусирует карту, если у выбранной вакансии есть координаты", () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+                selectedOfferId={1}
+            />,
+        );
+
+        expect(setCenter).toHaveBeenCalledWith([55.75, 37.61], 10, { duration: 400 });
+        expect(screen.queryByText(/местоположение/)).not.toBeInTheDocument();
+    });
+
+    it("показывает подсказку вместо тишины, если у вакансии нет координат", () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+                selectedOfferId={999}
+            />,
+        );
+
+        expect(setCenter).not.toHaveBeenCalled();
+        expect(screen.getByText("У этой вакансии не указано местоположение на карте")).toBeInTheDocument();
+    });
+});

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -37,6 +37,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const { locale } = useLocale();
     const { t } = useTranslation();
     const [ymapState, setYmapState] = useState<YmapType | undefined>(undefined);
+    const [showNoLocationNotice, setShowNoLocationNotice] = useState(false);
     const mapRef = useRef<any>(null);
     const objectManagerRef = useRef<any>(null);
 
@@ -45,6 +46,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const offerWithoutName = t("Вакансия без названия");
     const learnMore = t("Подробнее");
     const vacancyListTitle = t("Список вакансий:");
+    const noLocationText = t("У этой вакансии не указано местоположение на карте");
 
     const features = useMemo(() => {
         if (isOffersLoading || !offersData.length) return [];
@@ -94,12 +96,24 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     ]);
 
     useEffect(() => {
-        if (!selectedOfferId || !mapRef.current) return;
+        if (!selectedOfferId) {
+            setShowNoLocationNotice(false);
+            return;
+        }
 
-        const selectedOffer = offersData.find((offer) => offer.id === selectedOfferId);
-        if (!selectedOffer
-            || typeof selectedOffer.latitude !== "number"
-            || typeof selectedOffer.longitude !== "number") return;
+        const offerById = offersData.find((offer) => offer.id === selectedOfferId);
+        const selectedOffer = offerById
+            && typeof offerById.latitude === "number"
+            && typeof offerById.longitude === "number"
+            ? offerById
+            : undefined;
+
+        // Часть вакансий физически не имеет координат в базе (адрес не
+        // геокодирован) — карте попросту нечем "сфокусироваться". Раньше
+        // клик по такой карточке в списке просто ничего не делал молча,
+        // что выглядело как баг; показываем явную причину вместо тишины.
+        setShowNoLocationNotice(!selectedOffer);
+        if (!selectedOffer || !mapRef.current) return;
 
         const currentZoom = mapRef.current.getZoom();
         mapRef.current.setCenter(
@@ -121,6 +135,9 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
 
     return (
         <div className={cn(className, styles.wrapper)}>
+            {showNoLocationNotice && (
+                <div className={styles.noLocationNotice}>{noLocationText}</div>
+            )}
             <YMaps query={{ apikey: import.meta.env.VITE_API_YANDEX_KEY, load: "package.full" }}>
                 <Map
                     defaultState={{


### PR DESCRIPTION
## Разбор

Проверил на живых данных стейджа: `vacancy/list?page=2` и `vacancy/for-map/list` — 18 из 20 вакансий на 2-й странице (сортировка "по новизне") отсутствуют в `for-map/list` вообще. Причина — у них физически нет строки в `vacancy_where` (адрес не геокодирован), значит нет координат, значит нечем ставить метку на карте. Это не баг выбора/клика — `for-map/list` в принципе не может отдать маркер для вакансии без адреса.

Раньше клик по такой карточке молча ничего не делал — выглядело как поломка. `entities/Offer/ui/OfferCard`'s `isSelected` подсветка при этом работала нормально (это на уровне списка, не зависит от координат), поэтому баг казался специфичным именно для карты.

## Фикс

`OffersMap` теперь явно показывает подсказку («У этой вакансии не указано местоположение на карте») вместо тишины, когда у выбранной вакансии нет координат в `offersData` (данные для карты).

## Тесты

Новый `OffersMap.test.tsx` (мокает `@pbe/react-yandex-maps` — instanceRef-объект с шпионами `setCenter`/`getZoom`): фокус карты работает при наличии координат, подсказка показывается и `setCenter` не вызывается при их отсутствии. Revert-and-confirm-fails: тест на подсказку падает на старом коде (карта молчит).
