### PR TITLE
GS-102: fix NewsPersonal sending slug instead of real id to comments/like

### DIFF
--- a/src/widgets/News/ui/NewsPersonal/NewsPersonal.test.tsx
+++ b/src/widgets/News/ui/NewsPersonal/NewsPersonal.test.tsx
@@ -1,0 +1,82 @@
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import { NewsPersonal } from "./NewsPersonal";
+
+vi.mock("react-i18next", async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    useTranslation: () => ({
+        t: (key: string, fallback?: string) => fallback ?? key,
+        ready: true,
+        i18n: { changeLanguage: () => {} },
+    }),
+}));
+
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ isAuth: false, myProfile: null }),
+}));
+
+vi.mock("@/shared/ui/SeoHelmet", () => ({ SeoHelmet: () => null }));
+
+const newsItem = {
+    id: "1f17b75b-472b-69f4-95bf-092463684f00",
+    slug: "kak-razmestit-materialy-v-bloge",
+    name: "Как разместить материалы в блоге.",
+    description: "<p>текст</p>",
+    created: "2026-07-09",
+    reviewCount: 0,
+    likeCount: 0,
+    image: null,
+    category: { id: 1, name: "Онлайн", color: "#fff" },
+};
+
+const getReviews = vi.fn().mockReturnValue({
+    unwrap: () => Promise.resolve({ data: [], pagination: { total: 0, page: 1 } }),
+});
+
+vi.mock("@/entities/News", async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    useGetNewsByIdQuery: () => ({ data: newsItem, isLoading: false }),
+    useLazyGetReviewsNewsQuery: () => [getReviews, { data: undefined }],
+}));
+
+/**
+ * Регресс-guard для row 117 (ЧПУ): переход по slug-ссылке на новость
+ * (не сырой id) отправлял slug вместо настоящего id в review-news/list,
+ * бэкенд падал 500. Blog/Journal уже чинили этот класс бага раньше,
+ * News — нет.
+ */
+describe("NewsPersonal", () => {
+    it("запрашивает комментарии по настоящему id новости, а не по slug из URL", async () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <NewsPersonal newsId="kak-razmestit-materialy-v-bloge" />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(getReviews).toHaveBeenCalled());
+
+        expect(getReviews).toHaveBeenCalledWith(expect.objectContaining({
+            newsId: newsItem.id,
+        }));
+        expect(getReviews).not.toHaveBeenCalledWith(expect.objectContaining({
+            newsId: "kak-razmestit-materialy-v-bloge",
+        }));
+    });
+
+    it("не показывает ошибку загрузки комментариев, когда id уже известен", async () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <NewsPersonal newsId="kak-razmestit-materialy-v-bloge" />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(getReviews).toHaveBeenCalled());
+        expect(
+            screen.queryByText("Произошла ошибка при подгрузке комментариев"),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/News/ui/NewsPersonal/NewsPersonal.tsx
+++ b/src/widgets/News/ui/NewsPersonal/NewsPersonal.tsx
@@ -46,10 +46,17 @@ export const NewsPersonal: FC<NewsPersonalProps> = (props) => {
     const [createNews] = useCreateReviewNewsMutation();
     const [getReviews, { data: reviewsData }] = useLazyGetReviewsNewsQuery();
 
+    // Реальный id, а не newsId (это может быть slug из URL) — лайки/
+    // комментарии на бэкенде завязаны на настоящий id (row 117).
+    const realNewsId = data?.id;
+
     const fetchReviews = useCallback(async (pageItem: number) => {
+        if (realNewsId === undefined) {
+            return;
+        }
         try {
             await getReviews({
-                newsId,
+                newsId: realNewsId,
                 limit: VISIBLE_COUNT,
                 page: pageItem,
             }).unwrap();
@@ -59,7 +66,7 @@ export const NewsPersonal: FC<NewsPersonalProps> = (props) => {
                 type: HintType.Error,
             });
         }
-    }, [getReviews, newsId]);
+    }, [getReviews, realNewsId]);
 
     useEffect(() => {
         fetchReviews(page);
@@ -84,9 +91,12 @@ export const NewsPersonal: FC<NewsPersonalProps> = (props) => {
             });
             return;
         }
+        if (realNewsId === undefined) {
+            return;
+        }
         try {
             setToast(undefined);
-            await putLike(newsId).unwrap();
+            await putLike(realNewsId).unwrap();
         } catch {
             setToast({
                 text: "Произошла ошибка",
@@ -103,8 +113,11 @@ export const NewsPersonal: FC<NewsPersonalProps> = (props) => {
             });
             return;
         }
+        if (realNewsId === undefined) {
+            return;
+        }
         try {
-            await createNews({ newsId, description }).unwrap();
+            await createNews({ newsId: realNewsId, description }).unwrap();
             await fetchReviews(1);
         } catch {
             setToast({


### PR DESCRIPTION
## Summary
- Found live on production (mobile screenshot from the user): opening a news article by its slug URL immediately shows "Произошла ошибка при подгрузке комментариев"
- Root cause: `review-news/list/{id}`, like, and create-comment all received the raw `newsId` prop — which is the URL slug when navigating via a human-readable link — instead of the article's real id, and the backend 500s trying to parse a slug as an id
- Same class of bug already fixed in `BlogPersonal.tsx`/`JournalPersonal.tsx` (row 117 slug migration), missed in `NewsPersonal.tsx` — now resolves `realNewsId = data?.id` the same way

## Test plan
- [x] `npx vitest run` — 334/334 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean
- [x] revert-and-confirm-fails: stashed the fix, confirmed the new regression test fails with the exact reported symptom, restored it, confirmed it passes

Linear: GS-102
