### PR TITLE
feat(seo): proxy legacy apex-domain URLs to backend for redirect

### DIFF
--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -94,6 +94,42 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # ─── Остальные легаси-URL со старого апекс-домена ──────────
+    # /blog/article/{id} -> резолв Blog.id -> slug; /about, /about-nko,
+    # /offers/ -> статический 1:1 маппинг. См. LegacyBlogRedirectController
+    # и LegacyStaticRedirectController.
+    location ~ ^/blog/article/\d+$ {
+        resolver 127.0.0.11 valid=10s;
+        set $legacy_backend "http://backend:80";
+        proxy_pass $legacy_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /about {
+        resolver 127.0.0.11 valid=10s;
+        set $legacy_backend "http://backend:80";
+        proxy_pass $legacy_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /about-nko {
+        resolver 127.0.0.11 valid=10s;
+        set $legacy_backend "http://backend:80";
+        proxy_pass $legacy_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /offers/ {
+        resolver 127.0.0.11 valid=10s;
+        set $legacy_backend "http://backend:80";
+        proxy_pass $legacy_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ─── SPA fallback ──────────────────────────────────────────
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
GS-82

Companion PR to gs-backend — adds nginx proxy rules for `/blog/article/{id}`, `/about`, `/about-nko`, `/offers/` (matching the existing `/offers/host/{id}` rule) so the new backend redirect controllers actually receive these requests instead of falling through to the SPA shell.

Needs to deploy together with the gs-backend PR.

## Test plan
- [ ] Live-verify on staging once both PRs are merged + deployed

(Recreated after branch rename accidentally closed the original PR #469.)
