### PR TITLE
fix(about-project): center-wrap "ГудСёрфинг сегодня" counters instead of space-between

### DIFF
--- a/src/pages/AboutProjectPage/ui/GoodsurfingNow/GoodsurfingNow.module.scss
+++ b/src/pages/AboutProjectPage/ui/GoodsurfingNow/GoodsurfingNow.module.scss
@@ -1,7 +1,14 @@
 .content {
     margin-top: 36px;
     display: flex;
-    justify-content: space-between;
+    // space-between spreads items edge-to-edge only while they all fit on
+    // one row; the moment 4 fixed-140px circles + gaps + padding overflow
+    // (any width narrower than ~992px isn't even needed to trigger this —
+    // it also happened well above that breakpoint), the wrapped remainder
+    // lands flush-left instead of centered, looking broken. center wraps
+    // consistently at every width, so there's no separate override needed
+    // below 992px anymore either.
+    justify-content: center;
     flex-wrap: wrap;
     padding-left: 100px;
     padding-right: 100px;
@@ -19,7 +26,6 @@
 
 @media (max-width: 992px) {
     .content {
-        justify-content: center;
         padding-left: 0;
         padding-right: 0;
     }


### PR DESCRIPTION
## Summary
On `/about-project`, the "ГудСёрфинг сегодня" counters (гудсёрферов/стран/вакансий/отзывов) aren't guaranteed to fit 4-per-row (4 × 140px circles + 3 × 30px gaps + 200px side padding ≈ 850px minimum). Whenever they don't fit, `justify-content: space-between` spread the first 3 edge-to-edge and dumped the 4th alone, flush-left, on its own row — happens well above the existing 992px mobile breakpoint too, not just on narrow screens.

Switched to `justify-content: center` at all widths, so wrapped rows are always centered consistently. The `<992px` override is no longer needed for this property (kept the padding reset).

## Test plan
- [x] `tsc --noEmit` / `eslint` — 0 errors (CSS-only change)
- [ ] Will screenshot the deployed staging page at a few widths to confirm the wrap looks right

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>