### PR TITLE
feat(offers-map): viewport-scoped map markers + accurate location badge

### DIFF
--- a/src/entities/Offer/model/types/offer.ts
+++ b/src/entities/Offer/model/types/offer.ts
@@ -178,7 +178,15 @@ export interface GetOffersFilters {
     limit: number;
 }
 
-export type GetAllOffersMapFilters = Omit<GetOffersFilters, "sort" | "page" | "limit">;
+export interface MapBounds {
+    boundsSwLat: number;
+    boundsSwLng: number;
+    boundsNeLat: number;
+    boundsNeLng: number;
+}
+
+export type GetAllOffersMapFilters = Omit<GetOffersFilters, "sort" | "page" | "limit">
+& MapBounds & { ids: number[] };
 
 export interface GetOffersResponse {
     data: OfferApi[];

--- a/src/entities/Offer/ui/OfferCard/OfferCard.module.scss
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.module.scss
@@ -109,6 +109,16 @@
     max-width: 100%;
 }
 
+.noLocationBadge {
+    display: inline-block;
+    margin-top: 2px;
+    font-family: "Lato";
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--white-theme-color);
+    opacity: 0.7;
+}
+
 .subtitle {
     margin-top: 0.375rem;
     font-family: Lato;

--- a/src/entities/Offer/ui/OfferCard/OfferCard.test.tsx
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.test.tsx
@@ -64,4 +64,18 @@ describe("OfferCard", () => {
 
         expect(container.querySelector("[role=\"button\"]")?.className).toMatch(/selected/);
     });
+
+    it("показывает бейдж «нет на карте», если hasLocation=false", () => {
+        renderCard({ hasLocation: false });
+
+        expect(screen.getByText("нет на карте")).toBeInTheDocument();
+    });
+
+    it("не показывает бейдж, если hasLocation не false (неизвестно/есть локация)", () => {
+        renderCard({ hasLocation: true });
+        expect(screen.queryByText("нет на карте")).not.toBeInTheDocument();
+
+        renderCard({});
+        expect(screen.queryByText("нет на карте")).not.toBeInTheDocument();
+    });
 });

--- a/src/entities/Offer/ui/OfferCard/OfferCard.tsx
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.tsx
@@ -30,6 +30,9 @@ interface OfferCardProps {
     isFavoriteIconShow?: boolean;
     isFavorite: boolean;
     isSelected?: boolean;
+    // undefined — не знаем (ещё не проверяли/не актуально); false — точно
+    // известно, что у вакансии нет координат для карты.
+    hasLocation?: boolean;
     handleFavoriteClick?: (offerId: number) => void;
     onSelect?: (offerId: number) => void;
     locale: Locale;
@@ -52,6 +55,7 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
         isFavoriteIconShow = false,
         isFavorite,
         isSelected = false,
+        hasLocation,
         locale,
         handleFavoriteClick,
         onSelect,
@@ -93,6 +97,9 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
                 <p className={styles.title}>{textSlice(title, 50, "title")}</p>
                 <div className={styles.subtitle}>
                     <span className={styles.location}>{location}</span>
+                    {hasLocation === false && (
+                        <span className={styles.noLocationBadge}>{t("нет на карте")}</span>
+                    )}
                     <br />
                     <span className={styles.category}>{category}</span>
                 </div>

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.test.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {
     describe, it, expect, vi,
 } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
     MemoryRouter, Routes, Route, useNavigate,
@@ -12,9 +12,18 @@ import { renderWithProviders } from "@/test-utils";
 import { server } from "@/mocks/server";
 import { OffersSearchFilter } from "./OffersSearchFilter";
 
+const latestOffersMapProps: { current: Record<string, unknown> } = { current: {} };
+const latestOffersListProps: { current: Record<string, unknown> } = { current: {} };
+
 vi.mock("@/widgets/OffersMap", () => ({
-    OffersList: () => <div />,
-    OffersMap: () => <div />,
+    OffersList: (props: Record<string, unknown>) => {
+        latestOffersListProps.current = props;
+        return <div />;
+    },
+    OffersMap: (props: Record<string, unknown>) => {
+        latestOffersMapProps.current = props;
+        return <div />;
+    },
 }));
 vi.mock("../OffersFilter/OffersFilter", () => ({
     OffersFilter: () => <div />,
@@ -36,6 +45,22 @@ const NavigateToCleanOffersMap = () => {
         </button>
     );
 };
+
+const renderPage = () => renderWithProviders(
+    <MemoryRouter initialEntries={["/ru/offers-map"]}>
+        <Routes>
+            <Route
+                path="/ru/offers-map"
+                element={(
+                    <>
+                        <OffersSearchFilter />
+                        <NavigateToCleanOffersMap />
+                    </>
+                )}
+            />
+        </Routes>
+    </MemoryRouter>,
+);
 
 describe("OffersSearchFilter", () => {
     it("сбрасывает выбранную категорию при внешней навигации на чистый урл (\"Все вакансии\")", async () => {
@@ -74,5 +99,105 @@ describe("OffersSearchFilter", () => {
             expect(last).toBeDefined();
             expect(last).not.toContain("categoryIds");
         });
+    });
+
+    it("подмешивает границы viewport карты в запрос маркеров после onBoundsChange", async () => {
+        const requestedForMapUrls: string[] = [];
+        server.use(
+            rest.get("*/vacancy/list", (req, res, ctx) => res(ctx.status(200), ctx.json({ data: [], pagination: { total: 0 } }))),
+            rest.get("*/vacancy/for-map/list", (req, res, ctx) => {
+                requestedForMapUrls.push(req.url.toString());
+                return res(ctx.status(200), ctx.json([]));
+            }),
+            rest.get("*/category/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+        );
+
+        renderPage();
+
+        await waitFor(() => expect(typeof latestOffersMapProps.current.onBoundsChange).toBe("function"));
+        const requestsBeforeBoundsChange = requestedForMapUrls.length;
+
+        act(() => {
+            (latestOffersMapProps.current.onBoundsChange as (bounds: unknown) => void)({
+                boundsSwLat: 54, boundsSwLng: 36, boundsNeLat: 57, boundsNeLng: 39,
+            });
+        });
+
+        await waitFor(() => expect(requestedForMapUrls.length)
+            .toBeGreaterThan(requestsBeforeBoundsChange));
+        const last = requestedForMapUrls.at(-1)!;
+        expect(last).toContain("boundsSwLat=54");
+        expect(last).toContain("boundsNeLng=39");
+    });
+
+    it("запрашивает координаты для offer id именно текущей страницы списка", async () => {
+        const requestedIdsUrls: string[] = [];
+        server.use(
+            rest.get("*/vacancy/list", (req, res, ctx) => res(ctx.status(200), ctx.json({
+                data: [{
+                    id: 42,
+                    title: "Test",
+                    shortDescription: "",
+                    image: null,
+                    categories: [],
+                    address: "",
+                    acceptedApplicationsCount: 0,
+                    averageRating: 0,
+                    reviewsCount: 0,
+                    status: "active",
+                }],
+                pagination: { total: 1 },
+            }))),
+            rest.get("*/vacancy/for-map/list", (req, res, ctx) => {
+                // qs.stringify(..., { arrayFormat: "brackets" }) отдаёт
+                // ids[]=42 (URL-энкодится в ids%5B%5D=42), а не ids=42.
+                if (req.url.search.toLowerCase().includes("ids")) {
+                    requestedIdsUrls.push(req.url.toString());
+                }
+                return res(ctx.status(200), ctx.json([]));
+            }),
+            rest.get("*/category/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+        );
+
+        renderPage();
+
+        await waitFor(() => expect(requestedIdsUrls.length).toBeGreaterThan(0));
+        expect(requestedIdsUrls.at(-1)).toContain("42");
+    });
+
+    it("сбрасывает выбранную вакансию при смене страницы списка", async () => {
+        server.use(
+            rest.get("*/vacancy/list", (req, res, ctx) => res(ctx.status(200), ctx.json({
+                data: [{
+                    id: 7,
+                    title: "Test",
+                    shortDescription: "",
+                    image: null,
+                    categories: [],
+                    address: "",
+                    acceptedApplicationsCount: 0,
+                    averageRating: 0,
+                    reviewsCount: 0,
+                    status: "active",
+                }],
+                pagination: { total: 40 },
+            }))),
+            rest.get("*/vacancy/for-map/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+            rest.get("*/category/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+        );
+
+        renderPage();
+
+        await waitFor(() => expect(typeof latestOffersListProps.current.onSelectOffer).toBe("function"));
+
+        act(() => {
+            (latestOffersListProps.current.onSelectOffer as (id: number) => void)(7);
+        });
+        await waitFor(() => expect(latestOffersMapProps.current.selectedOfferId).toBe(7));
+
+        act(() => {
+            (latestOffersListProps.current.onChangePage as (page: number) => void)(2);
+        });
+        await waitFor(() => expect(latestOffersMapProps.current.selectedOfferId).toBeUndefined());
     });
 });

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import cn from "classnames";
 import React, {
-    useCallback, useEffect, useRef, useState,
+    useCallback, useEffect, useMemo, useRef, useState,
 } from "react";
 import { DefaultValues, FormProvider, useForm } from "react-hook-form";
 
 import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { OffersList, OffersMap } from "@/widgets/OffersMap";
+import type { MapViewportBounds } from "@/widgets/OffersMap/ui/OffersMap/OffersMap";
 
 import { OffersFilterFields } from "../../model/types";
 import { OffersFilter } from "../OffersFilter/OffersFilter";
@@ -44,6 +45,15 @@ export const OffersSearchFilter = () => {
             data: allOffersMap = [], isLoading: isAllOffersMapLoading,
             isFetching: isAllOffersMapFetching,
         }] = useLazyGetAllOffersMapQuery();
+    // Отдельный вызов того же эндпоинта по конкретным id вместо bounds —
+    // даёт координаты/наличие локации именно для карточек текущей страницы
+    // списка, независимо от того, что сейчас видно в viewport карты. Без
+    // этого нельзя было бы отличить "у вакансии правда нет координат" от
+    // "координаты есть, но карта сейчас смотрит в другое место".
+    const [fetchPageOffersLocation, {
+        data: pageOffersLocation = [], isFetching: isPageLocationFetching,
+    }] = useLazyGetAllOffersMapQuery();
+    const mapBoundsRef = useRef<MapViewportBounds | null>(null);
     const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const { t } = useTranslation("offers-map");
     const searchRef = useRef<SearchOffersRef>(null);
@@ -71,6 +81,22 @@ export const OffersSearchFilter = () => {
     const previousCategoryParamRef = useRef(searchParams.get("category"));
     const currentSearchRef = useRef<string>("");
 
+    const fetchOffersMapWithBounds = useCallback((params: Record<string, unknown>) => {
+        fetchAllOffersMap({ ...params, ...(mapBoundsRef.current ?? {}) });
+    }, [fetchAllOffersMap]);
+
+    const handleBoundsChange = useCallback((bounds: MapViewportBounds) => {
+        mapBoundsRef.current = bounds;
+
+        const watchData = watch();
+        const preparedData = offersFilterApiAdapter(watchData);
+        if (currentSearchRef.current) {
+            fetchOffersMapWithBounds({ search: currentSearchRef.current });
+        } else {
+            fetchOffersMapWithBounds({ ...preparedData });
+        }
+    }, [watch, fetchOffersMapWithBounds]);
+
     useEffect(() => {
         if (currentSearchRef.current) {
             fetchOffers({
@@ -89,7 +115,7 @@ export const OffersSearchFilter = () => {
     useEffect(() => {
         const watchData = watch();
         const preparedData = offersFilterApiAdapter(watchData);
-        fetchAllOffersMap({ ...preparedData });
+        fetchOffersMapWithBounds({ ...preparedData });
     }, []);
 
     useEffect(() => {
@@ -132,7 +158,7 @@ export const OffersSearchFilter = () => {
         if (isExternalCategoryChange) {
             const preparedData = offersFilterApiAdapter({ ...watch(), category: parsedCategories });
             fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: 1 });
-            fetchAllOffersMap({ ...preparedData });
+            fetchOffersMapWithBounds({ ...preparedData });
             setCurrentPage(1);
         }
         isInternalCategoryPushRef.current = false;
@@ -142,6 +168,11 @@ export const OffersSearchFilter = () => {
 
     const onChangePage = useCallback((pageItem: number) => {
         setCurrentPage(pageItem);
+        // Выделенная карточка принадлежит текущей странице списка — при
+        // переходе на другую страницу она пропадает из виду, так что и
+        // выбор логично сбрасывать (заодно не даёт селекту "залипнуть" на
+        // id, для которого больше нет свежих данных о координатах).
+        setSelectedOfferId(undefined);
     }, []);
 
     const onApplySearch = useCallback(async (search: string) => {
@@ -154,7 +185,7 @@ export const OffersSearchFilter = () => {
         fetchOffers({
             sort: OfferSort.UpdatedDesc, search, limit: OFFERS_PER_PAGE, page: 1,
         });
-        fetchAllOffersMap({ search });
+        fetchOffersMapWithBounds({ search });
         reset(defaultValues);
         onChangePage(1);
     }, []);
@@ -175,7 +206,7 @@ export const OffersSearchFilter = () => {
         currentSearchRef.current = "";
         const preparedData = offersFilterApiAdapter(data);
         fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: 1 });
-        fetchAllOffersMap({ ...preparedData });
+        fetchOffersMapWithBounds({ ...preparedData });
         onChangePage(1);
     }), []);
 
@@ -185,7 +216,7 @@ export const OffersSearchFilter = () => {
         searchRef.current?.clearSearch();
         const preparedData = offersFilterApiAdapter(defaultValues);
         fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: 1 });
-        fetchAllOffersMap({ ...preparedData });
+        fetchOffersMapWithBounds({ ...preparedData });
         reset(defaultValues);
         onChangePage(1);
     }, []);
@@ -197,6 +228,33 @@ export const OffersSearchFilter = () => {
     const handleSelectOffer = useCallback((offerId: number) => {
         setSelectedOfferId(offerId);
     }, []);
+
+    useEffect(() => {
+        const ids = offersData?.data.map((offer) => offer.id) ?? [];
+        if (ids.length > 0) {
+            fetchPageOffersLocation({ ids });
+        }
+    }, [offersData?.data]);
+
+    const offerIdsWithoutLocation = useMemo(() => {
+        if (isPageLocationFetching) return new Set<number>();
+
+        const withLocation = new Set(pageOffersLocation.map((offer) => offer.id));
+        return new Set(
+            (offersData?.data ?? [])
+                .map((offer) => offer.id)
+                .filter((id) => !withLocation.has(id)),
+        );
+    }, [pageOffersLocation, offersData?.data, isPageLocationFetching]);
+
+    const selectedOfferCoordinates = useMemo(() => {
+        if (!selectedOfferId || isPageLocationFetching) return undefined;
+
+        const match = pageOffersLocation.find((offer) => offer.id === selectedOfferId);
+        if (!match) return null;
+
+        return { latitude: match.latitude, longitude: match.longitude };
+    }, [selectedOfferId, pageOffersLocation, isPageLocationFetching]);
 
     useEffect(() => {
         const subscription = watch((value, { name, type }) => {
@@ -214,10 +272,12 @@ export const OffersSearchFilter = () => {
                             limit: OFFERS_PER_PAGE,
                             page: currentPage,
                         });
-                        fetchAllOffersMap({ ...preparedData, search: currentSearchRef.current });
+                        fetchOffersMapWithBounds({
+                            ...preparedData, search: currentSearchRef.current,
+                        });
                     } else {
                         fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: currentPage });
-                        fetchAllOffersMap({ ...preparedData });
+                        fetchOffersMapWithBounds({ ...preparedData });
                     }
                 }, 300);
             }
@@ -265,6 +325,7 @@ export const OffersSearchFilter = () => {
                             total={offersData?.pagination.total ?? 0}
                             selectedOfferId={selectedOfferId}
                             onSelectOffer={handleSelectOffer}
+                            offerIdsWithoutLocation={offerIdsWithoutLocation}
                         />
                     </div>
                     {isMapOpened && (
@@ -274,6 +335,8 @@ export const OffersSearchFilter = () => {
                             className={styles.offersMap}
                             classNameMap={styles.offersMap}
                             selectedOfferId={selectedOfferId}
+                            selectedOfferCoordinates={selectedOfferCoordinates}
+                            onBoundsChange={handleBoundsChange}
                         />
                     )}
                 </div>

--- a/src/widgets/OffersMap/ui/OfferCard/OfferCard.tsx
+++ b/src/widgets/OffersMap/ui/OfferCard/OfferCard.tsx
@@ -36,6 +36,7 @@ interface OfferCardProps {
     // isFavoriteIconShow: boolean;
     isSelected?: boolean;
     onSelect?: (offerId: number) => void;
+    hasLocation?: boolean;
     locale: Locale;
 }
 
@@ -52,6 +53,7 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
         classNameCard,
         isSelected,
         onSelect,
+        hasLocation,
         locale,
     } = props;
 
@@ -85,6 +87,7 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
                 isFavorite={isFavorite}
                 isSelected={isSelected}
                 onSelect={onSelect}
+                hasLocation={hasLocation}
                 locale={locale}
                 handleFavoriteClick={onFavoriteClick}
             />

--- a/src/widgets/OffersMap/ui/OffersList/OffersList.tsx
+++ b/src/widgets/OffersMap/ui/OffersList/OffersList.tsx
@@ -29,6 +29,7 @@ interface OffersListProps {
     onChangePage: (pageItem: number) => void;
     selectedOfferId?: number;
     onSelectOffer?: (offerId: number) => void;
+    offerIdsWithoutLocation?: Set<number>;
 }
 
 export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
@@ -44,6 +45,7 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
         isLoading,
         selectedOfferId,
         onSelectOffer,
+        offerIdsWithoutLocation,
     } = props;
 
     const { locale } = useLocale();
@@ -99,6 +101,7 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
                     key={offer.id}
                     isSelected={offer.id === selectedOfferId}
                     onSelect={onSelectOffer}
+                    hasLocation={!offerIdsWithoutLocation?.has(offer.id)}
                     // isFavoriteIconShow={!!isAuth}
                 />
             ));
@@ -111,7 +114,10 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
             />
         );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [data, isLoading, locale, mapOpenValue, t, selectedOfferId, onSelectOffer]);
+    }, [
+        data, isLoading, locale, mapOpenValue, t, selectedOfferId,
+        onSelectOffer, offerIdsWithoutLocation,
+    ]);
 
     const totalPages = Math.ceil(total / offersPerPage);
 

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -1,12 +1,17 @@
 import {
     describe, it, expect, vi, beforeEach,
 } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { useEffect } from "react";
+import {
+    render, screen, act, waitFor,
+} from "@testing-library/react";
 import { OffersMap } from "./OffersMap";
 import { OfferMap } from "@/entities/Offer";
 
 const setCenter = vi.fn();
 const getZoom = vi.fn(() => 5);
+const getBounds = vi.fn(() => [[54, 36], [57, 39]]);
+const boundsChangeHandlers: Array<() => void> = [];
 
 vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
@@ -19,10 +24,29 @@ vi.mock("@/app/providers/LocaleProvider", () => ({
 vi.mock("@pbe/react-yandex-maps", () => ({
     YMaps: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     // eslint-disable-next-line react/no-unused-prop-types
-    Map: (
-        { children, instanceRef }: { children: React.ReactNode; instanceRef: { current: unknown } },
-    ) => {
-        instanceRef.current = { setCenter, getZoom };
+    Map: (props: {
+        children: React.ReactNode;
+        instanceRef: { current: unknown };
+        onLoad?: (ymap: unknown) => void;
+    }) => {
+        const { children, instanceRef, onLoad } = props;
+        instanceRef.current = {
+            setCenter,
+            getZoom,
+            getBounds,
+            events: {
+                add: (_event: string, handler: () => void) => boundsChangeHandlers.push(handler),
+                remove: (_event: string, handler: () => void) => {
+                    const index = boundsChangeHandlers.indexOf(handler);
+                    if (index !== -1) boundsChangeHandlers.splice(index, 1);
+                },
+            },
+        };
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useEffect(() => {
+            onLoad?.({ templateLayoutFactory: { createClass: () => undefined } });
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
         return <div>{children}</div>;
     },
     ZoomControl: () => null,
@@ -43,14 +67,17 @@ describe("OffersMap", () => {
     beforeEach(() => {
         setCenter.mockClear();
         getZoom.mockClear();
+        getBounds.mockClear();
+        boundsChangeHandlers.length = 0;
     });
 
-    it("фокусирует карту, если у выбранной вакансии есть координаты", () => {
+    it("фокусирует карту, если у выбранной вакансии известны координаты", () => {
         render(
             <OffersMap
                 offersData={[offer({ id: 1 })]}
                 isOffersLoading={false}
                 selectedOfferId={1}
+                selectedOfferCoordinates={{ latitude: 55.75, longitude: 37.61 }}
             />,
         );
 
@@ -58,16 +85,57 @@ describe("OffersMap", () => {
         expect(screen.queryByText(/местоположение/)).not.toBeInTheDocument();
     });
 
-    it("показывает подсказку вместо тишины, если у вакансии нет координат", () => {
+    it("показывает подсказку вместо тишины, если координаты точно отсутствуют (null)", () => {
         render(
             <OffersMap
                 offersData={[offer({ id: 1 })]}
                 isOffersLoading={false}
                 selectedOfferId={999}
+                selectedOfferCoordinates={null}
             />,
         );
 
         expect(setCenter).not.toHaveBeenCalled();
         expect(screen.getByText("У этой вакансии не указано местоположение на карте")).toBeInTheDocument();
+    });
+
+    it("не показывает подсказку, пока координаты ещё не разрешены (undefined)", () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+                selectedOfferId={999}
+                selectedOfferCoordinates={undefined}
+            />,
+        );
+
+        expect(setCenter).not.toHaveBeenCalled();
+        expect(screen.queryByText(/местоположение/)).not.toBeInTheDocument();
+    });
+
+    it("сообщает границы видимой области карты через onBoundsChange", async () => {
+        const onBoundsChange = vi.fn();
+        render(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+                onBoundsChange={onBoundsChange}
+            />,
+        );
+
+        // Начальные границы сообщаются сразу при загрузке карты, ещё до
+        // какого-либо реального panning/zoom пользователем.
+        await waitFor(() => expect(onBoundsChange).toHaveBeenCalledWith({
+            boundsSwLat: 54, boundsSwLng: 36, boundsNeLat: 57, boundsNeLng: 39,
+        }));
+        onBoundsChange.mockClear();
+
+        act(() => {
+            boundsChangeHandlers.forEach((handler) => handler());
+        });
+
+        await waitFor(() => expect(onBoundsChange).toHaveBeenCalledWith({
+            boundsSwLat: 54, boundsSwLng: 36, boundsNeLat: 57, boundsNeLng: 39,
+        }), { timeout: 1000 });
     });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -20,6 +20,14 @@ import { getOfferPersonalPageUrl } from "@/shared/config/routes/AppUrls";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 
 const FOCUS_ZOOM = 10;
+const BOUNDS_CHANGE_DEBOUNCE_MS = 400;
+
+export interface MapViewportBounds {
+    boundsSwLat: number;
+    boundsSwLng: number;
+    boundsNeLat: number;
+    boundsNeLng: number;
+}
 
 interface OffersMapProps {
     className?: string;
@@ -27,12 +35,20 @@ interface OffersMapProps {
     offersData: OfferMap[];
     isOffersLoading: boolean;
     selectedOfferId?: number;
+    // undefined — нет выбора/ещё не знаем; объект — координаты для фокуса;
+    // null — точно известно, что у вакансии нет координат (показать notice).
+    // Намеренно НЕ выводится из offersData самой карты: после того как
+    // маркеры стали viewport-scoped, отсутствие в offersData означает "вне
+    // текущей видимой области", а не "нет координат вообще" — это два разных
+    // случая, которые раньше смешивались.
+    selectedOfferCoordinates?: { latitude: number; longitude: number } | null;
+    onBoundsChange?: (bounds: MapViewportBounds) => void;
 }
 
 export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const {
         className, classNameMap, isOffersLoading,
-        offersData, selectedOfferId,
+        offersData, selectedOfferId, selectedOfferCoordinates, onBoundsChange,
     } = props;
     const { locale } = useLocale();
     const { t } = useTranslation();
@@ -40,6 +56,8 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const [showNoLocationNotice, setShowNoLocationNotice] = useState(false);
     const mapRef = useRef<any>(null);
     const objectManagerRef = useRef<any>(null);
+    const onBoundsChangeRef = useRef(onBoundsChange);
+    onBoundsChangeRef.current = onBoundsChange;
 
     const noTitle = t("Без названия");
     const noCategory = t("Без категории");
@@ -96,32 +114,54 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     ]);
 
     useEffect(() => {
-        if (!selectedOfferId) {
+        if (!selectedOfferId || selectedOfferCoordinates === undefined) {
             setShowNoLocationNotice(false);
             return;
         }
-
-        const offerById = offersData.find((offer) => offer.id === selectedOfferId);
-        const selectedOffer = offerById
-            && typeof offerById.latitude === "number"
-            && typeof offerById.longitude === "number"
-            ? offerById
-            : undefined;
 
         // Часть вакансий физически не имеет координат в базе (адрес не
         // геокодирован) — карте попросту нечем "сфокусироваться". Раньше
         // клик по такой карточке в списке просто ничего не делал молча,
         // что выглядело как баг; показываем явную причину вместо тишины.
-        setShowNoLocationNotice(!selectedOffer);
-        if (!selectedOffer || !mapRef.current) return;
+        setShowNoLocationNotice(selectedOfferCoordinates === null);
+        if (!selectedOfferCoordinates || !mapRef.current) return;
 
         const currentZoom = mapRef.current.getZoom();
         mapRef.current.setCenter(
-            [selectedOffer.latitude, selectedOffer.longitude],
+            [selectedOfferCoordinates.latitude, selectedOfferCoordinates.longitude],
             Math.max(currentZoom, FOCUS_ZOOM),
             { duration: 400 },
         );
-    }, [selectedOfferId, offersData]);
+    }, [selectedOfferId, selectedOfferCoordinates]);
+
+    useEffect(() => {
+        if (!ymapState || !mapRef.current) return undefined;
+
+        const map = mapRef.current;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+        const emitBounds = () => {
+            const bounds = map.getBounds?.();
+            if (!bounds) return;
+            const [[swLat, swLng], [neLat, neLng]] = bounds;
+            onBoundsChangeRef.current?.({
+                boundsSwLat: swLat, boundsSwLng: swLng, boundsNeLat: neLat, boundsNeLng: neLng,
+            });
+        };
+
+        const handleBoundsChange = () => {
+            if (timeoutId) clearTimeout(timeoutId);
+            timeoutId = setTimeout(emitBounds, BOUNDS_CHANGE_DEBOUNCE_MS);
+        };
+
+        map.events.add("boundschange", handleBoundsChange);
+        emitBounds();
+
+        return () => {
+            if (timeoutId) clearTimeout(timeoutId);
+            map.events.remove("boundschange", handleBoundsChange);
+        };
+    }, [ymapState]);
 
     if (isOffersLoading) {
         return (


### PR DESCRIPTION
## Что делает

Так работает большинство сервисов с картой+списком (Airbnb, Booking, Avito) — карта запрашивает маркеры только в своей видимой области, а не весь результат разом. Использует новые bounds-параметры бэкенда (Goodsurfing/gs-backend#286).

- `OffersMap` слушает `boundschange` карты (debounce 400мс) и сообщает границы наверх через `onBoundsChange`.
- `OffersSearchFilter` подмешивает текущие bounds во **все** запросы маркеров (первая загрузка, смена фильтров/поиска/сортировки, панорамирование/зум).

## Заодно чинит скрытую проблему в уже смёрженном notice-фиксе (#456)

Как только маркеры стали viewport-scoped, «вакансии сейчас нет в маркерах карты» перестало однозначно означать «у неё нет координат» — она могла просто быть вне текущей видимой области. Раньше notice «нет местоположения на карте» опирался именно на этот (теперь уже неполный) набор.

Фикс: отдельный маленький запрос — тот же эндпоинт, но с `ids` именно для вакансий текущей страницы списка, независимо от viewport карты — даёт точные координаты/статус для каждой карточки:
- `OffersMap` получает явный проп `selectedOfferCoordinates` (`{lat,lng} | null | undefined`) вместо поиска по своему (теперь неполному) набору маркеров.
- `OfferCard` показывает бейдж «нет на карте» для карточек, где точно подтверждено отсутствие координат — вместо молчаливого обещания фокуса, который никогда не случится.
- Выбор вакансии сбрасывается при смене страницы (подсветка и её разрешённые координаты относятся к данным именно этой страницы).

## Тесты

- `OffersMap.test.tsx`: фокус по явным координатам, notice только при `null` (не при `undefined`), `onBoundsChange` дергается с реальными границами (мок `@pbe/react-yandex-maps` с `events.add/remove`+`getBounds`).
- `OffersSearchFilter.test.tsx`: bounds подмешиваются в запрос маркеров после `onBoundsChange`; координаты запрашиваются `ids[]` именно текущей страницы; выбор сбрасывается при смене страницы.
- `OfferCard.test.tsx`: бейдж «нет на карте» только при `hasLocation === false`.

Revert-and-confirm-fails: 7 из 21 теста корректно падают на откаченном коде (ровно те, что целятся в новое поведение), остальные не завязаны на изменения и остаются зелёными. `tsc --noEmit`/`eslint` чистые.

## Известное ограничение (не в скоупе)

На максимальном зуме-аутe (весь мир в кадре) bounds почти не сокращают выборку — это ожидаемо и так же ведут себя референсные сервисы; кластеризация на клиенте уже сглаживает визуальную часть.
