### PR TITLE
feat(review): attach and display photos on reviews (Avito-style gallery)

### DIFF
--- a/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
+++ b/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
@@ -18,6 +18,8 @@ import { useGetFullName } from "@/shared/lib/getFullName";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 import { ShowNext } from "@/shared/ui/ShowNext/ShowNext";
 import { Text } from "@/shared/ui/Text/Text";
+import { ImagesUploader } from "@/shared/ui/ImagesUploader/ImagesUploader";
+import { MediaObjectType } from "@/types/media";
 
 import { CommentInput } from "@/features/Article";
 import styles from "./OfferReviewsCard.module.scss";
@@ -36,6 +38,7 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
         const [isSendReview, setSendReview] = useState(false);
         const [rating, setRating] = useState<number | null>(null);
         const [commentInput, setCommentInput] = useState<string>("");
+        const [reviewImages, setReviewImages] = useState<MediaObjectType[]>([]);
         const [page, setPage] = useState<number>(1);
         const [error, setError] = useState<string | null>(null);
         const [reviews, setReviews] = useState<GetOfferReviewByVacancy[]>([]);
@@ -81,18 +84,22 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
                     vacancyId: offerId,
                     description: commentInput.trim(),
                     rating,
+                    imageIds: reviewImages.map((image) => image.id),
                 }).unwrap();
 
                 setSendReview(true);
                 setCommentInput("");
                 setRating(null);
+                setReviewImages([]);
 
                 setPage(1);
                 await fetchReviews(1);
             } catch (err) {
                 setError("Не удалось отправить отзыв. Попробуйте позже.");
             }
-        }, [canReview, commentInput, rating, createOfferReview, offerId, fetchReviews]);
+        }, [
+            canReview, commentInput, rating, reviewImages, createOfferReview, offerId, fetchReviews,
+        ]);
 
         const renderReviews = reviews.map((review) => (
             <ReviewWidget
@@ -101,6 +108,7 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
                 reviewText={review.description}
                 stars={review.rating}
                 url={getVolunteerPersonalPageUrl(locale, review.author.id)}
+                images={review.images}
                 key={review.id}
             />
         ));
@@ -150,6 +158,19 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
                     value={commentInput}
                     onChange={handleCommentInput}
                 />
+                {canReview && !isSendReview && (
+                    <ImagesUploader
+                        uploadedImgs={reviewImages}
+                        onUpload={async (uploaded) => {
+                            setReviewImages((prev) => [...prev, ...uploaded]);
+                        }}
+                        onDelete={(imgId) => {
+                            setReviewImages((prev) => prev.filter((img) => img.id !== imgId));
+                        }}
+                        onError={() => {}}
+                        maxLength={10}
+                    />
+                )}
                 <div className={styles.container}>
                     {renderContent()}
                 </div>

--- a/src/entities/Review/model/types/review.ts
+++ b/src/entities/Review/model/types/review.ts
@@ -38,6 +38,7 @@ export interface GetAboutVolunteerReview {
     rating: number;
     description: string;
     created: string;
+    images: Image[];
 }
 
 export interface CreateVolunteerReview {
@@ -45,6 +46,7 @@ export interface CreateVolunteerReview {
     vacancyId: number;
     rating: number;
     description: string;
+    imageIds?: string[];
 }
 
 export interface GetAboutVolunteerReviewRequest {
@@ -61,6 +63,7 @@ export interface CreateOfferReview {
     vacancyId: number;
     rating: number;
     description: string;
+    imageIds?: string[];
 }
 
 export interface GetOfferReview {
@@ -79,6 +82,7 @@ export interface GetOfferReview {
         lastName: string;
         image: Image;
     }
+    images: Image[];
 }
 
 export interface GetOfferReviewRequest {
@@ -107,6 +111,7 @@ export interface GetOfferReviewByVacancy {
     }
     description: string;
     rating: number;
+    images: Image[];
 }
 
 export interface GetOfferReviewByVacancyResponse {
@@ -140,6 +145,7 @@ export interface GetVolunteerReviewByVolunteerId {
     name: string;
     description: string;
     rating: number;
+    images: Image[];
 }
 
 export interface GetVolunteerReviewByVolunteerIdResponse {
@@ -169,6 +175,7 @@ export interface MyReviewVolunteer {
     rating: number;
     description: string;
     created: string;
+    images: Image[];
 }
 
 export interface MyReviewVolunteerRequest {
@@ -200,6 +207,7 @@ export interface MyReviewHost {
     }
     rating: number;
     description: string;
+    images: Image[];
 }
 
 export interface MyReviewHostResponse {

--- a/src/entities/Review/ui/HostModalReview/HostModalReview.tsx
+++ b/src/entities/Review/ui/HostModalReview/HostModalReview.tsx
@@ -4,6 +4,7 @@ import { ReviewTypeFields } from "@/features/Notes";
 
 import { ModalReview } from "@/shared/ui/ModalReview/ModalReview";
 import { Locale } from "@/entities/Locale";
+import { MediaObjectType } from "@/types/media";
 import { NotDoneReviewHost } from "../../model/types/review";
 import { MiniVolunteerReview } from "../MiniVolunteerReview/MiniVolunteerReview";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
@@ -19,6 +20,8 @@ interface HostModalReviewProps {
     successText?: string;
     errorText?: string;
     locale: Locale;
+    images?: MediaObjectType[];
+    onImagesChange?: (images: MediaObjectType[]) => void;
 }
 
 export const HostModalReview: FC<HostModalReviewProps> = (props) => {
@@ -33,6 +36,8 @@ export const HostModalReview: FC<HostModalReviewProps> = (props) => {
         successText,
         errorText,
         locale,
+        images,
+        onImagesChange,
     } = props;
     const { stars, text } = value;
     return (
@@ -49,6 +54,8 @@ export const HostModalReview: FC<HostModalReviewProps> = (props) => {
             sendReview={sendReview}
             successText={successText}
             errorText={errorText}
+            images={images}
+            onImagesChange={onImagesChange}
         >
             {review && (
                 <MiniVolunteerReview

--- a/src/entities/Review/ui/VolunteerModalReview/VolunteerModalReview.tsx
+++ b/src/entities/Review/ui/VolunteerModalReview/VolunteerModalReview.tsx
@@ -3,6 +3,7 @@ import React, { FC } from "react";
 import { ReviewTypeFields } from "@/features/Notes";
 import { ModalReview } from "@/shared/ui/ModalReview/ModalReview";
 import { Locale } from "@/entities/Locale";
+import { MediaObjectType } from "@/types/media";
 import { NotDoneReviewVolunteer } from "../../model/types/review";
 import { MiniOfferReview } from "../MiniOfferReview/MiniOfferReview";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
@@ -17,6 +18,8 @@ interface VolunteerModalReviewProps {
     successText?: string;
     errorText?: string;
     locale: Locale;
+    images?: MediaObjectType[];
+    onImagesChange?: (images: MediaObjectType[]) => void;
 }
 
 export const VolunteerModalReview: FC<VolunteerModalReviewProps> = (props) => {
@@ -30,6 +33,8 @@ export const VolunteerModalReview: FC<VolunteerModalReviewProps> = (props) => {
         successText,
         errorText,
         locale,
+        images,
+        onImagesChange,
     } = props;
     const { stars, text } = value;
     return (
@@ -46,6 +51,8 @@ export const VolunteerModalReview: FC<VolunteerModalReviewProps> = (props) => {
             sendReview={sendReview}
             successText={successText}
             errorText={errorText}
+            images={images}
+            onImagesChange={onImagesChange}
         >
             {application && (
                 <MiniOfferReview

--- a/src/entities/Volunteer/ui/VolunteerReviewsCard/VolunteerReviewsCard.tsx
+++ b/src/entities/Volunteer/ui/VolunteerReviewsCard/VolunteerReviewsCard.tsx
@@ -72,6 +72,7 @@ export const VolunteerReviewsCard: FC<VolunteerReviewsCardProps> = memo(
                 reviewText={review.description}
                 stars={review.rating}
                 url={getHostPersonalPageUrl(locale, review.id)}
+                images={review.images}
                 key={review.id}
             />
         ));

--- a/src/features/Review/ui/ReviewAboutVolunteerCard/ReviewAboutVolunteerCard.tsx
+++ b/src/features/Review/ui/ReviewAboutVolunteerCard/ReviewAboutVolunteerCard.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { Rating } from "@mui/material";
 import { GetAboutVolunteerReview } from "@/entities/Review";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
+import { ReviewGallery } from "@/shared/ui/ReviewGallery/ReviewGallery";
 import { getFullAddress, getFullName } from "@/shared/lib/getFullName";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 import styles from "./ReviewAboutVolunteerCard.module.scss";
@@ -12,7 +13,9 @@ interface ReviewAboutVolunteerCardProps {
 
 export const ReviewAboutVolunteerCard: FC<ReviewAboutVolunteerCardProps> = (props) => {
     const { data } = props;
-    const { author, description, rating } = data;
+    const {
+        author, description, rating, images,
+    } = data;
     const username = getFullName(author.firstName, author.lastName);
     const fullAddress = getFullAddress(author.city, author.country);
 
@@ -53,6 +56,7 @@ export const ReviewAboutVolunteerCard: FC<ReviewAboutVolunteerCardProps> = (prop
                 </div>
             </div>
             <p className={styles.textReview}>{description}</p>
+            <ReviewGallery images={images} />
         </div>
     );
 };

--- a/src/features/Review/ui/ReviewCardOffer/ReviewCardOffer.tsx
+++ b/src/features/Review/ui/ReviewCardOffer/ReviewCardOffer.tsx
@@ -4,6 +4,7 @@ import { Rating } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import cn from "classnames";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
+import { ReviewGallery } from "@/shared/ui/ReviewGallery/ReviewGallery";
 import { MyReviewVolunteer } from "@/entities/Review";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 import { getOfferPersonalPageUrl, getVolunteerPersonalPageUrl } from "@/shared/config/routes/AppUrls";
@@ -21,7 +22,7 @@ interface ReviewCardOfferProps {
 export const ReviewCardOffer: FC<ReviewCardOfferProps> = (props: ReviewCardOfferProps) => {
     const { reviewOffer, locale, className } = props;
     const {
-        vacancy, description, rating, created, author,
+        vacancy, description, rating, created, author, images,
     } = reviewOffer;
 
     const { getFullName } = useGetFullName();
@@ -55,6 +56,7 @@ export const ReviewCardOffer: FC<ReviewCardOfferProps> = (props: ReviewCardOffer
                 </span>
             </div>
             <p className={styles.textReview}>{description}</p>
+            <ReviewGallery images={images} />
             <div className={styles.ratingUserContainer}>
                 <Rating
                     value={rating}

--- a/src/features/Review/ui/ReviewFullCard/ReviewFullCard.tsx
+++ b/src/features/Review/ui/ReviewFullCard/ReviewFullCard.tsx
@@ -5,6 +5,7 @@ import cn from "classnames";
 import { MyReviewHost } from "@/entities/Review";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
+import { ReviewGallery } from "@/shared/ui/ReviewGallery/ReviewGallery";
 import { getFullAddress, useGetFullName } from "@/shared/lib/getFullName";
 import styles from "./ReviewFullCard.module.scss";
 
@@ -17,7 +18,7 @@ export const ReviewFullCard: FC<ReviewFullCardProps> = (props: ReviewFullCardPro
     const { review, className } = props;
     const {
         description, rating,
-        volunteer,
+        volunteer, images,
     } = review;
     const { getFullName } = useGetFullName();
     const userName = getFullName(volunteer.firstName, volunteer.lastName);
@@ -62,6 +63,7 @@ export const ReviewFullCard: FC<ReviewFullCardProps> = (props: ReviewFullCardPro
                 </div>
             </div>
             <p className={styles.textReview}>{description}</p>
+            <ReviewGallery images={images} />
         </div>
     );
 };

--- a/src/shared/ui/ModalReview/ModalReview.test.tsx
+++ b/src/shared/ui/ModalReview/ModalReview.test.tsx
@@ -50,4 +50,36 @@ describe("ModalReview", () => {
             screen.queryByText("Поставьте оценку, чтобы оставить отзыв"),
         ).not.toBeInTheDocument();
     });
+
+    it("не показывает загрузку фото без onImagesChange (GS-83)", () => {
+        renderWithProviders(
+            <ModalReview
+                isOpen
+                onClose={() => {}}
+                titleText="Отзыв"
+                sendReview={() => {}}
+                value={{ stars: undefined, text: "" }}
+                onChange={() => {}}
+            />,
+        );
+
+        expect(screen.queryByText("Добавить фото")).not.toBeInTheDocument();
+    });
+
+    it("показывает загрузку фото, когда передан onImagesChange (GS-83)", () => {
+        renderWithProviders(
+            <ModalReview
+                isOpen
+                onClose={() => {}}
+                titleText="Отзыв"
+                sendReview={() => {}}
+                value={{ stars: undefined, text: "" }}
+                onChange={() => {}}
+                images={[]}
+                onImagesChange={() => {}}
+            />,
+        );
+
+        expect(screen.getByText("Добавить фото")).toBeInTheDocument();
+    });
 });

--- a/src/shared/ui/ModalReview/ModalReview.tsx
+++ b/src/shared/ui/ModalReview/ModalReview.tsx
@@ -1,6 +1,7 @@
 import { Rating } from "@mui/material";
 import React, {
     FC, ReactNode,
+    useCallback,
     useEffect,
 } from "react";
 
@@ -11,6 +12,8 @@ import { Modal } from "../Modal/Modal";
 import Textarea from "../Textarea/Textarea";
 import styles from "./ModalReview.module.scss";
 import { ErrorText } from "../ErrorText/ErrorText";
+import { ImagesUploader } from "../ImagesUploader/ImagesUploader";
+import { MediaObjectType } from "@/types/media";
 
 interface ReviewType {
     stars: number | undefined;
@@ -27,6 +30,8 @@ interface ModalReviewProps {
     successText?: string;
     errorText?: string;
     children?: ReactNode;
+    images?: MediaObjectType[];
+    onImagesChange?: (images: MediaObjectType[]) => void;
 }
 
 export const ModalReview: FC<ModalReviewProps> = (props) => {
@@ -40,6 +45,8 @@ export const ModalReview: FC<ModalReviewProps> = (props) => {
         onChange,
         successText,
         errorText,
+        images,
+        onImagesChange,
     } = props;
     const {
         stars, text,
@@ -49,6 +56,14 @@ export const ModalReview: FC<ModalReviewProps> = (props) => {
     useEffect(() => {
         document.body.style.overflow = isOpen ? "hidden" : "";
     }, [isOpen]);
+
+    const handleUploadImages = useCallback(async (uploaded: MediaObjectType[]) => {
+        onImagesChange?.([...(images ?? []), ...uploaded]);
+    }, [images, onImagesChange]);
+
+    const handleDeleteImage = useCallback((imgId: string) => {
+        onImagesChange?.((images ?? []).filter((img) => img.id !== imgId));
+    }, [images, onImagesChange]);
 
     if (successText) {
         return (
@@ -101,6 +116,15 @@ export const ModalReview: FC<ModalReviewProps> = (props) => {
                     label={t("host-dashboard.Напишите ваш отзыв")}
                     maxLength={500}
                 />
+                {onImagesChange && (
+                    <ImagesUploader
+                        uploadedImgs={images ?? []}
+                        onUpload={handleUploadImages}
+                        onDelete={handleDeleteImage}
+                        onError={() => {}}
+                        maxLength={10}
+                    />
+                )}
                 {errorText && (<ErrorText text={errorText} />)}
                 {!stars && (
                     <p className={styles.hint}>

--- a/src/shared/ui/ReviewGallery/ReviewGallery.module.scss
+++ b/src/shared/ui/ReviewGallery/ReviewGallery.module.scss
@@ -1,0 +1,37 @@
+.wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 6px;
+}
+
+.thumbWrapper {
+    position: relative;
+    width: 56px;
+    height: 56px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    overflow: hidden;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.more {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    font-size: 14px;
+    font-weight: 600;
+}

--- a/src/shared/ui/ReviewGallery/ReviewGallery.tsx
+++ b/src/shared/ui/ReviewGallery/ReviewGallery.tsx
@@ -1,0 +1,64 @@
+import React, { FC, useState } from "react";
+import cn from "classnames";
+import { Image } from "@/types/media";
+import { getMediaContent, getMediaContentsArray } from "@/shared/lib/getMediaContent";
+import { ModalGallery } from "../ModalGallery/ModalGallery";
+import styles from "./ReviewGallery.module.scss";
+
+interface ReviewGalleryProps {
+    images?: Image[];
+    className?: string;
+    maxVisible?: number;
+}
+
+export const ReviewGallery: FC<ReviewGalleryProps> = (props) => {
+    const { images, className, maxVisible = 4 } = props;
+    const [isModalOpen, setModalOpen] = useState(false);
+    const [initialSlide, setInitialSlide] = useState(0);
+
+    if (!images || images.length === 0) {
+        return null;
+    }
+
+    const visibleImages = images.slice(0, maxVisible);
+    const hiddenCount = images.length - visibleImages.length;
+
+    const openGallery = (index: number) => {
+        setInitialSlide(index);
+        setModalOpen(true);
+    };
+
+    return (
+        <div className={cn(styles.wrapper, className)}>
+            {visibleImages.map((image, index) => {
+                const isLastVisible = index === visibleImages.length - 1;
+
+                return (
+                    <button
+                        type="button"
+                        key={image.id}
+                        className={styles.thumbWrapper}
+                        onClick={() => openGallery(index)}
+                    >
+                        <img
+                            className={styles.thumb}
+                            src={getMediaContent(image, "SMALL")}
+                            alt="review"
+                        />
+                        {isLastVisible && hiddenCount > 0 && (
+                            <span className={styles.more}>
+                                {`+${hiddenCount}`}
+                            </span>
+                        )}
+                    </button>
+                );
+            })}
+            <ModalGallery
+                isOpen={isModalOpen}
+                onClose={() => setModalOpen(false)}
+                images={getMediaContentsArray(images)}
+                initialSlide={initialSlide}
+            />
+        </div>
+    );
+};

--- a/src/widgets/HostReview/ui/ReviewAboutVolunteers/ReviewAboutVolunteers.tsx
+++ b/src/widgets/HostReview/ui/ReviewAboutVolunteers/ReviewAboutVolunteers.tsx
@@ -24,6 +24,7 @@ import { VerticalSlider } from "@/shared/ui/VerticalSlider/VerticalSlider";
 import { Locale } from "@/app/providers/LocaleProvider/ui/LocaleProvider";
 import { getErrorText } from "@/shared/lib/getErrorText";
 import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
+import { MediaObjectType } from "@/types/media";
 import styles from "./ReviewAboutVolunteers.module.scss";
 
 interface ReviewAboutVolunteersProps {
@@ -51,6 +52,7 @@ export const ReviewAboutVolunteers: FC<ReviewAboutVolunteersProps> = (props) => 
     const [selectedVolunteer, setSelectedVolunteer] = useState<NotDoneReviewHost | null>(
         null,
     );
+    const [reviewImages, setReviewImages] = useState<MediaObjectType[]>([]);
 
     const [page, setPage] = useState(1);
     const [hasMore, setHasMore] = useState(true);
@@ -106,6 +108,7 @@ export const ReviewAboutVolunteers: FC<ReviewAboutVolunteersProps> = (props) => 
     const resetSelectedReview = () => {
         setSelectedVolunteer(null);
         setToast(undefined);
+        setReviewImages([]);
         reset();
     };
 
@@ -121,6 +124,7 @@ export const ReviewAboutVolunteers: FC<ReviewAboutVolunteersProps> = (props) => 
                     volunteerId: selectedVolunteer.id,
                     description: text,
                     rating: stars,
+                    imageIds: reviewImages.map((image) => image.id),
                 }).unwrap();
                 setToast({
                     text: t("hostReviews.Ваш отзыв был отправлен"),
@@ -134,6 +138,7 @@ export const ReviewAboutVolunteers: FC<ReviewAboutVolunteersProps> = (props) => 
                 });
             } finally {
                 reset();
+                setReviewImages([]);
             }
         }
     });
@@ -222,6 +227,8 @@ export const ReviewAboutVolunteers: FC<ReviewAboutVolunteersProps> = (props) => 
                                 : undefined
                         }
                         locale={locale}
+                        images={reviewImages}
+                        onImagesChange={setReviewImages}
                     />
                 )}
             />

--- a/src/widgets/ReviewWidget/ui/ReviewWidget.tsx
+++ b/src/widgets/ReviewWidget/ui/ReviewWidget.tsx
@@ -3,6 +3,8 @@ import React, { FC, memo } from "react";
 import { useNavigate } from "react-router-dom";
 import star from "@/shared/assets/icons/offers/star.svg";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
+import { ReviewGallery } from "@/shared/ui/ReviewGallery/ReviewGallery";
+import { Image } from "@/types/media";
 
 import styles from "./ReviewWidget.module.scss";
 
@@ -12,12 +14,13 @@ interface ReviewWidgetProps {
     avatar?: string;
     name: string;
     url: string;
+    images?: Image[];
 }
 
 export const ReviewWidget: FC<ReviewWidgetProps> = memo(
     (props: ReviewWidgetProps) => {
         const {
-            reviewText, stars, name, avatar, url,
+            reviewText, stars, name, avatar, url, images,
         } = props;
         const navigate = useNavigate();
 
@@ -28,6 +31,7 @@ export const ReviewWidget: FC<ReviewWidgetProps> = memo(
         return (
             <div className={styles.wrapper}>
                 <p className={styles.reviewText}>{reviewText}</p>
+                <ReviewGallery images={images} />
                 <div className={styles.reviewInfo}>
                     <div className={styles.ratingContainer}>
                         <img src={star} alt="rating" />

--- a/src/widgets/VolunteerReview/ui/ReviewAboutOffers/ReviewAboutOffers.tsx
+++ b/src/widgets/VolunteerReview/ui/ReviewAboutOffers/ReviewAboutOffers.tsx
@@ -23,6 +23,7 @@ import { VerticalSlider } from "@/shared/ui/VerticalSlider/VerticalSlider";
 import { Locale } from "@/app/providers/LocaleProvider/ui/LocaleProvider";
 import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 import { NotDoneReviewVolunteer } from "@/entities/Review/model/types/review";
+import { MediaObjectType } from "@/types/media";
 import styles from "./ReviewAboutOffers.module.scss";
 import { getErrorText } from "@/shared/lib/getErrorText";
 
@@ -51,6 +52,7 @@ export const ReviewAboutOffers: FC<ReviewAboutOffersProps> = (props) => {
     const [selectedOffer, setSelectedOffer] = useState<NotDoneReviewVolunteer | null>(
         null,
     );
+    const [reviewImages, setReviewImages] = useState<MediaObjectType[]>([]);
 
     const [page, setPage] = useState(1);
     const [hasMore, setHasMore] = useState(true);
@@ -107,6 +109,7 @@ export const ReviewAboutOffers: FC<ReviewAboutOffersProps> = (props) => {
     const resetSelectedReview = () => {
         setSelectedOffer(null);
         setToast(undefined);
+        setReviewImages([]);
         reset();
     };
 
@@ -118,7 +121,12 @@ export const ReviewAboutOffers: FC<ReviewAboutOffersProps> = (props) => {
             setToast(undefined);
             try {
                 await createOfferReview(
-                    { vacancyId: selectedOffer.id, description: text, rating: stars },
+                    {
+                        vacancyId: selectedOffer.id,
+                        description: text,
+                        rating: stars,
+                        imageIds: reviewImages.map((image) => image.id),
+                    },
                 ).unwrap();
                 setToast({
                     text: "Ваш отзыв был отправлен",
@@ -132,6 +140,7 @@ export const ReviewAboutOffers: FC<ReviewAboutOffersProps> = (props) => {
                 });
             } finally {
                 reset();
+                setReviewImages([]);
             }
         }
     });
@@ -220,6 +229,8 @@ export const ReviewAboutOffers: FC<ReviewAboutOffersProps> = (props) => {
                                 : undefined
                         }
                         locale={locale}
+                        images={reviewImages}
+                        onImagesChange={setReviewImages}
                     />
                 )}
             />


### PR DESCRIPTION
GS-83

Depends on backend PR Goodsurfing/gs-backend#300 (`imageIds` on review create + `images` in all review list/read DTOs).

- `shared/ui/ReviewGallery` — новый компонент: ряд миниатюр + лайтбокс (переиспользует `ModalGallery`)
- `shared/ui/ModalReview` — добавлен `ImagesUploader` (опционально, через `images`/`onImagesChange`), пробрасывается через `VolunteerModalReview`/`HostModalReview` в оба личных кабинета (волонтёр → вакансия, хост → волонтёр)
- Публичная форма отзыва на странице вакансии (`OfferReviewsCard`) — тоже получила загрузку фото
- Галерея добавлена во все карточки/списки отзывов: `ReviewWidget` (публичные списки по вакансии/волонтёру), `ReviewCardOffer`, `ReviewFullCard`, `ReviewAboutVolunteerCard` (личные "мои отзывы")
- `entities/Review` типы обновлены (`images: Image[]` в списочных DTO, `imageIds?: string[]` в create-запросах)
- typecheck + lint зелёные