### PR TITLE
chore(api): point API base URL constants at v1 (matches backend v3→v1)

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,7 +1,7 @@
 import { rest } from "msw";
 
 export const handlers = [
-    rest.get("*/api/v3/verify/email/:id", (req, res, ctx) => res(
+    rest.get("*/api/v1/verify/email/:id", (req, res, ctx) => res(
         ctx.status(200),
         ctx.json({
             accessToken: "test-access-token",

--- a/src/shared/constants/api/index.ts
+++ b/src/shared/constants/api/index.ts
@@ -2,11 +2,12 @@
 // to staging) so CORS/IAP doesn't kick in. We use the running page origin
 // (typically http://localhost:3000) — NOT an empty string — because several
 // RTK Query endpoints inject API_BASE_URL_V3 directly into `url:` while
-// using `baseQuery` with baseUrl=API_BASE_URL (a.k.a. /api/v1/). When both
-// are relative, RTK joins them and you get nonsense like
-// `/api/v1/api/v3/profile`. When the injected URL is absolute, RTK's
-// `isAbsoluteUrl` short-circuits and uses it verbatim. Browser still hits
-// localhost:3000 so the Vite proxy catches it.
+// using `baseQuery` with baseUrl=API_BASE_URL. Both now point at /api/v1/,
+// but RTK still needs the injected one to be an absolute URL: when both are
+// relative, RTK naively concatenates them into nonsense like
+// `/api/v1/api/v1/profile`. Absolute URLs make RTK's `isAbsoluteUrl` short-
+// circuit and use the value verbatim. Browser still hits localhost:3000 so
+// the Vite proxy catches it.
 const API_ORIGIN = import.meta.env.DEV && typeof window !== "undefined"
     ? window.location.origin
     : `${import.meta.env.VITE_API_BASE_URL}`.replace(/\/+$/, "");
@@ -14,10 +15,9 @@ const API_ORIGIN = import.meta.env.DEV && typeof window !== "undefined"
 export const BASE_URL = API_ORIGIN;
 export const BASE_URI = "/api/v1/";
 export const API_BASE_URL = `${API_ORIGIN}/api/v1/`;
-export const API_BASE_URL_V2 = `${API_ORIGIN}/api/v2/`;
-export const API_BASE_URL_V3 = `${API_ORIGIN}/api/v3/`;
+export const API_BASE_URL_V3 = `${API_ORIGIN}/api/v1/`;
 export const BASE_VK_URI = `${API_ORIGIN}/api/vk/`;
-export const API_ADMIN_BASE_URL = `${API_ORIGIN}/admin/v3/`;
+export const API_ADMIN_BASE_URL = `${API_ORIGIN}/admin/v1/`;
 export const API_ORGANIZATIONS_BASE_URL = `${API_ORIGIN}/api/organizations/`;
 export const API_VACANCY_BASE_URL = `${API_ORIGIN}/api/vacancies/`;
 export const API_USER_BASE_URL = `${API_ORIGIN}/api/users/`;


### PR DESCRIPTION
## Что сделано

Ответная часть к gs-backend#288 (схлопывание `/api/v2/`, `/api/v3/`, `/admin/v3/` в единый `/api/v1/`, `/admin/v1/`).

Почти весь фронтенд обращается к API через две общие константы (`API_BASE_URL_V3`, `API_ADMIN_BASE_URL`), а не хардкодит пути — поэтому изменить пришлось только их значения в `src/shared/constants/api/index.ts`. Более 10 api-клиентов (offerApi, chatApi, profileApi, reviewApi, donationPaymentApi, adminApi и др.) подхватывают это автоматически.

Также убрал `API_BASE_URL_V2` — нигде в приложении не использовалась (реальный логин всегда шёл через `/api/v1/token`, а не через `/api/v2/token`, на который эта константа указывала).

## Test plan
- [x] `tsc --noEmit` — чисто
- [x] `eslint` на изменённых файлах — чисто
- [x] Полный vitest-сьют (260 тестов, 85 файлов) — все зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)
