### PR TITLE
fix(offers-map): stop unmounting Map on isOffersLoading

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
@@ -93,7 +93,13 @@
 }
 
 .loadingPlaceholder {
-    margin-top: 30px;
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(255, 255, 255, 0.5);
 }
 
 .noLocationNotice {

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -12,6 +12,7 @@ const setCenter = vi.fn();
 const getZoom = vi.fn(() => 5);
 const getBounds = vi.fn(() => [[54, 36], [57, 39]]);
 const boundsChangeHandlers: Array<() => void> = [];
+const onLoadCalls = vi.fn();
 
 vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
@@ -44,6 +45,7 @@ vi.mock("@pbe/react-yandex-maps", () => ({
         };
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
+            onLoadCalls();
             onLoad?.({ templateLayoutFactory: { createClass: () => undefined } });
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }, []);
@@ -68,6 +70,7 @@ describe("OffersMap", () => {
         setCenter.mockClear();
         getZoom.mockClear();
         getBounds.mockClear();
+        onLoadCalls.mockClear();
         boundsChangeHandlers.length = 0;
     });
 
@@ -137,5 +140,40 @@ describe("OffersMap", () => {
         await waitFor(() => expect(onBoundsChange).toHaveBeenCalledWith({
             boundsSwLat: 54, boundsSwLng: 36, boundsNeLat: 57, boundsNeLng: 39,
         }), { timeout: 1000 });
+    });
+
+    it("не пересоздаёт карту при переключении isOffersLoading (регресс: карта уходила в бесконечный цикл unmount/remount)", async () => {
+        const onBoundsChange = vi.fn();
+        const { rerender } = render(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+                onBoundsChange={onBoundsChange}
+            />,
+        );
+
+        await waitFor(() => expect(onLoadCalls).toHaveBeenCalledTimes(1));
+
+        // isOffersLoading становится true — как только onBoundsChange
+        // из первого рендера триггерит фетч у родителя. Раньше это
+        // размонтировало <Map> целиком (early return вместо оверлея),
+        // из-за чего onLoad срабатывал заново -> emitBounds() -> новый
+        // фетч -> isOffersLoading снова true -> бесконечный цикл.
+        rerender(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading
+                onBoundsChange={onBoundsChange}
+            />,
+        );
+        rerender(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+                onBoundsChange={onBoundsChange}
+            />,
+        );
+
+        expect(onLoadCalls).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -163,18 +163,13 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         };
     }, [ymapState]);
 
-    if (isOffersLoading) {
-        return (
-            <div className={cn(className, styles.wrapper)}>
+    return (
+        <div className={cn(className, styles.wrapper)}>
+            {isOffersLoading && (
                 <div className={styles.loadingPlaceholder}>
                     <MiniLoader />
                 </div>
-            </div>
-        );
-    }
-
-    return (
-        <div className={cn(className, styles.wrapper)}>
+            )}
             {showNoLocationNotice && (
                 <div className={styles.noLocationNotice}>{noLocationText}</div>
             )}


### PR DESCRIPTION
## Проблема

После #457 карта на `/offers-map` на стейдже вообще не грузилась. Причина — бесконечный цикл unmount/remount `<Map>`:

1. `boundschange`-эффект вызывает `emitBounds()` сразу при монтировании карты.
2. Родитель получает bounds, запускает фетч маркеров → `isOffersLoading` становится `true`.
3. `OffersMap` при `isOffersLoading === true` делал ранний `return` с полной заменой дерева на плейсхолдер — это **размонтировало** `<Map>` целиком, а не просто показывало лоадер поверх.
4. Когда фетч завершался, `isOffersLoading` → `false`, `<Map>` монтировался заново → `onLoad` срабатывал снова → `emitBounds()` снова → новый фетч → `isOffersLoading` → `true` → размонтирование → ... по кругу бесконечно.

Карта физически не успевала стабилизироваться — застревала в мерцании между плейсхолдером и картой.

## Фикс

`<Map>` теперь монтируется один раз и не размонтируется при смене `isOffersLoading` — состояние загрузки показывается как оверлей поверх карты, а не заменяет её дерево.

## Test plan
- [x] Новый regression-тест: воспроизвёл баг (revert-and-confirm-fails — тест падает на коде до фикса: `onLoad` вызывается 2 раза вместо 1 при переключении `isOffersLoading`), после фикса — зелёный
- [x] Остальные тесты `OffersMap`/`OffersSearchFilter`/`OfferCard` — зелёные
- [x] `tsc --noEmit`, `eslint` — чисто
- [ ] Живая проверка на стейдже после деплоя

🤖 Generated with [Claude Code](https://claude.com/claude-code)
