### PR TITLE
fix(offers-map): clicking Применить after unchecking a category resurrected it

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.regression.test.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.regression.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { rest } from "msw";
+import { Controller, useFormContext } from "react-hook-form";
+import { renderWithProviders } from "@/test-utils";
+import { server } from "@/mocks/server";
+import { OffersSearchFilter } from "./OffersSearchFilter";
+
+vi.mock("@/widgets/OffersMap", () => ({
+    OffersList: () => <div />,
+    OffersMap: () => <div />,
+}));
+vi.mock("../OffersSearchFilterMobile/OffersSearchFilterMobile", () => ({
+    OffersSearchFilterMobile: () => <div />,
+}));
+vi.mock("@/widgets/OffersMap/ui/SearchOffers/SearchOffers", () => ({
+    SearchOffers: React.forwardRef(
+        (_props: unknown, ref: React.Ref<HTMLDivElement>) => <div ref={ref} />,
+    ),
+}));
+// A minimal stand-in for the real OffersFilter that exposes just enough of the
+// category Controller wiring to drive the same code path a real checkbox
+// click would (field.onChange -> the watch subscriber -> setSearchParams).
+vi.mock("../OffersFilter/OffersFilter", () => ({
+    OffersFilter: ({ onSubmit }: { onSubmit: () => void }) => {
+        const { control } = useFormContext();
+        return (
+            <div>
+                <Controller
+                    name="category"
+                    control={control}
+                    render={({ field }) => (
+                        <button type="button" onClick={() => field.onChange([])}>
+                            Deselect category
+                        </button>
+                    )}
+                />
+                <button type="button" onClick={onSubmit}>Применить</button>
+            </div>
+        );
+    },
+}));
+
+/**
+ * Регресс-guard: onApplyFilters/onApplySearch/onResetFilters были
+ * замемоизированы с пустым массивом зависимостей, но внутри звали
+ * onChangePage — который сам меняется при каждом изменении searchParams.
+ * Из-за этого они навсегда захватывали onChangePage/setSearchParams
+ * момента первого рендера, и его setSearchParams(prev => ...) при вызове
+ * читал prev из URL на момент загрузки страницы, а не текущий — клик
+ * "Применить" после снятия категории с фильтра воскрешал старую
+ * категорию из URL при загрузке (репорт техподдержки, 2026-07-29).
+ */
+describe("OffersSearchFilter — регресс: категория не должна воскресать после Применить", () => {
+    it("не переотправляет снятую категорию при клике Применить", async () => {
+        const requestedUrls: string[] = [];
+        server.use(
+            rest.get("*/vacancy/list", (req, res, ctx) => {
+                requestedUrls.push(req.url.toString());
+                return res(ctx.status(200), ctx.json({ data: [], pagination: { total: 0 } }));
+            }),
+            rest.get("*/vacancy/for-map/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+            rest.get("*/category/list", (req, res, ctx) => res(ctx.status(200), ctx.json([]))),
+        );
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={["/ru/offers-map?category=2"]}>
+                <Routes>
+                    <Route path="/ru/offers-map" element={<OffersSearchFilter />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(requestedUrls.some((url) => url.includes("categoryIds"))).toBe(true));
+
+        await userEvent.click(screen.getByText("Deselect category"));
+        await userEvent.click(screen.getByText("Применить"));
+
+        await waitFor(() => expect(requestedUrls.length).toBeGreaterThan(1));
+        expect(requestedUrls.at(-1)).not.toContain("categoryIds");
+    });
+});

--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -208,7 +208,13 @@ export const OffersSearchFilter = () => {
         fetchOffersMapWithBounds({ search });
         reset(defaultValues);
         onChangePage(1);
-    }, []);
+        // onChangePage must stay in deps: it closes over setSearchParams via a
+        // functional updater, and setSearchParams is recreated on every URL
+        // change — an empty deps array here would freeze this handler on the
+        // mount-time onChangePage/setSearchParams forever, so its updater's
+        // `prev` would always resolve to whatever searchParams existed on
+        // page load, silently reintroducing them on every apply/reset click.
+    }, [onChangePage]);
 
     useEffect(() => {
         const searchParam = searchParams.get("search");
@@ -228,7 +234,10 @@ export const OffersSearchFilter = () => {
         fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: 1 });
         fetchOffersMapWithBounds({ ...preparedData });
         onChangePage(1);
-    }), []);
+        // See onApplySearch above for why onChangePage can't be omitted here —
+        // this is exactly the bug that made "Применить" resurrect a category
+        // the user had just unchecked (GS staging report, 2026-07-29).
+    }), [onChangePage]);
 
     const onResetFilters = useCallback(async () => {
         currentSearchRef.current = "";
@@ -239,7 +248,7 @@ export const OffersSearchFilter = () => {
         fetchOffersMapWithBounds({ ...preparedData });
         reset(defaultValues);
         onChangePage(1);
-    }, []);
+    }, [onChangePage]);
 
     const handleMapOpen = useCallback(() => {
         setMapOpened((prev) => !prev);


### PR DESCRIPTION
## Summary
Support ticket: on `/offers-map?category=2`, unchecking the category in the filter and clicking "Применить" was expected to show all categories, but the category filter stayed applied.

**Root cause** — a deterministic stale-closure bug, not a timing race (reproduces identically with a 2s delay inserted): `onApplyFilters`, `onApplySearch`, and `onResetFilters` are memoized with an empty `useCallback` dependency array, but each internally calls `onChangePage` — which itself gets a *new* identity on every URL change (its own deps include `setSearchParams`, which react-router recreates on navigation). Because the empty deps array freezes these three handlers at mount, they permanently call the **mount-time** `onChangePage`, whose `setSearchParams` functional updater resolves its `prev` argument against the URL **as it was on page load** — silently reintroducing whatever query params existed then (here, `category=2`).

This also affects `onResetFilters` ("Очистить все") the same way whenever the page was loaded with any URL params.

**Fix**: add `onChangePage` to all three handlers' dependency arrays so they always call the current `onChangePage`, bound to the current `setSearchParams`.

Diagnosed by reproducing live on staging via Playwright (mocking the CORS-blocked `/category/list` request to interact with real checkboxes), then pinpointing the exact mechanism with a temporary debug-instrumented Vitest reproduction before implementing the fix.

## Test plan
- [x] New regression test: uncheck category → click Применить → last request must not contain `categoryIds`.
- [x] `revert-and-confirm-fails`: stashing the fix makes the new test fail with the exact stale `categoryIds=2` request, confirming it's load-bearing.
- [x] `tsc --noEmit` — 0 errors, `eslint` — 0 errors, full suite: 268/268 passing (1 new test, no regressions).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>