### PR TITLE
fix(host): add key prop to HostReviewCard reviews list (GS-98)

### DIFF
--- a/src/entities/Host/ui/HostReviewCard/HostReviewCard.test.tsx
+++ b/src/entities/Host/ui/HostReviewCard/HostReviewCard.test.tsx
@@ -1,0 +1,61 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { HostReviewCard } from "./HostReviewCard";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+const reviewsData = {
+    data: [
+        {
+            id: "review-1", firstName: "Аня", lastName: null, image: null, description: "Отлично", rating: 5,
+        },
+        {
+            id: "review-2", firstName: "Боря", lastName: null, image: null, description: "Хорошо", rating: 4,
+        },
+    ],
+    pagination: { total: 2, page: 1 },
+};
+const getReviewsData = vi.fn().mockReturnValue({
+    unwrap: () => Promise.resolve(reviewsData),
+});
+
+vi.mock("@/entities/Review/api/reviewApi", async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    useLazyGetHostReviewByHostIdQuery: () => [getReviewsData, { data: reviewsData }],
+}));
+
+/**
+ * Регресс-guard: список отзывов на странице организации рендерился без
+ * key (React warning "Each child in a list should have a unique key
+ * prop") — та же категория бага, что и GS-96 у OfferWhenCard.
+ */
+describe("HostReviewCard", () => {
+    it("не выдаёт React-предупреждение об отсутствии key при рендере нескольких отзывов", async () => {
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        renderWithProviders(
+            <MemoryRouter>
+                <HostReviewCard hostId="host-1" />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(screen.getByText("Отлично")).toBeInTheDocument());
+
+        const hasKeyWarning = consoleErrorSpy.mock.calls.some(
+            (call) => typeof call[0] === "string" && call[0].includes("unique \"key\" prop"),
+        );
+        expect(hasKeyWarning).toBe(false);
+
+        consoleErrorSpy.mockRestore();
+    });
+});

--- a/src/entities/Host/ui/HostReviewCard/HostReviewCard.tsx
+++ b/src/entities/Host/ui/HostReviewCard/HostReviewCard.tsx
@@ -62,6 +62,7 @@ export const HostReviewCard: FC<HostReviewCardProps> = memo((props: HostReviewCa
 
     const renderReviews = reviews.map((review) => (
         <ReviewWidget
+            key={review.id}
             name={getFullName(review.firstName, review.lastName)}
             avatar={getMediaContent(review.image ?? undefined, "SMALL")}
             reviewText={review.description}


### PR DESCRIPTION
## Summary
- Fixes a React "missing unique key" console warning on the organization page's reviews block when it renders multiple reviews.
- Same bug class as GS-96 (`OfferWhenCard`).

## Test plan
- [x] New regression test asserting no console.error with the "unique key" text
- [x] revert-and-confirm-fails: reverted the fix, confirmed new test fails; restored, confirmed passes
- [x] Full frontend suite (328 tests) green, `tsc --noEmit` and `eslint` clean

GS-98