### PR TITLE
feat(about-project): bold highlighting + justify for how-it-started text

### DIFF
--- a/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.module.scss
+++ b/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.module.scss
@@ -20,7 +20,7 @@
     overflow-wrap: break-word;
     max-width: 720px;
     width: 100%;
-    text-align: left;
+    text-align: justify;
 }
 
 .button {

--- a/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.test.tsx
+++ b/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.test.tsx
@@ -1,0 +1,23 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HowItStarted } from "./HowItStarted";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * GS-85: как и Mission, текст "Как всё началось" — plain-текст из админки,
+ * **bold** синтаксис даёт админу управлять выделением (см. renderBoldText.test.tsx).
+ */
+describe("HowItStarted", () => {
+    it("выделяет жирным фразы в **...** и оставляет остальной текст как есть", () => {
+        render(<HowItStarted description="Обычный текст. **Важная фраза.** Ещё текст." />);
+
+        const strong = screen.getByText("Важная фраза.");
+        expect(strong.tagName).toBe("STRONG");
+        expect(screen.getByText(/Обычный текст\./)).toBeInTheDocument();
+    });
+});

--- a/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.tsx
+++ b/src/pages/AboutProjectPage/ui/HowItStarted/HowItStarted.tsx
@@ -3,6 +3,7 @@ import React, { FC } from "react";
 
 import { useTranslation } from "react-i18next";
 import styles from "./HowItStarted.module.scss";
+import { renderBoldText } from "@/shared/lib/renderBoldText";
 
 interface HowItStartedProps {
     className?: string;
@@ -18,7 +19,7 @@ export const HowItStarted: FC<HowItStartedProps> = (
         <section className={cn(className, styles.wrapper)}>
             <h2 className={styles.title}>{t("Как всё началось")}</h2>
             <p className={styles.description}>
-                {description}
+                {description && renderBoldText(description)}
             </p>
         </section>
     );


### PR DESCRIPTION
## Summary
- Same treatment as the mission text (GS-85): justify alignment + **bold** markdown support for the "Как всё началось" admin-editable text.

GS-85

## Test plan
- [x] `HowItStarted.test.tsx` — renders `<strong>` for `**...**` segments (parsing logic itself covered by renderBoldText.test.tsx)
- [x] full suite green (297 tests), typecheck + lint clean