### PR TITLE
fix(offers-map): tidy vacancy card in map balloon, align marker with popup

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
@@ -10,11 +10,17 @@
 
 .balloonWrapper {
     display: flex;
-    gap: 8px;
-    align-items: flex-start;
-    padding: 4px;
+    flex-direction: column;
+    width: 220px;
     cursor: pointer;
-    min-width: 200px;
+    background: var(--color-white);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.balloonImageLink {
+    display: block;
+    line-height: 0;
 }
 
 .text {
@@ -22,6 +28,7 @@
     flex-direction: column;
     gap: 4px;
     overflow: hidden;
+    padding: 10px 12px 12px;
 }
 
 .map {
@@ -52,19 +59,20 @@
     color: var(--text-primary-1);
 }
 
-.balloonLink {
-    color: var(--accent-color);
-}
-
 .balloonImage {
-    width: 100px;
-    height: 50px;
+    display: block;
+    width: 100%;
+    height: 120px;
     object-fit: cover;
 }
 
 .balloonTitle {
     font-weight: 700;
     font-size: 14px;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
 }
 
 .balloonCategory {

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -14,6 +14,7 @@ const getBounds = vi.fn(() => [[54, 36], [57, 39]]);
 const boundsChangeHandlers: Array<() => void> = [];
 const onLoadCalls = vi.fn();
 const balloonOpen = vi.fn().mockResolvedValue(undefined);
+let capturedFeatures: any[] = [];
 
 vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
@@ -56,6 +57,7 @@ vi.mock("@pbe/react-yandex-maps", () => ({
     // eslint-disable-next-line react/no-unused-prop-types
     ObjectManager: (props: { features: unknown[]; instanceRef?: { current: unknown } }) => {
         const { features, instanceRef } = props;
+        capturedFeatures = features;
         if (instanceRef) {
             instanceRef.current = { objects: { balloon: { open: balloonOpen } } };
         }
@@ -81,6 +83,7 @@ describe("OffersMap", () => {
         onLoadCalls.mockClear();
         balloonOpen.mockClear();
         boundsChangeHandlers.length = 0;
+        capturedFeatures = [];
     });
 
     it("фокусирует карту, если у выбранной вакансии известны координаты", () => {
@@ -238,5 +241,36 @@ describe("OffersMap", () => {
         );
 
         await waitFor(() => expect(screen.getByTestId("object-manager")).toHaveTextContent("1"));
+    });
+
+    it("даёт маркеру круглую iconShape, совпадающую с кастомной иконкой, чтобы balloon указывал точно на неё", async () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+        expect(capturedFeatures[0].options.iconShape).toEqual({
+            type: "Circle",
+            coordinates: [15, 15],
+            radius: 15,
+        });
+    });
+
+    it("рисует balloon как карточку: фото сверху на всю ширину, ссылка на вакансию", async () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+        const { balloonContent } = capturedFeatures[0].properties;
+        expect(balloonContent).toContain("balloonImageLink");
+        expect(balloonContent).toContain("balloonImage");
+        expect(balloonContent).toContain("/ru/offers/1");
     });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -83,13 +83,16 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 const categoryName = offer.categories[0]?.name ?? noCategory;
                 const categoryColor = offer.categories[0]?.color ?? "var(--text-caption)";
 
+                const offerUrl = getOfferPersonalPageUrl(locale, offer.id.toString());
                 const balloonContent = `
           <div class="${styles.balloonWrapper}">
-            <a href="${getOfferPersonalPageUrl(locale, offer.id.toString())}"><img class="${styles.balloonImage}" src="${getMediaContent(imgSrc, "SMALL") ?? defaultImage}" /></a>
+            <a href="${offerUrl}" class="${styles.balloonImageLink}">
+              <img class="${styles.balloonImage}" src="${getMediaContent(imgSrc, "SMALL") ?? defaultImage}" />
+            </a>
             <div class="${styles.text}">
               <div class="${styles.balloonTitle}">${title}</div>
               <div class="${styles.balloonCategory}" style="color: ${categoryColor};">${categoryName}</div>
-              <a href="${getOfferPersonalPageUrl(locale, offer.id.toString())}" class="${styles.balloonLink}">${learnMore}</a>
+              <a href="${offerUrl}" class="${styles.balloonLink}">${learnMore}</a>
             </div>
           </div>
         `;
@@ -111,6 +114,17 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                         ),
                         iconImageSize: [30, 30],
                         iconImageOffset: [-15, -15],
+                        // Без iconShape Яндекс.Карты по умолчанию считают форму
+                        // маркера прямоугольным пином, а не нашим кастомным
+                        // кружком — из-за этого хвостик balloon указывал не в
+                        // центр маркера. Круг тех же размеров/центра, что и сама
+                        // иконка (без учёта iconImageOffset — как в
+                        // clusterIconShape ниже).
+                        iconShape: {
+                            type: "Circle",
+                            coordinates: [15, 15],
+                            radius: 15,
+                        },
                     },
                 };
             });

--- a/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
@@ -1,27 +1,27 @@
-// .ymaps-2-1-79-balloon {
-//     box-shadow: none !important;
-// }
+// Наша карточка (.balloonWrapper в OffersMap.module.scss) уже сама рисует
+// фон/скругление/тень — снимаем дефолтные отступы и рамку balloon у Яндекса,
+// иначе вокруг карточки остаётся некрасивый белый паддинг. border-radius +
+// overflow: hidden вешаем на __layout, а не на внешний .ymaps-2-1-79-balloon,
+// чтобы не обрезать хвостик-указатель (он рендерится соседним элементом).
+.ymaps-2-1-79-balloon {
+    box-shadow: none !important;
+}
 
-// .ymaps-2-1-79-balloon__content {
-//     padding: 0 !important;
-//     background: transparent !important;
-//     margin: 0 !important;
-// }
+.ymaps-2-1-79-balloon__content {
+    padding: 0 !important;
+    background: transparent !important;
+    margin: 0 !important;
+}
 
-// .ymaps-2-1-79-balloon__layout {
-//     background: transparent !important;
-//     border: none !important;
-//     width: auto !important;
-//     height: auto;
-// }
-
-// .offer-card {
-//     width: 200px;
-//     height: auto;
-// }
-// .ymaps-2-1-79-balloon__content > ymaps {
-//     height: auto;
-// }
+.ymaps-2-1-79-balloon__layout {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: 0 8px 24px rgba(33, 33, 33, 0.16) !important;
+    border-radius: 12px !important;
+    overflow: hidden;
+    width: auto !important;
+    height: auto;
+}
 
 .ymaps-2-1-79-map-copyrights-promo {
     display: none;


### PR DESCRIPTION
## Summary
- GS-88: the vacancy balloon (popup) on the `/offers` map had a cramped side-by-side layout with no real card styling, and its pointer didn't line up with the custom round marker.
- Rebuilt the balloon as a tidy card: full-width photo on top (rounded corners), title/category/link below.
- Added an explicit circular `iconShape` matching the marker's actual size/center, so the balloon now opens right out of the marker instead of pointing at the wrong spot.
- Removed Yandex's default balloon padding/shadow since our own card now draws its own background/radius/shadow.

## Test plan
- [x] New tests: `iconShape` matches the marker, balloon markup renders the new card structure
- [x] revert-and-confirm-fails on both
- [x] Full frontend suite green (311 tests)
- [x] Full visual/click-through verification blocked by the known staging IAP login wall — confirmed via code + tests only