### PR TITLE
fix(offer): add key prop to OfferWhenCard periods list (GS-96)

### DIFF
--- a/src/entities/Offer/ui/OfferWhenCard/OfferWhenCard.test.tsx
+++ b/src/entities/Offer/ui/OfferWhenCard/OfferWhenCard.test.tsx
@@ -46,4 +46,33 @@ describe("OfferWhenCard", () => {
         expect(screen.getByText("30")).toBeInTheDocument();
         expect(screen.queryByText("personalOffer.notSpecified")).not.toBeInTheDocument();
     });
+
+    /**
+     * Регресс-guard: список periods рендерился без key (React варнинг
+     * "Each child in a list should have a unique key prop" на странице
+     * вакансии), что ломает корректную сверку списка react при изменении
+     * периодов.
+     */
+    it("не выдаёт React-предупреждение об отсутствии key при рендере нескольких периодов", () => {
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        renderWithProviders(
+            <OfferWhenCard
+                offerWhen={{
+                    ...baseOfferWhen,
+                    periods: [
+                        { start: "2026-06-01", end: "2026-06-10" },
+                        { start: "2026-07-01", end: "2026-07-10" },
+                    ],
+                }}
+            />,
+        );
+
+        const hasKeyWarning = consoleErrorSpy.mock.calls.some(
+            (call) => typeof call[0] === "string" && call[0].includes("unique \"key\" prop"),
+        );
+        expect(hasKeyWarning).toBe(false);
+
+        consoleErrorSpy.mockRestore();
+    });
 });

--- a/src/entities/Offer/ui/OfferWhenCard/OfferWhenCard.tsx
+++ b/src/entities/Offer/ui/OfferWhenCard/OfferWhenCard.tsx
@@ -36,11 +36,12 @@ export const OfferWhenCard = memo((props: OfferWhenProps) => {
     const isHavePeriods = periods.length > 0;
     const isRenderGridPeriods = periods.length > 3;
 
-    const renderItemPeriods = periods.map((period) => {
+    const renderItemPeriods = periods.map((period, index) => {
         const { start, end } = period;
 
         return (
-            <p>
+            // eslint-disable-next-line react/no-array-index-key
+            <p key={`${start ?? ""}-${end ?? ""}-${index}`}>
                 {`${start ?? ""} — ${end ?? ""}`}
             </p>
         );


### PR DESCRIPTION
## Summary
- Fixes a React "missing unique key" console warning on the vacancy detail page (`OfferWhenCard`) for offers with multiple availability periods.

## Test plan
- [x] New regression test asserting no console.error with the "unique key" text
- [x] revert-and-confirm-fails: reverted the fix, confirmed new test fails; restored, confirmed passes
- [x] `tsc --noEmit` and `eslint` clean on touched files

GS-96