### PR TITLE
fix(offer): hide review form entirely when the visitor can't submit one

### DIFF
--- a/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.test.tsx
+++ b/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.test.tsx
@@ -1,0 +1,57 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { OfferReviewsCard } from "./OfferReviewsCard";
+
+/**
+ * GS-91: форма написания отзыва (рейтинг + текст + загрузка фото) раньше
+ * рендерилась всегда, просто в disabled-состоянии, когда canReview=false —
+ * выглядело как баг для незалогиненных/неоткликнувшихся посетителей.
+ * Теперь форма не рендерится вовсе, если canReview=false; список
+ * существующих отзывов при этом остаётся видимым.
+ */
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+const getReviewsData = vi.fn().mockReturnValue({
+    unwrap: () => Promise.resolve({ data: [], pagination: { total: 0, page: 1 } }),
+});
+const createOfferReview = vi.fn();
+// Стабильная ссылка важна: если этот объект пересоздавать на каждый вызов
+// мока, useEffect с [reviewsData] в зависимостях будет срабатывать на
+// каждый рендер и уходить в бесконечный цикл setState → ререндер.
+const reviewsQueryResult = { data: { data: [], pagination: { total: 0, page: 1 } } };
+
+vi.mock("@/entities/Review", () => ({
+    useLazyGetOfferReviewByVacancyIdQuery: () => [getReviewsData, reviewsQueryResult],
+    useCreateOfferReviewMutation: () => [createOfferReview],
+}));
+
+describe("OfferReviewsCard", () => {
+    beforeEach(() => {
+        getReviewsData.mockClear();
+    });
+
+    it("не показывает форму написания отзыва, если canReview=false", async () => {
+        render(<OfferReviewsCard offerId={1} canReview={false} />);
+
+        await waitFor(() => expect(getReviewsData).toHaveBeenCalled());
+        expect(screen.queryByPlaceholderText("personalOffer.Ваш отзыв")).not.toBeInTheDocument();
+        expect(screen.queryByText("personalOffer.Написать отзыв")).not.toBeInTheDocument();
+    });
+
+    it("показывает форму написания отзыва, если canReview=true", async () => {
+        render(<OfferReviewsCard offerId={1} canReview />);
+
+        await waitFor(() => expect(getReviewsData).toHaveBeenCalled());
+        expect(screen.getByPlaceholderText("personalOffer.Ваш отзыв")).toBeInTheDocument();
+        expect(screen.getByText("personalOffer.Написать отзыв")).toBeInTheDocument();
+    });
+});

--- a/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
+++ b/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
@@ -137,39 +137,45 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
         return (
             <div className={styles.wrapper} id="review">
                 <Text title={t("personalOffer.Отзывы")} titleSize="h3" />
-                <Rating
-                    disabled={!canReview || isSendReview}
-                    size="large"
-                    value={rating}
-                    onChange={(_, valueItem) => setRating(valueItem)}
-                    sx={{
-                        "& .MuiRating-iconFilled": {
-                            color: "#FED81C",
-                        },
-                    }}
-                />
-                <CommentInput
-                    onSend={handleSendReview}
-                    btnText={t("personalOffer.Написать отзыв")}
-                    disabled={!canReview || isSendReview}
-                    disabledBtn={!commentInput.trim() || rating === null}
-                    placeholder={t("personalOffer.Ваш отзыв")}
-                    className={styles.commentInput}
-                    value={commentInput}
-                    onChange={handleCommentInput}
-                />
-                {canReview && !isSendReview && (
-                    <ImagesUploader
-                        uploadedImgs={reviewImages}
-                        onUpload={async (uploaded) => {
-                            setReviewImages((prev) => [...prev, ...uploaded]);
-                        }}
-                        onDelete={(imgId) => {
-                            setReviewImages((prev) => prev.filter((img) => img.id !== imgId));
-                        }}
-                        onError={() => {}}
-                        maxLength={10}
-                    />
+                {canReview && (
+                    <>
+                        <Rating
+                            disabled={isSendReview}
+                            size="large"
+                            value={rating}
+                            onChange={(_, valueItem) => setRating(valueItem)}
+                            sx={{
+                                "& .MuiRating-iconFilled": {
+                                    color: "#FED81C",
+                                },
+                            }}
+                        />
+                        <CommentInput
+                            onSend={handleSendReview}
+                            btnText={t("personalOffer.Написать отзыв")}
+                            disabled={isSendReview}
+                            disabledBtn={!commentInput.trim() || rating === null}
+                            placeholder={t("personalOffer.Ваш отзыв")}
+                            className={styles.commentInput}
+                            value={commentInput}
+                            onChange={handleCommentInput}
+                        />
+                        {!isSendReview && (
+                            <ImagesUploader
+                                uploadedImgs={reviewImages}
+                                onUpload={async (uploaded) => {
+                                    setReviewImages((prev) => [...prev, ...uploaded]);
+                                }}
+                                onDelete={(imgId) => {
+                                    setReviewImages(
+                                        (prev) => prev.filter((img) => img.id !== imgId),
+                                    );
+                                }}
+                                onError={() => {}}
+                                maxLength={10}
+                            />
+                        )}
+                    </>
                 )}
                 <div className={styles.container}>
                     {renderContent()}


### PR DESCRIPTION
## Summary
- GS-91: the rating/comment/photo-upload form on a vacancy's review section rendered for every visitor, just disabled when `canReview` was false. Backend already blocked the actual submission, but a visibly-disabled form for anonymous or non-applied visitors read as a bug.
- Now the entire form (rating, comment input, image uploader) doesn't render at all unless `canReview` is true. The existing reviews list stays visible regardless.

## Test plan
- [x] New tests: form hidden when `canReview=false`, shown when `canReview=true`
- [x] revert-and-confirm-fails
- [x] Full frontend suite green (321 tests)