### PR TITLE
fix: preserve selected offer and list page on back navigation

### DIFF
--- a/src/entities/Offer/ui/OfferCard/OfferCard.test.tsx
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.test.tsx
@@ -50,13 +50,13 @@ describe("OfferCard", () => {
         expect(onSelect).toHaveBeenCalledWith(1);
     });
 
-    it("клик по «Подробнее» не вызывает onSelect (переход по ссылке отдельно)", () => {
+    it("клик по «Подробнее» тоже вызывает onSelect (id должен попасть в URL до перехода)", () => {
         const onSelect = vi.fn();
         renderCard({ onSelect, link: "/ru/offer-personal/1" });
 
         fireEvent.click(screen.getByText("Подробнее"));
 
-        expect(onSelect).not.toHaveBeenCalled();
+        expect(onSelect).toHaveBeenCalledWith(1);
     });
 
     it("подсвечивает карточку, если isSelected=true", () => {

--- a/src/entities/Offer/ui/OfferCard/OfferCard.tsx
+++ b/src/entities/Offer/ui/OfferCard/OfferCard.tsx
@@ -154,7 +154,15 @@ export const OfferCard: FC<OfferCardProps> = memo((props: OfferCardProps) => {
                 </p>
                 <Link
                     to={link ?? getMainPageUrl(locale)}
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                        // Не даём клику дойти до onClick обёртки (двойной вызов
+                        // onSelect не нужен), но сам onSelect всё равно должны
+                        // вызвать явно — иначе при переходе именно по этой
+                        // ссылке (а не по клику на карточку) id вакансии никогда
+                        // не попадёт в URL, и "назад" вернёт к списку без выбора.
+                        e.stopPropagation();
+                        onSelect?.(offerId);
+                    }}
                     className={styles.learnMore}
                 >
                     {t("Подробнее")}

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.test.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.test.tsx
@@ -165,6 +165,56 @@ describe("OffersSearchFilter", () => {
         expect(requestedIdsUrls.at(-1)).toContain("42");
     });
 
+    it("восстанавливает страницу и выбранную вакансию из URL (кнопка \"назад\" с карты/детальной)", async () => {
+        const requestedListUrls: string[] = [];
+        const requestedIdsUrls: string[] = [];
+        server.use(
+            rest.get("*/vacancy/list", (req, res, ctx) => {
+                requestedListUrls.push(req.url.toString());
+                return res(ctx.status(200), ctx.json({
+                    data: [{
+                        id: 99,
+                        title: "Test",
+                        shortDescription: "",
+                        image: null,
+                        categories: [],
+                        address: "",
+                        acceptedApplicationsCount: 0,
+                        averageRating: 0,
+                        reviewsCount: 0,
+                        status: "active",
+                    }],
+                    pagination: { total: 40 },
+                }));
+            }),
+            rest.get("*/vacancy/for-map/list", (req, res, ctx) => {
+                if (req.url.search.toLowerCase().includes("ids")) {
+                    requestedIdsUrls.push(req.url.toString());
+                }
+                return res(ctx.status(200), ctx.json([]));
+            }),
+            rest.get("*/category/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/offers-map?page=2&offerId=99"]}>
+                <Routes>
+                    <Route path="/ru/offers-map" element={<OffersSearchFilter />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(requestedListUrls.length).toBeGreaterThan(0));
+        expect(requestedListUrls.at(-1)).toContain("page=2");
+
+        await waitFor(() => expect(latestOffersMapProps.current.selectedOfferId).toBe(99));
+        // selectedOfferId (99) не входит в мокнутую страницу списка (id=99 —
+        // единственный элемент, но сценарий проверяет именно "id пришёл из URL,
+        // а не из onSelectOffer") — координаты для него всё равно должны
+        // запрашиваться, иначе карта не сможет выделить/отцентровать маркер.
+        await waitFor(() => expect(requestedIdsUrls.some((url) => url.includes("99"))).toBe(true));
+    });
+
     it("сбрасывает выбранную вакансию при смене страницы списка", async () => {
         server.use(
             rest.get("*/vacancy/list", (req, res, ctx) => res(ctx.status(200), ctx.json({

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -58,9 +58,19 @@ export const OffersSearchFilter = () => {
     const { t } = useTranslation("offers-map");
     const searchRef = useRef<SearchOffersRef>(null);
 
-    const [currentPage, setCurrentPage] = useState<number>(1);
+    // Восстанавливаем страницу списка и выбранную карточку из URL — иначе при
+    // возврате кнопкой "назад" со страницы вакансии (открытой из списка или с
+    // карты) React Router размонтирует эту страницу заново, и весь локальный
+    // state (currentPage, selectedOfferId) сбрасывается к дефолту, хотя
+    // category/search такого не делают именно потому, что живут в URL.
+    const [currentPage, setCurrentPage] = useState<number>(
+        () => Number(searchParams.get("page")) || 1,
+    );
     const [initialSearchValue, setInitialSearchValue] = useState<string>();
-    const [selectedOfferId, setSelectedOfferId] = useState<number>();
+    const [selectedOfferId, setSelectedOfferId] = useState<number | undefined>(() => {
+        const offerIdParam = searchParams.get("offerId");
+        return offerIdParam ? Number(offerIdParam) : undefined;
+    });
 
     const initialCategories = getCategoryIdsFromUrlParam(searchParams.get("category") ?? "");
 
@@ -173,7 +183,17 @@ export const OffersSearchFilter = () => {
         // выбор логично сбрасывать (заодно не даёт селекту "залипнуть" на
         // id, для которого больше нет свежих данных о координатах).
         setSelectedOfferId(undefined);
-    }, []);
+        setSearchParams((prev) => {
+            const updated = new URLSearchParams(prev);
+            if (pageItem > 1) {
+                updated.set("page", String(pageItem));
+            } else {
+                updated.delete("page");
+            }
+            updated.delete("offerId");
+            return updated;
+        }, { replace: true });
+    }, [setSearchParams]);
 
     const onApplySearch = useCallback(async (search: string) => {
         currentSearchRef.current = search;
@@ -227,14 +247,30 @@ export const OffersSearchFilter = () => {
 
     const handleSelectOffer = useCallback((offerId: number) => {
         setSelectedOfferId(offerId);
-    }, []);
+        // Пишем в URL, чтобы кнопка "назад" со страницы вакансии (открытой
+        // и из списка, и с карты) вернула пользователя к тому же
+        // выделенному элементу, а не к чистому списку — см. fetchPageOffersLocation
+        // ниже, который подтягивает координаты именно по этому id.
+        setSearchParams((prev) => {
+            const updated = new URLSearchParams(prev);
+            updated.set("offerId", String(offerId));
+            return updated;
+        }, { replace: true });
+    }, [setSearchParams]);
 
     useEffect(() => {
         const ids = offersData?.data.map((offer) => offer.id) ?? [];
+        // selectedOfferId может не входить в текущую страницу списка — например,
+        // он был выбран кликом по маркеру на карте, а не карточкой из списка.
+        // Без этого координаты для восстановления после навигации "назад"
+        // никогда бы не подтянулись.
+        if (selectedOfferId && !ids.includes(selectedOfferId)) {
+            ids.push(selectedOfferId);
+        }
         if (ids.length > 0) {
             fetchPageOffersLocation({ ids });
         }
-    }, [offersData?.data]);
+    }, [offersData?.data, selectedOfferId]);
 
     const offerIdsWithoutLocation = useMemo(() => {
         if (isPageLocationFetching) return new Set<number>();

--- a/src/widgets/OffersMap/ui/OfferPlacemark/OfferPlacemark.tsx
+++ b/src/widgets/OffersMap/ui/OfferPlacemark/OfferPlacemark.tsx
@@ -3,7 +3,7 @@ import React, {
     FC, memo, useCallback, useEffect,
     useRef,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import defaultImage from "@/shared/assets/images/default-offer-image.png";
 import { useCategories } from "@/shared/data/categories";
@@ -29,6 +29,7 @@ export const OfferPlacemark: FC<OfferPlacemarkProps> = memo((props: OfferPlacema
     } = props;
 
     const navigate = useNavigate();
+    const [, setSearchParams] = useSearchParams();
     const ymaps = useYMaps();
     const { getTranslation } = useCategories();
     const [getOffer, {
@@ -38,8 +39,16 @@ export const OfferPlacemark: FC<OfferPlacemarkProps> = memo((props: OfferPlacema
     const placemarkRef = useRef<any>(null);
 
     const handleClick = useCallback(() => {
+        // Клик по маркеру не идёт через OffersList/onSelectOffer, поэтому сам
+        // пишет offerId в URL — иначе кнопка "назад" со страницы вакансии,
+        // открытой с карты, возвращала бы к списку без выделенного маркера.
+        setSearchParams((prev) => {
+            const updated = new URLSearchParams(prev);
+            updated.set("offerId", id);
+            return updated;
+        }, { replace: true });
         navigate(getOfferPersonalPageUrl(locale, id));
-    }, [locale, id, navigate]);
+    }, [locale, id, navigate, setSearchParams]);
 
     const updateBalloonContent = useCallback(() => {
         const element = document.getElementById(`ballon-offer-${id}`);


### PR DESCRIPTION
## Summary
Reported bug: navigate from the map (or list) to a specific offer, press browser Back, and you land on a blank/reset offers list instead of the same page with the same offer highlighted/centered.

Root cause: `currentPage` and `selectedOfferId` only lived in `OffersSearchFilter`'s local `useState`. React Router unmounts/remounts this component on Back navigation (it's a different route), which resets all local state to defaults — unlike `category`/`search`, which already survive because they're synced to the URL.

## Changes
- `currentPage` and `selectedOfferId` are now synced to URL search params (`page`, `offerId`), mirroring the existing `category` pattern.
- Map markers (`OfferPlacemark`) write `offerId` to the URL directly before navigating — they never went through `OffersList`'s `onSelectOffer`, so this path was silently losing the selection even without the Back-button bug.
- The offer card's "Подробнее" link now also calls `onSelect` before navigating (it previously called `stopPropagation()` and skipped it — the removed test asserting that behavior was itself testing the bug).
- `fetchPageOffersLocation` now always includes the restored/selected offer id even when it isn't part of the current list page's data, so the map can still center on it after a marker-originated visit.

## Test plan
- [x] New test: mounts with `?page=2&offerId=99` in the URL, asserts the list fetches page 2 and the map receives `selectedOfferId=99` with its coordinates fetched.
- [x] `revert-and-confirm-fails`: reverted the `OffersSearchFilter` change alone, confirmed the new test fails (`page=1` instead of `page=2`), restored.
- [x] Updated the now-outdated `OfferCard` test that asserted `onSelect` was *not* called on "Подробнее" click.
- [x] Full suite: 87 files / 266 tests passing, `tsc --noEmit` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)