### PR TITLE
feat(about-project): bold highlighting + justify for mission text

### DIFF
--- a/src/pages/AboutProjectPage/ui/Mission/Mission.module.scss
+++ b/src/pages/AboutProjectPage/ui/Mission/Mission.module.scss
@@ -20,7 +20,7 @@
     overflow-wrap: break-word;
     max-width: 720px;
     width: 100%;
-    text-align: left;
+    text-align: justify;
 }
 
 .button {

--- a/src/pages/AboutProjectPage/ui/Mission/Mission.test.tsx
+++ b/src/pages/AboutProjectPage/ui/Mission/Mission.test.tsx
@@ -1,0 +1,31 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Mission } from "./Mission";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+/**
+ * GS-85: текст миссии — plain-текст из админки без HTML, **bold** синтаксис
+ * даёт админу управлять выделением конкретных фраз (см. renderBoldText.test.tsx).
+ */
+describe("Mission", () => {
+    it("выделяет жирным фразы в **...** и оставляет остальной текст как есть", () => {
+        render(<Mission description="Обычный текст. **Важная фраза.** Ещё текст." />);
+
+        const strong = screen.getByText("Важная фраза.");
+        expect(strong.tagName).toBe("STRONG");
+        expect(screen.getByText(/Обычный текст\./)).toBeInTheDocument();
+    });
+});

--- a/src/pages/AboutProjectPage/ui/Mission/Mission.tsx
+++ b/src/pages/AboutProjectPage/ui/Mission/Mission.tsx
@@ -8,6 +8,7 @@ import Button from "@/shared/ui/Button/Button";
 import styles from "./Mission.module.scss";
 import { useLocale } from "@/app/providers/LocaleProvider";
 import { getNPOPageUrl } from "@/shared/config/routes/AppUrls";
+import { renderBoldText } from "@/shared/lib/renderBoldText";
 
 interface MissionProps {
     className?: string;
@@ -28,7 +29,7 @@ export const Mission: FC<MissionProps> = (props: MissionProps) => {
         <section className={cn(className, styles.wrapper)}>
             <h2 className={styles.title}>{t("Миссия ГудСёрфинга")}</h2>
             <p className={styles.description}>
-                {description}
+                {description && renderBoldText(description)}
             </p>
             <Button
                 className={styles.button}

--- a/src/shared/lib/renderBoldText.test.tsx
+++ b/src/shared/lib/renderBoldText.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { renderBoldText } from "./renderBoldText";
+
+describe("renderBoldText", () => {
+    it("возвращает исходный текст без изменений, если разметки нет", () => {
+        const { container } = render(<>{renderBoldText("Обычный текст без выделения")}</>);
+        expect(container.textContent).toBe("Обычный текст без выделения");
+        expect(container.querySelector("strong")).toBeNull();
+    });
+
+    it("оборачивает **текст** в <strong>, убирая звёздочки", () => {
+        const { container } = render(<>{renderBoldText("До **важная фраза** после")}</>);
+
+        expect(container.textContent).toBe("До важная фраза после");
+        const strong = container.querySelector("strong");
+        expect(strong).not.toBeNull();
+        expect(strong?.textContent).toBe("важная фраза");
+    });
+
+    it("поддерживает несколько выделенных фраз в одном тексте", () => {
+        const { container } = render(
+            <>{renderBoldText("**Первая.** Обычный текст. **Вторая!**")}</>,
+        );
+
+        const strongs = container.querySelectorAll("strong");
+        expect(strongs).toHaveLength(2);
+        expect(strongs[0].textContent).toBe("Первая.");
+        expect(strongs[1].textContent).toBe("Вторая!");
+        expect(container.textContent).toBe("Первая. Обычный текст. Вторая!");
+    });
+
+    it("не ломается на непарной звёздочке", () => {
+        const { container } = render(<>{renderBoldText("Текст с одной * звёздочкой")}</>);
+
+        expect(container.textContent).toBe("Текст с одной * звёздочкой");
+        expect(container.querySelector("strong")).toBeNull();
+    });
+});

--- a/src/shared/lib/renderBoldText.tsx
+++ b/src/shared/lib/renderBoldText.tsx
@@ -1,0 +1,20 @@
+import React, { Fragment, ReactNode } from "react";
+
+const BOLD_PATTERN = /(\*\*[^*]+\*\*)/g;
+const BOLD_SEGMENT_PATTERN = /^\*\*([^*]+)\*\*$/;
+
+/**
+ * Админ-контент (например, миссия на /about-project) хранится как обычный
+ * текст без HTML — простая **bold** разметка даёт возможность выделять
+ * отдельные фразы жирным без полноценного WYSIWYG-редактора.
+ */
+export const renderBoldText = (text: string): ReactNode[] => text
+    .split(BOLD_PATTERN)
+    .filter(Boolean)
+    .map((segment, index) => {
+        const match = segment.match(BOLD_SEGMENT_PATTERN);
+        if (match) {
+            return <strong key={index}>{match[1]}</strong>;
+        }
+        return <Fragment key={index}>{segment}</Fragment>;
+    });


### PR DESCRIPTION
## Summary
- Adds minimal **bold** markdown support for the admin-editable mission text on `/about-project`, so admin can highlight specific phrases without a WYSIWYG editor.
- Switches the mission paragraph to justify alignment per the requested mockup.

GS-85

## Test plan
- [x] `renderBoldText.test.tsx` — bold parsing, multiple phrases, unmatched `*`, revert-and-confirm-fails
- [x] `Mission.test.tsx` — renders `<strong>` for `**...**` segments
- [x] full suite green (296 tests), typecheck + lint clean