### PR TITLE
chore(lint): enable react/jsx-key, fix remaining violations (GS-99)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -58,6 +58,7 @@
         "jsx-a11y/no-static-element-interactions": "off",
         "jsx-a11y/label-has-associated-control": "warn",
         "react/no-array-index-key": "off",
+        "react/jsx-key": "error",
         "import/no-extraneous-dependencies": [
             "error",
             {

--- a/src/features/Admin/ui/AdminDonationReportForm/AdminDonationReportForm.tsx
+++ b/src/features/Admin/ui/AdminDonationReportForm/AdminDonationReportForm.tsx
@@ -124,8 +124,8 @@ export const AdminDonationReportForm: FC<AdminDonationReportFormProps> = (props)
                             {files.length === 0 && (
                                 <p className={styles.emptyList}>Файлы не добавлены</p>
                             )}
-                            {files.map((field, index) => (
-                                <div className={styles.fileItemWrapper}>
+                            {files.map((field) => (
+                                <div className={styles.fileItemWrapper} key={field.file.id}>
                                     {" "}
                                     {/* Общий контейнер */}
                                     <CustomLink
@@ -133,7 +133,6 @@ export const AdminDonationReportForm: FC<AdminDonationReportFormProps> = (props)
                                         // eslint-disable-next-line no-restricted-syntax
                                         to={getMediaContent(field.file.contentUrl) ?? ""}
                                         variant="DEFAULT"
-                                        key={index}
                                         className={styles.fileItem}
                                         target="_blank"
                                     >

--- a/src/features/ProfilePreferences/ui/InputSelectedCountries/ui/InputSelectedCountries/InputSelectedCountries.tsx
+++ b/src/features/ProfilePreferences/ui/InputSelectedCountries/ui/InputSelectedCountries/InputSelectedCountries.tsx
@@ -44,7 +44,12 @@ export const InputSelectedCountries: FC = memo(() => {
             <div className={styles.tagInput}>
                 <ul className={styles.tagList}>
                     {tags.map((tag, index) => (
-                        <TagComponent tag={tag} handleDelete={handleDelete} index={index} />
+                        <TagComponent
+                            key={tag}
+                            tag={tag}
+                            handleDelete={handleDelete}
+                            index={index}
+                        />
                     ))}
                 </ul>
                 <input

--- a/src/shared/ui/Accordion/Accordion.tsx
+++ b/src/shared/ui/Accordion/Accordion.tsx
@@ -33,7 +33,7 @@ export const Accordion: FC<AccordionProps> = memo((props: AccordionProps) => {
 
     const renderList = useMemo(
         () => data.map((item, key) => (
-            <li className={styles.item}>
+            <li className={styles.item} key={key}>
                 <button
                     className={styles.header}
                     type="button"


### PR DESCRIPTION
## Summary
- Found `react/jsx-key` explicitly disabled in `.eslintrc` despite being part of the `airbnb` config it extends — this meant missing-key bugs (GS-96, GS-98) only surfaced via manual browser console inspection, not CI.
- Enabled the rule and fixed the 3 other spots it found across the codebase (`AdminDonationReportForm`, `InputSelectedCountries`, `Accordion`) — none previously flagged, all unrelated to today's other fixes.

## Test plan
- [x] `eslint src/` — 0 errors (was 1 error after enabling, from a line-length side effect, now fixed)
- [x] Full test suite green (328/328)
- [x] `tsc --noEmit` clean

GS-99