### PR TITLE
fix(offers-map): open marker balloon when a list card is selected

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -13,6 +13,7 @@ const getZoom = vi.fn(() => 5);
 const getBounds = vi.fn(() => [[54, 36], [57, 39]]);
 const boundsChangeHandlers: Array<() => void> = [];
 const onLoadCalls = vi.fn();
+const balloonOpen = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
@@ -52,9 +53,14 @@ vi.mock("@pbe/react-yandex-maps", () => ({
         return <div>{children}</div>;
     },
     ZoomControl: () => null,
-    ObjectManager: ({ features }: { features: unknown[] }) => (
-        <div data-testid="object-manager">{features.length}</div>
-    ),
+    // eslint-disable-next-line react/no-unused-prop-types
+    ObjectManager: (props: { features: unknown[]; instanceRef?: { current: unknown } }) => {
+        const { features, instanceRef } = props;
+        if (instanceRef) {
+            instanceRef.current = { objects: { balloon: { open: balloonOpen } } };
+        }
+        return <div data-testid="object-manager">{features.length}</div>;
+    },
 }));
 
 const offer = (overrides: Partial<OfferMap> = {}): OfferMap => ({
@@ -73,6 +79,7 @@ describe("OffersMap", () => {
         getZoom.mockClear();
         getBounds.mockClear();
         onLoadCalls.mockClear();
+        balloonOpen.mockClear();
         boundsChangeHandlers.length = 0;
     });
 
@@ -88,6 +95,27 @@ describe("OffersMap", () => {
 
         expect(setCenter).toHaveBeenCalledWith([55.75, 37.61], 10, { duration: 400 });
         expect(screen.queryByText(/местоположение/)).not.toBeInTheDocument();
+    });
+
+    it("открывает balloon выбранной вакансии, когда фокусировка карты завершилась", async () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+                selectedOfferId={1}
+                selectedOfferCoordinates={{ latitude: 55.75, longitude: 37.61 }}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+        expect(balloonOpen).not.toHaveBeenCalled();
+
+        // Симулируем завершение panning-анимации карты (событие "actionend").
+        act(() => {
+            boundsChangeHandlers.forEach((handler) => handler());
+        });
+
+        expect(balloonOpen).toHaveBeenCalledWith("1");
     });
 
     it("показывает подсказку вместо тишины, если координаты точно отсутствуют (null)", () => {

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -141,7 +141,29 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
             Math.max(currentZoom, FOCUS_ZOOM),
             { duration: 400 },
         );
-    }, [selectedOfferId, selectedOfferCoordinates]);
+
+        // Клик по карточке в списке раньше молча подвигал карту, а подсказку
+        // с превью вакансии видел только тот, кто кликнул прямо по маркеру.
+        // Открываем тот же balloon программно, но только после того как pan
+        // завершится (actionend) — иначе ObjectManager может не найти
+        // объект, если он ещё не попал в текущий кластер на новом месте.
+        const map = mapRef.current;
+        const objectManager = objectManagerRef.current;
+        if (!objectManager) return undefined;
+
+        const openBalloon = () => {
+            map.events.remove("actionend", openBalloon);
+            objectManager.objects.balloon.open(selectedOfferId.toString()).catch(() => {});
+        };
+        map.events.add("actionend", openBalloon);
+        return () => {
+            map.events.remove("actionend", openBalloon);
+        };
+        // ymapState в зависимостях намеренно: ObjectManager монтируется
+        // (и заполняет objectManagerRef) только после onLoad карты, который
+        // может случиться позже, чем этот эффект уже отработал на первом
+        // рендере с уже выбранной вакансией (например, ?offerId= в URL).
+    }, [selectedOfferId, selectedOfferCoordinates, ymapState]);
 
     useEffect(() => {
         if (!ymapState || !mapRef.current) return undefined;


### PR DESCRIPTION
## Summary
- GS-87: clicking a card in the offers list panned/zoomed the map to the matching marker, but the balloon with the vacancy preview never opened — only a direct click on the marker itself opened it.
- Now the balloon opens programmatically via `ObjectManager.objects.balloon.open(id)` once the pan animation finishes (`actionend`), so selecting a list item shows the same hint a map click would.

## Test plan
- [x] New unit test: balloon opens after the focus animation completes
- [x] revert-and-confirm-fails on the fix
- [x] Full frontend suite green (309 tests)