### PR TITLE
chore: rename misleading API_BASE_URL_V3 constant to API_BASE_URL_ABSOLUTE

### DIFF
--- a/src/entities/Admin/api/adminApi.ts
+++ b/src/entities/Admin/api/adminApi.ts
@@ -69,7 +69,7 @@ import { Achievement, GetAchievement, GetAchievementRequest } from "@/types/achi
 import {
     Food, GetFood, GetFoodRequest, GetHouse, GetTransfer, House, Transfer,
 } from "@/shared/data/conditions";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import { UpdateOfferImageGallery, UpdateOfferStatusRequest, UpdateOfferStatusResponse } from "@/entities/Offer";
 
 export const adminApi = createApi({
@@ -126,7 +126,7 @@ export const adminApi = createApi({
         }),
         getPublicSkills: build.query<Skill[], GetPublicSkillRequest>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}skill/list`,
+                url: `${API_BASE_URL_ABSOLUTE}skill/list`,
                 method: "GET",
                 params,
             }),
@@ -195,7 +195,7 @@ export const adminApi = createApi({
         getPublicAchievements: build.query<Achievement[],
         GetAchievementRequest>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}achievement/list`,
+                url: `${API_BASE_URL_ABSOLUTE}achievement/list`,
                 method: "GET",
                 params,
             }),
@@ -265,7 +265,7 @@ export const adminApi = createApi({
         getPublicTransfers: build.query<Transfer[],
         GetAdminTransferRequest>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}transfer/list`,
+                url: `${API_BASE_URL_ABSOLUTE}transfer/list`,
                 method: "GET",
                 params,
             }),
@@ -335,7 +335,7 @@ export const adminApi = createApi({
         getPublicHouses: build.query<House[],
         GetHouseRequest>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}house/list`,
+                url: `${API_BASE_URL_ABSOLUTE}house/list`,
                 method: "GET",
                 params,
             }),
@@ -405,7 +405,7 @@ export const adminApi = createApi({
         getPublicFoods: build.query<Food[],
         GetFoodRequest>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}food/list`,
+                url: `${API_BASE_URL_ABSOLUTE}food/list`,
                 method: "GET",
                 params,
             }),
@@ -681,7 +681,7 @@ export const adminApi = createApi({
         getPublicCategoriesVacancy: build.query<CategoryCountVacancy[],
         GetCategoryRequest>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}category/list`,
+                url: `${API_BASE_URL_ABSOLUTE}category/list`,
                 method: "GET",
                 params,
             }),
@@ -821,7 +821,7 @@ export const adminApi = createApi({
         // Ambassadors
         getAmbassadors: build.query<GetAmbassadorsResponse, GetAmbassadorsParams>({
             query: () => ({
-                url: `${API_BASE_URL_V3}leader/list`,
+                url: `${API_BASE_URL_ABSOLUTE}leader/list`,
                 method: "GET",
             }),
             providesTags: ["ambassadors"],
@@ -870,7 +870,7 @@ export const adminApi = createApi({
         // About project
         getAbouProjectPageInfo: build.query<GetAboutProjectInfo, void>({
             query: () => ({
-                url: `${API_BASE_URL_V3}about-project/element`,
+                url: `${API_BASE_URL_ABSOLUTE}about-project/element`,
                 method: "GET",
             }),
             providesTags: ["about"],

--- a/src/entities/Admin/api/adminBannerMarketingApi.ts
+++ b/src/entities/Admin/api/adminBannerMarketingApi.ts
@@ -1,6 +1,6 @@
 import { createApi } from "@reduxjs/toolkit/dist/query/react";
 import { baseAdminQueryAcceptJson } from "@/shared/api/baseQuery/baseQuery";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import {
     BannerMarketingElement, CreateAdminBannerMarketing, GetAdminBannerMarketingListParams,
     GetAdminBannerMarketingListResponse, GetAdminMarketingBanner, GetBannerMarketingParams,
@@ -15,7 +15,7 @@ export const adminBannerMarketingApi = createApi({
         getBannerMarketing: build.query<BannerMarketingElement,
         GetBannerMarketingParams>({
             query: ({ type }) => ({
-                url: `${API_BASE_URL_V3}marketing-banner/element/${type}`,
+                url: `${API_BASE_URL_ABSOLUTE}marketing-banner/element/${type}`,
                 method: "GET",
             }),
             providesTags: ["banner"],

--- a/src/entities/Admin/api/adminOurTeamApi.ts
+++ b/src/entities/Admin/api/adminOurTeamApi.ts
@@ -1,6 +1,6 @@
 import { createApi } from "@reduxjs/toolkit/dist/query/react";
 import { baseAdminQueryAcceptJson } from "@/shared/api/baseQuery/baseQuery";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import {
     CreateAdminOurTeam,
     GetAdminOurTeam,
@@ -15,7 +15,7 @@ export const adminOurTeamApi = createApi({
     endpoints: (build) => ({
         getOurTeamList: build.query<GetOurTeamResponse, GetOurTeamParams>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}our-team/list`,
+                url: `${API_BASE_URL_ABSOLUTE}our-team/list`,
                 method: "GET",
                 params,
             }),

--- a/src/entities/Chat/api/chatApi.ts
+++ b/src/entities/Chat/api/chatApi.ts
@@ -10,7 +10,7 @@ import {
 } from "@/entities/Application";
 import { CreateMessageResponse, CreateMessageType } from "../model/types/messages";
 import { PaginationParams } from "@/types/api/pagination";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 
 interface MessagesRequest {
     chatId: string;
@@ -117,7 +117,7 @@ export const chatApi = createApi({
         getMyHostApplications: build.query<
         GetHostFormApplicationResponse, GetHostApplicationsParams>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}application/list-of-organization`,
+                url: `${API_BASE_URL_ABSOLUTE}application/list-of-organization`,
                 method: "GET",
                 params,
             }),
@@ -126,7 +126,7 @@ export const chatApi = createApi({
         getMyVolunteerApplications: build.query<GetVolunteerFormApplicationResponse,
         PaginationParams>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}application/list-of-volunteer`,
+                url: `${API_BASE_URL_ABSOLUTE}application/list-of-volunteer`,
                 method: "GET",
                 params,
             }),

--- a/src/entities/Offer/api/offerApi.ts
+++ b/src/entities/Offer/api/offerApi.ts
@@ -14,7 +14,7 @@ import {
 } from "../model/types/offer";
 import { GalleryItem } from "@/types/media";
 import { OfferStatus } from "../model/types/offerStatus";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import { UpdateOfferWhatToDoParams } from "../model/types/offerWhatToDo";
 import { UpdateOfferConditionsParams } from "../model/types/offerConditions";
 import { UpdateOfferDescriptionParams } from "../model/types/offerDescription";
@@ -81,7 +81,7 @@ export const offerApi = createApi({
         }),
         updateOfferImageGallery: build.mutation<void, UpdateOfferImageGallery>({
             query: ({ offerId, body }) => ({
-                url: `${API_BASE_URL_V3}vacancy/image-gallery/${offerId}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/image-gallery/${offerId}`,
                 method: "PATCH",
                 body,
             }),
@@ -89,7 +89,7 @@ export const offerApi = createApi({
         }),
         updateOfferDescription: build.mutation<void, UpdateOfferDescriptionParams>({
             query: ({ offerId, body }) => ({
-                url: `${API_BASE_URL_V3}vacancy/description/${offerId}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/description/${offerId}`,
                 method: "PATCH",
                 body,
             }),
@@ -97,7 +97,7 @@ export const offerApi = createApi({
         }),
         updateOfferWhatToDo: build.mutation<void, UpdateOfferWhatToDoParams>({
             query: ({ offerId, body }) => ({
-                url: `${API_BASE_URL_V3}vacancy/what-to-do/${offerId}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/what-to-do/${offerId}`,
                 method: "PATCH",
                 body,
             }),
@@ -105,7 +105,7 @@ export const offerApi = createApi({
         }),
         updateOfferConditions: build.mutation<void, UpdateOfferConditionsParams>({
             query: ({ offerId, body }) => ({
-                url: `${API_BASE_URL_V3}vacancy/condition/${offerId}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/condition/${offerId}`,
                 method: "PATCH",
                 body,
             }),
@@ -114,7 +114,7 @@ export const offerApi = createApi({
         updateOfferStatus: build.mutation<UpdateOfferStatusResponse, UpdateOfferStatusRequest>({
             query: (data) => ({
                 // url: `/vacancies/${data.id}/status`,
-                url: `${API_BASE_URL_V3}vacancy/toggle-status/${data.id}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/toggle-status/${data.id}`,
                 method: "PATCH",
                 headers: {
                     // "Content-Type": "application/merge-patch+json",
@@ -125,14 +125,14 @@ export const offerApi = createApi({
         }),
         deleteOffer: build.mutation<CreateOfferResponse, string>({
             query: (offerId) => ({
-                url: `${API_BASE_URL_V3}vacancy/${offerId}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/${offerId}`,
                 method: "DELETE",
             }),
             invalidatesTags: ["offer"],
         }),
         getOfferById: build.query<Offer, string>({
             query: (offerId) => ({
-                url: `${API_BASE_URL_V3}vacancy/${offerId}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/${offerId}`,
                 method: "GET",
             }),
             providesTags: ["offer"],
@@ -140,7 +140,7 @@ export const offerApi = createApi({
         getOfferParticipantListByOfferId: build.query<GetOfferParticipantListByOfferId,
         PaginationIdParams>({
             query: ({ id, limit, page }) => ({
-                url: `${API_BASE_URL_V3}profile/vacancy-participant/list/${id}`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/vacancy-participant/list/${id}`,
                 method: "GET",
                 params: { vacancyId: id, limit, page },
             }),
@@ -148,7 +148,7 @@ export const offerApi = createApi({
         }),
         getOffers: build.query<GetOffersResponse, Partial<GetOffersFilters> | undefined>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}vacancy/list`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/list`,
                 method: "GET",
                 params,
             }),
@@ -156,7 +156,7 @@ export const offerApi = createApi({
         }),
         getAllOffersMap: build.query<OfferMap[], Partial<GetAllOffersMapFilters> | undefined>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}vacancy/for-map/list`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/for-map/list`,
                 method: "GET",
                 params,
             }),
@@ -164,7 +164,7 @@ export const offerApi = createApi({
         }),
         getHostOffersById: build.query<GetHostOffersResponse, Partial<GetHostOffersFilters>>({
             query: ({ organizationId, limit, page }) => ({
-                url: `${API_BASE_URL_V3}vacancy/list/${organizationId}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/list/${organizationId}`,
                 method: "GET",
                 params: { limit, page, sort: OfferSort.UpdatedDesc },
             }),
@@ -174,7 +174,7 @@ export const offerApi = createApi({
             query: ({
                 organizationId, limit, page, statuses,
             }) => ({
-                url: `${API_BASE_URL_V3}vacancy/list/${organizationId}`,
+                url: `${API_BASE_URL_ABSOLUTE}vacancy/list/${organizationId}`,
                 method: "GET",
                 params: { limit, page, statuses },
             }),

--- a/src/entities/Profile/api/profileApi.ts
+++ b/src/entities/Profile/api/profileApi.ts
@@ -5,7 +5,7 @@ import {
     UpdateProfileVideoGallery,
 } from "../model/types/profile";
 import { baseQueryAcceptJson } from "@/shared/api/baseQuery/baseQuery";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import { UpdateVolunteer } from "@/entities/Volunteer";
 
 interface ChangePasswordRequest {
@@ -51,21 +51,21 @@ export const profileApi = createApi({
     endpoints: (build) => ({
         getProfileInfo: build.query<Profile, void>({
             query: () => ({
-                url: `${API_BASE_URL_V3}profile`,
+                url: `${API_BASE_URL_ABSOLUTE}profile`,
                 method: "GET",
             }),
             providesTags: ["profile"],
         }),
         getProfileInfoById: build.query<ProfileById, string>({
             query: (userId) => ({
-                url: `${API_BASE_URL_V3}profile/${userId}`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/${userId}`,
                 method: "GET",
             }),
             providesTags: ["profile"],
         }),
         updateProfileInfo: build.mutation<void, UpdateProfile>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}profile`,
+                url: `${API_BASE_URL_ABSOLUTE}profile`,
                 method: "PATCH",
                 body,
             }),
@@ -73,7 +73,7 @@ export const profileApi = createApi({
         }),
         updateVolunteer: build.mutation<void, UpdateVolunteer>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}volunteer`,
+                url: `${API_BASE_URL_ABSOLUTE}volunteer`,
                 method: "PATCH",
                 body,
             }),
@@ -81,7 +81,7 @@ export const profileApi = createApi({
         }),
         updateProfileVideoGallery: build.mutation<void, UpdateProfileVideoGallery>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}profile/video-gallery`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/video-gallery`,
                 method: "PATCH",
                 body,
             }),
@@ -89,7 +89,7 @@ export const profileApi = createApi({
         }),
         updateProfileImageGallery: build.mutation<void, UpdateProfileImageGallery>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}profile/image-gallery`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/image-gallery`,
                 method: "PATCH",
                 body,
             }),
@@ -97,7 +97,7 @@ export const profileApi = createApi({
         }),
         updateProfileCertificates: build.mutation<void, UpdateProfileCertificates>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}volunteer/certificate`,
+                url: `${API_BASE_URL_ABSOLUTE}volunteer/certificate`,
                 method: "PATCH",
                 body,
             }),
@@ -105,7 +105,7 @@ export const profileApi = createApi({
         }),
         updateProfilePreferences: build.mutation<void, UpdateProfilePreferences>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}profile/favorite-category`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/favorite-category`,
                 method: "PATCH",
                 body,
             }),
@@ -122,7 +122,7 @@ export const profileApi = createApi({
         changePasswordWithoutOldPassword: build.mutation<void,
         ChangePasswordWithoutOldPasswordRequest>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}profile/password/change`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/password/change`,
                 method: "POST",
                 body,
             }),
@@ -130,7 +130,7 @@ export const profileApi = createApi({
         }),
         toggleActiveProfile: build.mutation<void, ToggleActiveProfileRequest>({
             query: ({ body }) => ({
-                url: `${API_BASE_URL_V3}profile/toggle-active`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/toggle-active`,
                 method: "POST",
                 body,
             }),
@@ -138,7 +138,7 @@ export const profileApi = createApi({
         }),
         deleteProfile: build.mutation<void, void>({
             query: () => ({
-                url: `${API_BASE_URL_V3}profile/delete`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/delete`,
                 method: "DELETE",
             }),
             invalidatesTags: ["profile"],
@@ -159,14 +159,14 @@ export const profileApi = createApi({
         }),
         getProfileOccupancy: build.query<ProfileOccupancyResponse, void>({
             query: () => ({
-                url: `${API_BASE_URL_V3}profile/occupancy`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/occupancy`,
                 method: "GET",
             }),
             providesTags: ["profile"],
         }),
         getProfilePasswordIsChange: build.query<ProfilePasswordIsChangeResponse, void>({
             query: () => ({
-                url: `${API_BASE_URL_V3}profile/password/is-change`,
+                url: `${API_BASE_URL_ABSOLUTE}profile/password/is-change`,
                 method: "GET",
             }),
             providesTags: ["profile"],

--- a/src/entities/Review/api/reviewApi.ts
+++ b/src/entities/Review/api/reviewApi.ts
@@ -19,7 +19,7 @@ import {
     NotDoneReviewHost,
     NotDoneReviewVolunteer,
 } from "../model/types/review";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import { PaginationParams } from "@/types/api/pagination";
 
 interface ReviewRequest {
@@ -126,7 +126,7 @@ export const reviewApi = createApi({
         createVolunteerReview: build.mutation<void,
         CreateVolunteerReview>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}review-volunteer/create`,
+                url: `${API_BASE_URL_ABSOLUTE}review-volunteer/create`,
                 method: "POST",
                 body,
             }),
@@ -135,7 +135,7 @@ export const reviewApi = createApi({
         getAboutVolunteerReviews: build.query<GetAboutVolunteerReviewRequest,
         GetAboutVolunteerReviewParams>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}review-volunteer/list`,
+                url: `${API_BASE_URL_ABSOLUTE}review-volunteer/list`,
                 method: "GET",
                 params,
             }),
@@ -144,7 +144,7 @@ export const reviewApi = createApi({
         getMyVolunteerReviews: build.query<MyReviewVolunteerRequest,
         PaginationParams>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}volunteer/vacancy/review/list`,
+                url: `${API_BASE_URL_ABSOLUTE}volunteer/vacancy/review/list`,
                 method: "GET",
                 params,
             }),
@@ -153,7 +153,7 @@ export const reviewApi = createApi({
         getMyNotDoneVolunteerReview: build.query<NotDoneReviewVolunteer[],
         void>({
             query: () => ({
-                url: `${API_BASE_URL_V3}volunteer/vacancy/without-review/list`,
+                url: `${API_BASE_URL_ABSOLUTE}volunteer/vacancy/without-review/list`,
                 method: "GET",
             }),
             providesTags: ["volunteer", "host"],
@@ -161,7 +161,7 @@ export const reviewApi = createApi({
         createOfferReview: build.mutation<void,
         CreateOfferReview>({
             query: (body) => ({
-                url: `${API_BASE_URL_V3}review-vacancy/create`,
+                url: `${API_BASE_URL_ABSOLUTE}review-vacancy/create`,
                 method: "POST",
                 body,
             }),
@@ -170,7 +170,7 @@ export const reviewApi = createApi({
         getOfferReviews: build.query<GetOfferReviewRequest,
         GetOfferReviewParams>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}review-vacancy/list`,
+                url: `${API_BASE_URL_ABSOLUTE}review-vacancy/list`,
                 method: "GET",
                 params,
             }),
@@ -179,7 +179,7 @@ export const reviewApi = createApi({
         getOfferReviewByVacancyId: build.query<GetOfferReviewByVacancyResponse,
         GetOfferReviewByVacancyIdParams>({
             query: ({ vacancyId, limit, page }) => ({
-                url: `${API_BASE_URL_V3}review-vacancy/list/${vacancyId}`,
+                url: `${API_BASE_URL_ABSOLUTE}review-vacancy/list/${vacancyId}`,
                 method: "GET",
                 params: { page, limit },
             }),
@@ -188,7 +188,7 @@ export const reviewApi = createApi({
         getHostReviewByHostId: build.query<GetOfferReviewByHostResponse,
         GetOfferReviewByHostIdParams>({
             query: ({ hostId, limit, page }) => ({
-                url: `${API_BASE_URL_V3}review-vacancy/list-by-organization/${hostId}`,
+                url: `${API_BASE_URL_ABSOLUTE}review-vacancy/list-by-organization/${hostId}`,
                 method: "GET",
                 params: { page, limit },
             }),
@@ -197,7 +197,7 @@ export const reviewApi = createApi({
         getVolunteerReviewByVolunteerId: build.query<GetVolunteerReviewByVolunteerIdResponse,
         GetVolunteerReviewByVolunteerIdParams>({
             query: ({ volunteerId, limit, page }) => ({
-                url: `${API_BASE_URL_V3}review-volunteer/list/${volunteerId}`,
+                url: `${API_BASE_URL_ABSOLUTE}review-volunteer/list/${volunteerId}`,
                 method: "GET",
                 params: { page, limit },
             }),
@@ -206,7 +206,7 @@ export const reviewApi = createApi({
         getMyHostReviews: build.query<MyReviewHostResponse,
         PaginationParams>({
             query: (params) => ({
-                url: `${API_BASE_URL_V3}organization/volunteer/review/list`,
+                url: `${API_BASE_URL_ABSOLUTE}organization/volunteer/review/list`,
                 method: "GET",
                 params,
             }),
@@ -215,7 +215,7 @@ export const reviewApi = createApi({
         getMyNotDoneHostReview: build.query<NotDoneReviewHost[],
         void>({
             query: () => ({
-                url: `${API_BASE_URL_V3}organization/volunteer/without-review/list`,
+                url: `${API_BASE_URL_ABSOLUTE}organization/volunteer/without-review/list`,
                 method: "GET",
             }),
             providesTags: ["host", "volunteer"],

--- a/src/features/VerifyEmailForm/ui/VerifyEmailForm.tsx
+++ b/src/features/VerifyEmailForm/ui/VerifyEmailForm.tsx
@@ -8,7 +8,7 @@ import { HintType, ToastAlert } from "@/shared/ui/HintPopup/HintPopup.interface"
 import HintPopup from "@/shared/ui/HintPopup/HintPopup";
 import Button from "@/shared/ui/Button/Button";
 import styles from "./VerifyEmailForm.module.scss";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import { useAuth } from "@/routes/model/guards/AuthProvider";
 // import Input from "@/shared/ui/Input/Input";
 
@@ -51,7 +51,7 @@ export const VerifyEmailForm = () => {
 
         setIsLoading(true);
         try {
-            const response = await fetch(`${API_BASE_URL_V3}send-email`, {
+            const response = await fetch(`${API_BASE_URL_ABSOLUTE}send-email`, {
                 method: "POST",
                 credentials: "include",
                 headers: {

--- a/src/pages/VerifyEmailHashPage/ui/VerifyEmailHashPage.tsx
+++ b/src/pages/VerifyEmailHashPage/ui/VerifyEmailHashPage.tsx
@@ -9,7 +9,7 @@ import SignLayout from "@/shared/ui/SignLayout/SignLayout";
 import SignTitle from "@/shared/ui/SignTitle/SignTitle";
 import ButtonLink from "@/shared/ui/ButtonLink/ButtonLink";
 import { getProfileInfoPageUrl, getSignUpPageUrl } from "@/shared/config/routes/AppUrls";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import Preloader from "@/shared/ui/Preloader/Preloader";
 import { userActions } from "@/entities/User";
 import { useAuth } from "@/routes/model/guards/AuthProvider";
@@ -28,7 +28,7 @@ const VerifyEmailHashPage = () => {
     const getVerifyEmail = useCallback(async () => {
         if (hasFetchedRef.current) return;
         try {
-            const response = await fetch(`${API_BASE_URL_V3}verify/email/${id}`, {
+            const response = await fetch(`${API_BASE_URL_ABSOLUTE}verify/email/${id}`, {
                 method: "GET",
                 credentials: "include",
                 headers: {

--- a/src/shared/api/baseQuery/baseQuery.ts
+++ b/src/shared/api/baseQuery/baseQuery.ts
@@ -2,7 +2,7 @@ import { fetchBaseQuery } from "@reduxjs/toolkit/dist/query";
 import qs from "qs";
 import { RootState } from "@/store/store";
 
-import { API_ADMIN_BASE_URL, API_BASE_URL, API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_ADMIN_BASE_URL, API_BASE_URL, API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import { TOKEN_LOCALSTORAGE_KEY } from "@/shared/constants/localstorage";
 
 export const baseQuery = fetchBaseQuery({
@@ -46,7 +46,7 @@ export const baseQueryAcceptJson = fetchBaseQuery({
 });
 
 export const baseQueryV3 = fetchBaseQuery({
-    baseUrl: API_BASE_URL_V3,
+    baseUrl: API_BASE_URL_ABSOLUTE,
     credentials: "include",
     prepareHeaders: (headers, { getState }) => {
         const state = getState() as RootState;

--- a/src/shared/constants/api/index.ts
+++ b/src/shared/constants/api/index.ts
@@ -1,7 +1,7 @@
 // In dev (`npm start`) the SPA must hit the Vite dev-server (which proxies
 // to staging) so CORS/IAP doesn't kick in. We use the running page origin
 // (typically http://localhost:3000) — NOT an empty string — because several
-// RTK Query endpoints inject API_BASE_URL_V3 directly into `url:` while
+// RTK Query endpoints inject API_BASE_URL_ABSOLUTE directly into `url:` while
 // using `baseQuery` with baseUrl=API_BASE_URL. Both now point at /api/v1/,
 // but RTK still needs the injected one to be an absolute URL: when both are
 // relative, RTK naively concatenates them into nonsense like
@@ -15,7 +15,7 @@ const API_ORIGIN = import.meta.env.DEV && typeof window !== "undefined"
 export const BASE_URL = API_ORIGIN;
 export const BASE_URI = "/api/v1/";
 export const API_BASE_URL = `${API_ORIGIN}/api/v1/`;
-export const API_BASE_URL_V3 = `${API_ORIGIN}/api/v1/`;
+export const API_BASE_URL_ABSOLUTE = `${API_ORIGIN}/api/v1/`;
 export const BASE_VK_URI = `${API_ORIGIN}/api/vk/`;
 export const API_ADMIN_BASE_URL = `${API_ORIGIN}/admin/v1/`;
 export const API_ORGANIZATIONS_BASE_URL = `${API_ORIGIN}/api/organizations/`;

--- a/src/store/api/donationPaymentApi.ts
+++ b/src/store/api/donationPaymentApi.ts
@@ -1,6 +1,6 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { baseQuery } from "@/shared/api/baseQuery/baseQuery";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 
 export interface CreateDonationPaymentRequest {
     fundraiseId: string;
@@ -67,7 +67,7 @@ export const donationPaymentApi = createApi({
         CreateDonationPaymentRequest
         >({
             query: (data) => ({
-                url: `${API_BASE_URL_V3}donation`,
+                url: `${API_BASE_URL_ABSOLUTE}donation`,
                 method: "POST",
                 body: data,
             }),
@@ -78,14 +78,14 @@ export const donationPaymentApi = createApi({
         { fundraiseId: string; page?: number; limit?: number }
         >({
             query: ({ fundraiseId, page = 1, limit = 20 }) => ({
-                url: `${API_BASE_URL_V3}donation/fundraise/${fundraiseId}/list?page=${page}&limit=${limit}`,
+                url: `${API_BASE_URL_ABSOLUTE}donation/fundraise/${fundraiseId}/list?page=${page}&limit=${limit}`,
                 method: "GET",
             }),
             providesTags: ["donationList"],
         }),
         getDonationRating: build.query<DonationRatingItem[], { limit?: number }>({
             query: ({ limit = 50 }) => ({
-                url: `${API_BASE_URL_V3}donation/rating?limit=${limit}`,
+                url: `${API_BASE_URL_ABSOLUTE}donation/rating?limit=${limit}`,
                 method: "GET",
             }),
         }),
@@ -94,7 +94,7 @@ export const donationPaymentApi = createApi({
         { page?: number; limit?: number; sort?: string }
         >({
             query: ({ page = 1, limit = 20, sort }) => ({
-                url: `${API_BASE_URL_V3}donation/host?page=${page}&limit=${limit}${sort ? `&sort=${sort}` : ""}`,
+                url: `${API_BASE_URL_ABSOLUTE}donation/host?page=${page}&limit=${limit}${sort ? `&sort=${sort}` : ""}`,
                 method: "GET",
             }),
             providesTags: ["donationList"],

--- a/src/widgets/OffersMap/ui/Categories/Categories.test.tsx
+++ b/src/widgets/OffersMap/ui/Categories/Categories.test.tsx
@@ -7,7 +7,7 @@ import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { renderWithProviders } from "@/test-utils";
 import { server } from "@/mocks/server";
-import { API_BASE_URL_V3 } from "@/shared/constants/api";
+import { API_BASE_URL_ABSOLUTE } from "@/shared/constants/api";
 import { Categories } from "./Categories";
 
 vi.mock("@/app/providers/LocaleProvider", () => ({
@@ -15,7 +15,7 @@ vi.mock("@/app/providers/LocaleProvider", () => ({
 }));
 
 const mockCategories = () => server.use(
-    rest.get(`*${API_BASE_URL_V3}category/list`, (req, res, ctx) => res(ctx.status(200), ctx.json([
+    rest.get(`*${API_BASE_URL_ABSOLUTE}category/list`, (req, res, ctx) => res(ctx.status(200), ctx.json([
         { id: 10, name: "Археология", color: "#fff" },
         { id: 8, name: "Спорт", color: "#fff" },
     ]))),


### PR DESCRIPTION
## Summary
`API_BASE_URL_V3` has pointed at `/api/v1/` since the v1 URL consolidation — the "V3" suffix was stale naming, not a real version. Renamed to `API_BASE_URL_ABSOLUTE`, which describes what it's actually for: an absolute URL RTK Query endpoints inject directly into `url:` fields (needed because RTK naively concatenates two relative URLs instead of treating the second as absolute).

Pure rename, no behavior change — value is still `${API_ORIGIN}/api/v1/`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] ESLint clean on all touched files
- [x] `Categories.test.tsx` (the one test file referencing the constant) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)