### PR TITLE
fix(offers-map): stop markers blinking on every pan

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -52,7 +52,9 @@ vi.mock("@pbe/react-yandex-maps", () => ({
         return <div>{children}</div>;
     },
     ZoomControl: () => null,
-    ObjectManager: () => null,
+    ObjectManager: ({ features }: { features: unknown[] }) => (
+        <div data-testid="object-manager">{features.length}</div>
+    ),
 }));
 
 const offer = (overrides: Partial<OfferMap> = {}): OfferMap => ({
@@ -175,5 +177,38 @@ describe("OffersMap", () => {
         );
 
         expect(onLoadCalls).toHaveBeenCalledTimes(1);
+    });
+
+    it("не прячет уже показанные маркеры на время bounds-рефетча (регресс: карта моргала при каждом перемещении)", async () => {
+        const { rerender } = render(
+            <OffersMap
+                offersData={[offer({ id: 1 }), offer({ id: 2 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId("object-manager")).toHaveTextContent("2"));
+
+        // Пользователь подвинул карту -> сработал onBoundsChange -> родитель
+        // начал bounds-рефетч: isOffersLoading=true, offersData на
+        // мгновение вернулся к [] (новая комбинация bounds ещё не в кеше).
+        rerender(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading
+            />,
+        );
+
+        expect(screen.getByTestId("object-manager")).toHaveTextContent("2");
+
+        // Рефетч завершился с обновлённым набором вакансий для новых bounds.
+        rerender(
+            <OffersMap
+                offersData={[offer({ id: 3 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId("object-manager")).toHaveTextContent("1"));
     });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -58,6 +58,12 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const objectManagerRef = useRef<any>(null);
     const onBoundsChangeRef = useRef(onBoundsChange);
     onBoundsChangeRef.current = onBoundsChange;
+    // Пока идёт bounds-рефетч, offersData на мгновение становится [] —
+    // если сразу же чистить markers, ObjectManager размонтируется и
+    // смонтируется заново при приходе новых данных, и карта один раз
+    // моргает при каждом перемещении. Держим последний непустой набор
+    // маркеров на экране, пока не придут новые (stale-while-revalidate).
+    const lastFeaturesRef = useRef<any[]>([]);
 
     const noTitle = t("Без названия");
     const noCategory = t("Без категории");
@@ -67,9 +73,9 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const noLocationText = t("У этой вакансии не указано местоположение на карте");
 
     const features = useMemo(() => {
-        if (isOffersLoading || !offersData.length) return [];
+        if (isOffersLoading || !offersData.length) return lastFeaturesRef.current;
 
-        return offersData
+        const computed = offersData
             .filter((offer) => typeof offer.latitude === "number" && typeof offer.longitude === "number")
             .map((offer) => {
                 const imgSrc = offer?.image ?? undefined;
@@ -108,6 +114,9 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                     },
                 };
             });
+
+        lastFeaturesRef.current = computed;
+        return computed;
     }, [
         isOffersLoading, offersData, locale, ymapState?.templateLayoutFactory,
         noTitle, noCategory, offerWithoutName, learnMore,


### PR DESCRIPTION
## Summary
- Reported: on https://staging.goodsurfing.org/ru/offers-map, dragging the map causes a visible one-time blink.
- Root cause: while a bounds-triggered marker refetch is in flight, `offersData` briefly becomes `[]` (the new bounds combination isn't cached yet), and `OffersMap`'s `features` memo unconditionally returned `[]` whenever `isOffersLoading` was true — unmounting the marker `ObjectManager` and remounting it once the new batch arrived. Distinct from the earlier infinite unmount/remount loop fixed in #458 (that tore down the whole `<Map>`; this is just the marker layer blinking once per pan).
- Fix: keep the last non-empty computed feature set on screen while a refetch is in flight (stale-while-revalidate), instead of clearing it. `ObjectManager` stays mounted and just receives fresh features once they arrive.

## Test plan
- [x] New regression test: markers stay visible across a simulated bounds-refetch cycle (`isOffersLoading` true + `offersData=[]` in between), then update to the new batch once it resolves.
- [x] `revert-and-confirm-fails`: stashing the fix makes the new test fail (`ObjectManager` unmounts), confirming it's load-bearing.
- [x] `tsc --noEmit` — 0 errors, `eslint` — 0 errors, full suite: 267/267 passing (1 new test, no regressions).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>