### PR TITLE
fix(offers-map): ignore degenerate bounds so mobile markers stop disappearing

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -79,7 +79,8 @@ describe("OffersMap", () => {
     beforeEach(() => {
         setCenter.mockClear();
         getZoom.mockClear();
-        getBounds.mockClear();
+        getBounds.mockReset();
+        getBounds.mockReturnValue([[54, 36], [57, 39]]);
         onLoadCalls.mockClear();
         balloonOpen.mockClear();
         boundsChangeHandlers.length = 0;
@@ -173,6 +174,21 @@ describe("OffersMap", () => {
         await waitFor(() => expect(onBoundsChange).toHaveBeenCalledWith({
             boundsSwLat: 54, boundsSwLng: 36, boundsNeLat: 57, boundsNeLng: 39,
         }), { timeout: 1000 });
+    });
+
+    it("не сообщает вырожденный (нулевой площади) bounds (регресс: скрытая через display:none десктопная карта на мобильном шлёт SW===NE и стирает реальные маркеры пустым ответом)", async () => {
+        getBounds.mockReturnValue([[50, 50], [50, 50]]);
+        const onBoundsChange = vi.fn();
+        render(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+                onBoundsChange={onBoundsChange}
+            />,
+        );
+
+        await waitFor(() => expect(onLoadCalls).toHaveBeenCalledTimes(1));
+        expect(onBoundsChange).not.toHaveBeenCalled();
     });
 
     it("не пересоздаёт карту при переключении isOffersLoading (регресс: карта уходила в бесконечный цикл unmount/remount)", async () => {

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -189,6 +189,15 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
             const bounds = map.getBounds?.();
             if (!bounds) return;
             const [[swLat, swLng], [neLat, neLng]] = bounds;
+            // На мобильном эта же карта продолжает существовать в DOM, просто
+            // скрыта через display:none (десктопная раскладка в
+            // OffersSearchFilter.tsx) — Яндекс.Карты в нулевом контейнере
+            // отдают вырожденный bounds, где SW и NE совпадают. Реальный pan/
+            // zoom так не бывает; без этой проверки такой bounds улетает
+            // наверх, там уходит в vacancy/for-map/list и стирает реальный
+            // набор маркеров пустым ответом — в том числе у видимой мобильной
+            // карты, которая делит один и тот же allOffersMap со скрытой.
+            if (swLat === neLat && swLng === neLng) return;
             onBoundsChangeRef.current?.({
                 boundsSwLat: swLat, boundsSwLng: swLng, boundsNeLat: neLat, boundsNeLng: neLng,
             });


### PR DESCRIPTION
## Summary
- GS-89: found while live-checking GS-88 on a mobile viewport — the "Карта" tab on mobile showed a completely empty map.
- Root cause: the desktop `<OffersMap onBoundsChange=.../>` in `OffersSearchFilter.tsx` stays mounted on mobile, only hidden via `display: none`. Yandex Maps in a zero-size container reports a degenerate `getBounds()` (SW === NE), which flowed into `vacancy/for-map/list` as a zero-area bbox, got back `[]`, and overwrote `allOffersMap` — state shared with the visible mobile map tab.
- Fix: `OffersMap.tsx` now skips firing `onBoundsChange` when the computed bounds have zero area — real pan/zoom never produces identical SW/NE corners, so this only ever triggers for a collapsed/hidden map.

## Test plan
- [x] New regression test: degenerate bounds never reach `onBoundsChange`
- [x] revert-and-confirm-fails
- [x] Full frontend suite green (312 tests)
- [x] Live-verified locally (`npm start` + dev API proxy to staging, bypassing the IAP wall that blocks staging.goodsurfing.org directly) at a 390×844 mobile viewport: before the fix, the mobile map tab showed 0 markers; after, 77 markers/clusters render and clicking one opens the GS-88 card correctly