### PR TITLE
feat(review): clicking a homepage review card opens its vacancy

### DIFF
--- a/src/entities/Review/model/types/review.ts
+++ b/src/entities/Review/model/types/review.ts
@@ -218,6 +218,7 @@ export interface MyReviewHostResponse {
 export interface FeaturedReview {
     id: string;
     title: string;
+    vacancyId: number;
     description: string;
     rating: number;
     authorName: string;

--- a/src/widgets/ReviewsContainer/ui/ReviewItem/ReviewItem.module.scss
+++ b/src/widgets/ReviewsContainer/ui/ReviewItem/ReviewItem.module.scss
@@ -4,6 +4,7 @@
 	border-radius: var(--radius);
 	background-color: var(--color-white);
 	box-shadow: 0 5px 20px rgb(14 29 39 / 5%);
+	cursor: pointer;
 }
 
 .image {

--- a/src/widgets/ReviewsContainer/ui/ReviewItem/ReviewItem.tsx
+++ b/src/widgets/ReviewsContainer/ui/ReviewItem/ReviewItem.tsx
@@ -1,5 +1,8 @@
 import React, { FC } from "react";
+import { useNavigate } from "react-router-dom";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
+import { useLocale } from "@/app/providers/LocaleProvider";
+import { getOfferPersonalPageUrl } from "@/shared/config/routes/AppUrls";
 
 import styles from "./ReviewItem.module.scss";
 
@@ -9,6 +12,7 @@ interface ReviewItemProps {
     image: string;
     author: string;
     avatar?: string;
+    vacancyId: number;
 }
 
 const ReviewItem: FC<ReviewItemProps> = ({
@@ -17,24 +21,34 @@ const ReviewItem: FC<ReviewItemProps> = ({
     image,
     avatar,
     author,
-}) => (
-    <div className={styles.wrapper}>
-        <img src={image} alt={title} className={styles.image} loading="lazy" />
-        <div className={styles.info}>
-            <h3 className={styles.title}>{title}</h3>
-            <p className={styles.text}>{text}</p>
-            <div className={styles.user}>
-                <Avatar
-                    size="SMALL"
-                    icon={avatar}
-                    text={author}
-                    alt={author}
-                    className={styles.avatar}
-                />
-                <p className={styles.author}>{author}</p>
+    vacancyId,
+}) => {
+    const navigate = useNavigate();
+    const { locale } = useLocale();
+
+    const handleClick = () => {
+        navigate(getOfferPersonalPageUrl(locale, String(vacancyId)));
+    };
+
+    return (
+        <div className={styles.wrapper} onClick={handleClick} role="button" tabIndex={0}>
+            <img src={image} alt={title} className={styles.image} loading="lazy" />
+            <div className={styles.info}>
+                <h3 className={styles.title}>{title}</h3>
+                <p className={styles.text}>{text}</p>
+                <div className={styles.user}>
+                    <Avatar
+                        size="SMALL"
+                        icon={avatar}
+                        text={author}
+                        alt={author}
+                        className={styles.avatar}
+                    />
+                    <p className={styles.author}>{author}</p>
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default ReviewItem;

--- a/src/widgets/ReviewsContainer/ui/ReviewsContainer/ReviewsContainer.test.tsx
+++ b/src/widgets/ReviewsContainer/ui/ReviewsContainer/ReviewsContainer.test.tsx
@@ -1,13 +1,23 @@
 import {
     describe, it, expect, vi,
 } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import ReviewsContainer from "./ReviewsContainer";
+
+const navigateMock = vi.fn();
 
 let mockFeaturedReviews: unknown[] | undefined;
 
 vi.mock("@/entities/Review", () => ({
     useGetFeaturedReviewsQuery: () => ({ data: mockFeaturedReviews }),
+}));
+
+vi.mock("react-router-dom", () => ({
+    useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
 }));
 
 /**
@@ -42,6 +52,7 @@ describe("ReviewsContainer", () => {
         mockFeaturedReviews = [{
             id: "1",
             title: "Отзыв с фото",
+            vacancyId: 42,
             description: "Отличная поездка",
             rating: 5,
             authorName: "Тест Волонтёр",
@@ -50,5 +61,23 @@ describe("ReviewsContainer", () => {
         }];
         render(<ReviewsContainer />);
         expect(screen.getByText("Отзыв с фото")).toBeInTheDocument();
+    });
+
+    it("переходит на страницу вакансии по клику на карточку отзыва", () => {
+        navigateMock.mockClear();
+        mockFeaturedReviews = [{
+            id: "1",
+            title: "Отзыв с фото",
+            vacancyId: 42,
+            description: "Отличная поездка",
+            rating: 5,
+            authorName: "Тест Волонтёр",
+            authorAvatar: null,
+            images: [{ id: "img1", contentUrl: "https://example.com/1.jpg" }],
+        }];
+        render(<ReviewsContainer />);
+        fireEvent.click(screen.getByText("Отзыв с фото"));
+
+        expect(navigateMock).toHaveBeenCalledWith("/ru/offers/42");
     });
 });

--- a/src/widgets/ReviewsContainer/ui/ReviewsContainer/ReviewsContainer.tsx
+++ b/src/widgets/ReviewsContainer/ui/ReviewsContainer/ReviewsContainer.tsx
@@ -68,6 +68,7 @@ const ReviewsContainer: FC = () => {
                                 image={getMediaContent(review.images[0], "LARGE") ?? ""}
                                 author={review.authorName}
                                 avatar={getMediaContent(review.authorAvatar ?? undefined, "SMALL")}
+                                vacancyId={review.vacancyId}
                             />
                         </SwiperSlide>
                     ))}


### PR DESCRIPTION
## Summary
- `ReviewItem` (homepage featured-reviews slider) had no click handler at all — cards went nowhere. Wires the card to navigate to the vacancy page using the `vacancyId` now exposed by the backend.

GS-84

Depends on Goodsurfing/gs-backend#304 for `vacancyId` on the featured endpoint.

## Test plan
- [x] `ReviewsContainer.test.tsx` — click navigates to `/ru/offers/{vacancyId}`, revert-and-confirm-fails
- [x] full suite green (298 tests), typecheck + lint clean