### PR TITLE
test(host): add coverage for HostMainInfoPage and HostTeamPage

### DIFF
--- a/src/pages/HostMainInfoPage/ui/HostMainInfoPage/HostMainInfoPage.test.tsx
+++ b/src/pages/HostMainInfoPage/ui/HostMainInfoPage/HostMainInfoPage.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import HostMainInfoPage from "./HostMainInfoPage";
+
+const capturedProps: { current: Record<string, unknown> | null } = { current: null };
+const translationsReady = { current: true };
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key, ready: translationsReady.current }),
+}));
+
+vi.mock("@/features/HostDescription", () => ({
+    HostDescriptionForm: (props: Record<string, unknown>) => {
+        capturedProps.current = props;
+        return <div>host-description-form</div>;
+    },
+}));
+
+describe("HostMainInfoPage", () => {
+    it("передаёт hostId и данные профиля в HostDescriptionForm после загрузки", async () => {
+        server.use(
+            rest.get("*/profile", (req, res, ctx) => res(ctx.status(200), ctx.json({
+                id: "u1",
+                email: "host@test.ru",
+                hostId: "h1",
+                firstName: null,
+                lastName: null,
+            }))),
+        );
+
+        renderWithProviders(<HostMainInfoPage />);
+
+        await waitFor(() => expect(capturedProps.current).toMatchObject({
+            host: "h1",
+            isLoading: false,
+            isError: false,
+        }));
+
+        expect(screen.getByText("hostDescription.Основная информация")).toBeInTheDocument();
+        expect((capturedProps.current?.myProfile as { id: string })?.id).toBe("u1");
+    });
+
+    it("isError=true при ошибке загрузки профиля", async () => {
+        server.use(
+            rest.get("*/profile", (req, res, ctx) => res(ctx.status(500))),
+        );
+
+        renderWithProviders(<HostMainInfoPage />);
+
+        await waitFor(() => expect(capturedProps.current).toMatchObject({ isError: true }));
+    });
+
+    it("показывает лоадер вместо формы, пока переводы не готовы", () => {
+        server.use(
+            rest.get("*/profile", (req, res, ctx) => res(ctx.status(200), ctx.json({ id: "u1", hostId: "h1" }))),
+        );
+        translationsReady.current = false;
+        try {
+            renderWithProviders(<HostMainInfoPage />);
+
+            expect(screen.queryByText("hostDescription.Основная информация")).not.toBeInTheDocument();
+            expect(screen.queryByText("host-description-form")).not.toBeInTheDocument();
+        } finally {
+            translationsReady.current = true;
+        }
+    });
+});

--- a/src/pages/HostTeamPage/ui/HostTeamPage.test.tsx
+++ b/src/pages/HostTeamPage/ui/HostTeamPage.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { rest } from "msw";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import HostTeamPage from "./HostTeamPage";
+
+const capturedProps: { current: Record<string, unknown> | null } = { current: null };
+
+vi.mock("@/features/TeamForm", () => ({
+    TeamForm: (props: Record<string, unknown>) => {
+        capturedProps.current = props;
+        return <div>team-form</div>;
+    },
+}));
+
+describe("HostTeamPage", () => {
+    it("ничего не рендерит, пока данные организации не загружены", () => {
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(ctx.delay("infinite"))),
+        );
+
+        renderWithProviders(<HostTeamPage />);
+
+        expect(screen.queryByText("team-form")).not.toBeInTheDocument();
+    });
+
+    it("передаёт hostId и email владельца в TeamForm после загрузки", async () => {
+        server.use(
+            rest.get("*/personal/organization", (req, res, ctx) => res(ctx.status(200), ctx.json({
+                id: "h1",
+                owner: { email: "owner@test.ru" },
+            }))),
+        );
+
+        renderWithProviders(<HostTeamPage />);
+
+        await screen.findByText("team-form");
+
+        expect(capturedProps.current).toMatchObject({
+            hostId: "h1",
+            hostEmail: "owner@test.ru",
+        });
+    });
+});


### PR DESCRIPTION
## Что сделано

Закрывает реальный пробел в покрытии: `HostMainInfoPage` и `HostTeamPage` не имели вообще никаких тестов (в трекере задач числились выполненными из более ранней сессии, но файлов на диске не было — судя по всему, потерялись до коммита).

Обе страницы — тонкие обёртки над уже хорошо покрытыми формами (`HostDescriptionForm`, `TeamForm`), так что тесты фокусируются на корректности связки:
- `HostMainInfoPage`: проброс `host`/`myProfile`/`isLoading`/`isError` в форму, лоадер вместо контента пока переводы не готовы
- `HostTeamPage`: ничего не рендерит до загрузки организации, проброс `hostId`/`hostEmail` после загрузки

## Test plan
- [x] `tsc --noEmit`, `eslint` — чисто
- [x] Новые тесты (5 штук) — зелёные
- [x] Полный vitest-сьют (265 тестов, 87 файлов) — все зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)
