### PR TITLE
feat(review): quick-toggle for featured reviews in admin list

### DIFF
--- a/src/entities/Admin/model/types/adminSchema.ts
+++ b/src/entities/Admin/model/types/adminSchema.ts
@@ -449,6 +449,7 @@ export interface GetAdminReviewVacancyListParams {
     authorLastName?: string;
     authorFirstName?: string;
     vacancyName?: string;
+    isFeatured?: boolean;
     page: number;
     limit: number;
 }

--- a/src/widgets/Admin/ui/AdminReviewVacanciesTable/AdminReviewVacanciesTable.module.scss
+++ b/src/widgets/Admin/ui/AdminReviewVacanciesTable/AdminReviewVacanciesTable.module.scss
@@ -12,6 +12,12 @@
     align-items: center;
 }
 
+.featuredCounter {
+    color: var(--text-caption);
+    font-size: 14px;
+    white-space: nowrap;
+}
+
 .btnIcon {
     background: transparent;
     border: none;

--- a/src/widgets/Admin/ui/AdminReviewVacanciesTable/AdminReviewVacanciesTable.test.tsx
+++ b/src/widgets/Admin/ui/AdminReviewVacanciesTable/AdminReviewVacanciesTable.test.tsx
@@ -1,0 +1,68 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AdminReviewVacanciesTable } from "./AdminReviewVacanciesTable";
+import { MAX_FEATURED_REVIEWS } from "./featuredToggle";
+
+/**
+ * GS-84: смоук-тест на счётчик "На главной: X из N" в списке отзывов на
+ * вакансии — сам переключатель и лимит покрыты юнит-тестами в
+ * featuredToggle.test.ts (MUI DataGrid не виртуализирует строки в jsdom
+ * без реального layout, поэтому кликать по ячейкам сетки в тесте
+ * ненадёжно).
+ */
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+    useNavigate: () => vi.fn(),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("@/widgets/OffersMap", () => ({
+    OfferPagination: () => null,
+}));
+
+let featuredCountTotal = 0;
+
+vi.mock("@/entities/Admin", async () => {
+    const actual = await vi.importActual<typeof import("@/entities/Admin")>("@/entities/Admin");
+    return {
+        ...actual,
+        useLazyGetAdminReviewVacanciesListQuery: () => [
+            vi.fn().mockReturnValue({ unwrap: () => Promise.resolve() }),
+            { data: { data: [], pagination: { total: 0 } }, isLoading: false, isFetching: false },
+        ],
+        useGetAdminReviewVacanciesListQuery: () => ({
+            data: { data: [], pagination: { total: featuredCountTotal } },
+        }),
+        useEditAdminReviewVacancyMutation: () => [vi.fn(), { isLoading: false }],
+        useDeleteAdminReviewVacancyMutation: () => [vi.fn(), { isLoading: false }],
+    };
+});
+
+describe("AdminReviewVacanciesTable — счётчик отзывов на главной", () => {
+    beforeEach(() => {
+        featuredCountTotal = 0;
+    });
+
+    it(`показывает 0 из ${MAX_FEATURED_REVIEWS}, когда ни один отзыв не выбран`, () => {
+        render(<AdminReviewVacanciesTable />);
+
+        expect(screen.getByText(`На главной: 0 из ${MAX_FEATURED_REVIEWS}`)).toBeInTheDocument();
+    });
+
+    it("отражает реальное количество выбранных отзывов", () => {
+        featuredCountTotal = 3;
+        render(<AdminReviewVacanciesTable />);
+
+        expect(screen.getByText(`На главной: 3 из ${MAX_FEATURED_REVIEWS}`)).toBeInTheDocument();
+    });
+});

--- a/src/widgets/Admin/ui/AdminReviewVacanciesTable/AdminReviewVacanciesTable.tsx
+++ b/src/widgets/Admin/ui/AdminReviewVacanciesTable/AdminReviewVacanciesTable.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import {
-    FormControl, InputLabel, MenuItem, Select, Stack, TextField,
+    Checkbox,
+    FormControl, FormControlLabel, InputLabel, MenuItem, Select, Stack, Switch, TextField, Tooltip,
 } from "@mui/material";
 import { ReactSVG } from "react-svg";
 import cn from "classnames";
@@ -12,7 +13,8 @@ import deleteIcon from "@/shared/assets/icons/admin/delete.svg";
 import { useLocale } from "@/app/providers/LocaleProvider";
 import { getAdminReviewVacancyPersonalPageUrl } from "@/shared/config/routes/AppUrls";
 import {
-    AdminSort, useDeleteAdminReviewVacancyMutation,
+    AdminSort, useDeleteAdminReviewVacancyMutation, useEditAdminReviewVacancyMutation,
+    useGetAdminReviewVacanciesListQuery,
     useLazyGetAdminReviewVacanciesListQuery,
 } from "@/entities/Admin";
 import { OfferPagination } from "@/widgets/OffersMap";
@@ -27,12 +29,14 @@ import { useGetFullName } from "@/shared/lib/getFullName";
 import { textSlice } from "@/shared/lib/textSlice";
 import styles from "./AdminReviewVacanciesTable.module.scss";
 import { useQueryFilters } from "@/shared/hooks/usePaginationParams";
+import { buildFeaturedEditBody, isFeaturedCapReached, MAX_FEATURED_REVIEWS } from "./featuredToggle";
 
 interface ReviewVacancyFilters {
     sort?: AdminSort;
     authorLastName?: string;
     authorFirstName?: string;
     vacancyName?: string;
+    isFeatured?: string;
 }
 
 const reviewVacancyCustomFields: CustomFilterField<keyof ReviewVacancyFilters>[] = [
@@ -75,6 +79,22 @@ const reviewVacancyCustomFields: CustomFilterField<keyof ReviewVacancyFilters>[]
                 fullWidth
                 size="small"
                 disabled={disabled}
+            />
+        ),
+    },
+    {
+        key: "isFeatured",
+        label: "Только на главной",
+        render: ({ value, onChange, disabled }) => (
+            <FormControlLabel
+                disabled={disabled}
+                control={(
+                    <Checkbox
+                        checked={value === "true"}
+                        onChange={(e) => onChange(e.target.checked ? "true" : undefined)}
+                    />
+                )}
+                label="Только на главной"
             />
         ),
     },
@@ -127,6 +147,7 @@ export const AdminReviewVacanciesTable = () => {
         authorLastName: undefined,
         authorFirstName: undefined,
         vacancyName: undefined,
+        isFeatured: undefined,
     });
 
     const { getFullName } = useGetFullName();
@@ -136,6 +157,13 @@ export const AdminReviewVacanciesTable = () => {
         isFetching,
     }] = useLazyGetAdminReviewVacanciesListQuery();
     const [deleteReview, { isLoading: isDeleting }] = useDeleteAdminReviewVacancyMutation();
+    const [editReview, { isLoading: isTogglingFeatured }] = useEditAdminReviewVacancyMutation();
+    const { data: featuredCountData } = useGetAdminReviewVacanciesListQuery({
+        page: 1,
+        limit: 1,
+        isFeatured: true,
+    });
+    const featuredCount = featuredCountData?.pagination.total ?? 0;
 
     useEffect(() => {
         const fetchData = async () => {
@@ -148,6 +176,7 @@ export const AdminReviewVacanciesTable = () => {
                     authorFirstName: filters.authorFirstName,
                     authorLastName: filters.authorLastName,
                     vacancyName: filters.vacancyName,
+                    isFeatured: filters.isFeatured === "true" ? true : undefined,
                 }).unwrap();
             } catch {
                 setToast({
@@ -158,7 +187,39 @@ export const AdminReviewVacanciesTable = () => {
         };
         fetchData();
     }, [filters.authorFirstName, filters.authorLastName,
-        filters.page, filters.sort, filters.vacancyName, getReviews]);
+        filters.isFeatured, filters.page, filters.sort, filters.vacancyName, getReviews]);
+
+    const handleToggleFeatured = async (row: {
+        id: string; rating: number; description: string; isFeatured: boolean;
+    }) => {
+        setToast(undefined);
+        const nextValue = !row.isFeatured;
+
+        if (isFeaturedCapReached(featuredCount, nextValue)) {
+            setToast({
+                text: `На главной уже выбрано максимум отзывов (${MAX_FEATURED_REVIEWS}). `
+                    + "Уберите один, чтобы добавить другой.",
+                type: HintType.Error,
+            });
+            return;
+        }
+
+        try {
+            await editReview({
+                reviewId: row.id,
+                body: buildFeaturedEditBody(row, nextValue),
+            }).unwrap();
+            setToast({
+                text: nextValue ? "Отзыв добавлен на главную страницу" : "Отзыв убран с главной страницы",
+                type: HintType.Success,
+            });
+        } catch {
+            setToast({
+                text: "Не удалось изменить показ отзыва на главной",
+                type: HintType.Error,
+            });
+        }
+    };
 
     const handleOpenDeleteModal = (id: string) => {
         setReviewlToDelete({ id });
@@ -243,6 +304,26 @@ export const AdminReviewVacanciesTable = () => {
             width: 180,
         },
         {
+            field: "isFeatured",
+            headerName: "На главной",
+            width: 130,
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            hideable: false,
+            renderCell: (params) => (
+                <Tooltip title={params.row.isFeatured ? "Убрать с главной" : "Показать на главной"}>
+                    <span>
+                        <Switch
+                            checked={params.row.isFeatured}
+                            disabled={isTogglingFeatured}
+                            onChange={() => handleToggleFeatured(params.row)}
+                        />
+                    </span>
+                </Tooltip>
+            ),
+        },
+        {
             field: "actions",
             headerName: "Действия",
             width: 160,
@@ -308,7 +389,7 @@ export const AdminReviewVacanciesTable = () => {
             const {
                 id, authorFirstName, authorLastName,
                 vacancyName,
-                rating, description, created, authorId,
+                rating, description, created, authorId, isFeatured,
             } = review;
             return {
                 id,
@@ -318,6 +399,7 @@ export const AdminReviewVacanciesTable = () => {
                 rating,
                 description,
                 created,
+                isFeatured,
             };
         });
         return (
@@ -348,6 +430,9 @@ export const AdminReviewVacanciesTable = () => {
                     disabled={isLoading}
                     customFields={reviewVacancyCustomFields}
                 />
+                <span className={styles.featuredCounter}>
+                    {`На главной: ${featuredCount} из ${MAX_FEATURED_REVIEWS}`}
+                </span>
             </div>
             <div className={styles.table}>
                 {renderTable()}

--- a/src/widgets/Admin/ui/AdminReviewVacanciesTable/featuredToggle.test.ts
+++ b/src/widgets/Admin/ui/AdminReviewVacanciesTable/featuredToggle.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+    buildFeaturedEditBody, isFeaturedCapReached, MAX_FEATURED_REVIEWS,
+} from "./featuredToggle";
+
+/**
+ * GS-84: логика быстрого переключателя "На главной" в списке отзывов.
+ * Вынесена в чистые функции отдельно от AdminReviewVacanciesTable.tsx,
+ * потому что сам компонент рендерит MUI DataGrid, который в jsdom не
+ * виртуализирует строки без реального layout — тестировать через него
+ * логику каждый раз ненадёжно.
+ */
+describe("isFeaturedCapReached", () => {
+    it("не блокирует включение, пока лимит не достигнут", () => {
+        expect(isFeaturedCapReached(9, true)).toBe(false);
+    });
+
+    it("блокирует включение, когда лимит уже достигнут", () => {
+        expect(isFeaturedCapReached(MAX_FEATURED_REVIEWS, true)).toBe(true);
+    });
+
+    it("блокирует включение и при превышении лимита", () => {
+        expect(isFeaturedCapReached(MAX_FEATURED_REVIEWS + 3, true)).toBe(true);
+    });
+
+    it("никогда не блокирует выключение, даже при переполненном лимите", () => {
+        expect(isFeaturedCapReached(MAX_FEATURED_REVIEWS, false)).toBe(false);
+    });
+});
+
+describe("buildFeaturedEditBody", () => {
+    it("передаёт текущие rating/description вместе с новым isFeatured", () => {
+        const row = {
+            id: "review-1", rating: 4.5, description: "Отличная вакансия", isFeatured: false,
+        };
+
+        expect(buildFeaturedEditBody(row, true)).toEqual({
+            rating: 4.5,
+            description: "Отличная вакансия",
+            isFeatured: true,
+        });
+    });
+
+    it("не теряет описание при выключении показа на главной", () => {
+        const row = {
+            id: "review-1", rating: 5, description: "Текст отзыва", isFeatured: true,
+        };
+
+        expect(buildFeaturedEditBody(row, false)).toEqual({
+            rating: 5,
+            description: "Текст отзыва",
+            isFeatured: false,
+        });
+    });
+});

--- a/src/widgets/Admin/ui/AdminReviewVacanciesTable/featuredToggle.ts
+++ b/src/widgets/Admin/ui/AdminReviewVacanciesTable/featuredToggle.ts
@@ -1,0 +1,25 @@
+// Совпадает с App\Module\ReviewVacancy\Api\Query\Featured\FeaturedHandler::MAX_RESULTS
+export const MAX_FEATURED_REVIEWS = 10;
+
+export interface FeaturableReviewRow {
+    id: string;
+    rating: number;
+    description: string;
+    isFeatured: boolean;
+}
+
+/**
+ * Включение отзыва блокируем только когда лимит уже исчерпан — выключение
+ * уже показанного на главной отзыва должно работать всегда, иначе admin
+ * не сможет освободить место под другой отзыв.
+ */
+export const isFeaturedCapReached = (
+    currentFeaturedTotal: number,
+    nextValue: boolean,
+): boolean => nextValue && currentFeaturedTotal >= MAX_FEATURED_REVIEWS;
+
+export const buildFeaturedEditBody = (row: FeaturableReviewRow, nextValue: boolean) => ({
+    rating: row.rating,
+    description: row.description,
+    isFeatured: nextValue,
+});


### PR DESCRIPTION
## Summary
- Admin can toggle a review's "on homepage" status directly from the review-vacancy list (switch column), no need to open the edit form.
- Adds a "только на главной" filter and a "N из 10" counter matching the homepage endpoint's cap (`FeaturedHandler::MAX_RESULTS`).
- Turning a review ON is blocked with a toast once the cap is reached; turning OFF always works so admin can free up a slot.

GS-84

Depends on Goodsurfing/gs-backend#（isFeatured filter PR) for the "только на главной" filter.

## Test plan
- [x] `featuredToggle.test.ts` — cap guard + edit-body construction, revert-and-confirm-fails
- [x] `AdminReviewVacanciesTable.test.tsx` — counter reflects real featured count
- [x] full suite green (291 tests), typecheck + lint clean