### PR TITLE
fix(about-project): constrain paragraph width, add hero overlay for legibility

### DIFF
--- a/src/pages/AboutProjectPage/ui/Header/Header.module.scss
+++ b/src/pages/AboutProjectPage/ui/Header/Header.module.scss
@@ -1,5 +1,5 @@
 .wrapper {
-    background-image: url("@/shared/assets/images/about-project/header.webp");
+    background-image: linear-gradient(rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.35)), url("@/shared/assets/images/about-project/header.webp");
     width: 100%;
     max-width: 1920px;
     margin: 0 auto;
@@ -19,10 +19,16 @@
     text-align: center;
     font-size: 2.5rem;
     font-weight: 600;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
 }
 
 @media(max-width: 992px) {
     .wrapper {
         padding: 20px;
+        min-height: 260px;
+    }
+
+    .title {
+        font-size: 1.75rem;
     }
 }

--- a/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.module.scss
+++ b/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.module.scss
@@ -15,8 +15,12 @@
 
 .description {
     font-size: 0.875rem;
+    line-height: 1.6;
     white-space: pre-line;
     overflow-wrap: break-word;
+    max-width: 720px;
+    width: 100%;
+    text-align: left;
 }
 
 .button {

--- a/src/pages/AboutProjectPage/ui/Mission/Mission.module.scss
+++ b/src/pages/AboutProjectPage/ui/Mission/Mission.module.scss
@@ -15,8 +15,12 @@
 
 .description {
     font-size: 0.875rem;
+    line-height: 1.6;
     white-space: pre-line;
     overflow-wrap: break-word;
+    max-width: 720px;
+    width: 100%;
+    text-align: left;
 }
 
 .button {


### PR DESCRIPTION
## Summary
- Mission and HowItStarted description text had no `max-width` and stretched to the full section width (~1140px on desktop) — way past comfortable reading line length. Constrained to 720px, left-aligned, degrades to full width on mobile automatically since the container is already narrower than the cap.
- Hero title had no contrast safeguard against the background photo — added a semi-transparent dark overlay + text-shadow so it stays legible regardless of how light a future photo is, and shrunk the mobile hero height/title size.

## Test plan
- [x] Visual check on staging at desktop (1440px) and mobile (390px) widths
- [x] Confirm text still readable/centered at both sizes, hero overlay doesn't over-darken the photo
