### PR TITLE
fix(GS-104): NotFoundPage in site style

### DIFF
--- a/src/pages/NotFoundPage/NotFoundPage.module.scss
+++ b/src/pages/NotFoundPage/NotFoundPage.module.scss
@@ -1,73 +1,41 @@
 .wrapper {
-    width: 100vw;
-    height: 100vh;
-    background: linear-gradient(45deg, #32a6ff 0%, #3f6fff 49%, #8d54ff 82%);
-    background-size: 200%;
-    animation: aurora 10s infinite;
-
-
     display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.container {
-    border-radius: 8px;
-    background: radial-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.7));
-    background-size: 200%;
-    animation: aurora 7s infinite;
-    padding: 100px 150px;
-    // background-color: white;
-    display: flex;
-    justify-self: center;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
 
-    h1 {
-        font-size: 84px;
-    }
-    
-    .smile {
-        font-size: 128px;
-    }   
-
-    .subtitle {
-        margin-top: 32px;
-        font-size: 32px;
-        color: white;
-    }
-
-    .return {
-        margin-top: 32px;
-    }
-
-    .link {
-        border: none;
-        border-radius: 30px;
-        background-color: var(--color-blue);
-        padding: 15px 30px;
-        color: white;
-        font-weight: bold;
-        text-decoration: none;
-        text-transform: uppercase;
-    }
-
+    min-height: 60vh;
+    padding: 80px 20px;
+    text-align: center;
 }
 
-@keyframes aurora {
-    0% {
-        background-position: left top;
+.icon {
+    svg {
+        width: 120px;
+        height: 120px;
     }
-    25% {
-        background-position: right top;
-    }
-    50% {
-        background-position: right bottom;
-    }
-    75% {
-        background-position: left bottom;
-    }
-    100% {
-        background-position: left top;
+
+    margin-bottom: 24px;
+}
+
+.title {
+    font: var(--font-h1);
+    color: var(--color-blue);
+}
+
+.subtitle {
+    margin-top: 16px;
+    font: var(--font-h3);
+    font-weight: 400;
+    color: var(--color-black-tertiary);
+}
+
+.link {
+    margin-top: 32px;
+}
+
+@media (max-width: 992px) {
+    .wrapper {
+        padding: 60px 20px;
     }
 }

--- a/src/pages/NotFoundPage/NotFoundPage.test.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "@/test-utils";
+import NotFoundPage from "./NotFoundPage";
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+// MainPageLayout — общий каркас (шапка/футер), тянет за собой Auth/i18n-
+// контекст, не предмет этого теста.
+vi.mock("@/widgets/MainPageLayout", () => ({
+    MainPageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe("NotFoundPage", () => {
+    it("показывает текст 404 и ссылку на главную с текущей локалью", () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <NotFoundPage />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText("404")).toBeInTheDocument();
+        expect(screen.getByText(/не существует/i)).toBeInTheDocument();
+
+        const link = screen.getByRole("link", { name: /на главную/i });
+        expect(link).toHaveAttribute("href", "/ru/");
+    });
+});

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,29 +1,36 @@
-import { Link } from "react-router-dom";
-
-import styles from "./NotFoundPage.module.scss";
-import { getMainPageUrl } from "@/shared/config/routes/AppUrls";
+import { ReactSVG } from "react-svg";
 
 import { useLocale } from "@/app/providers/LocaleProvider";
+import { getMainPageUrl } from "@/shared/config/routes/AppUrls";
+import documentSearchIcon from "@/shared/assets/icons/document-search.svg";
+import ButtonLink from "@/shared/ui/ButtonLink/ButtonLink";
+import { MainPageLayout } from "@/widgets/MainPageLayout";
+
+import styles from "./NotFoundPage.module.scss";
 
 const NotFoundPage = () => {
     const { locale } = useLocale();
     return (
-        <div className={styles.wrapper}>
-            <div className={styles.container}>
-                <h1>404</h1>
-                <p className={styles.smile}>🤕</p>
+        <MainPageLayout headerVariant="static">
+            <div className={styles.wrapper}>
+                <ReactSVG src={documentSearchIcon} className={styles.icon} />
+                <h1 className={styles.title}>404</h1>
                 <p className={styles.subtitle}>
-                    Извините, но страница на которую вы хотели перейти
+                    Извините, но страница, на которую вы хотели перейти,
                     {" "}
                     <br />
-                    {" "}
                     не существует.
                 </p>
-                <div className={styles.return}>
-                    <Link className={styles.link} to={getMainPageUrl(locale)}>Главная</Link>
-                </div>
+                <ButtonLink
+                    className={styles.link}
+                    type="primary"
+                    size="MEDIUM"
+                    path={getMainPageUrl(locale)}
+                >
+                    На главную
+                </ButtonLink>
             </div>
-        </div>
+        </MainPageLayout>
     );
 };
 


### PR DESCRIPTION
## Что не так

Старая страница 404 была отдельным fullscreen-компонентом: анимированный фиолетовый градиент, эмодзи 🤕, без хедера/футера сайта — выглядела как случайно вставленная заглушка, а не часть GoodSurfing.

## Что сделано

- Обёрнута в `MainPageLayout` — теперь есть тот же хедер/футер, что и на всех публичных страницах.
- Цвета/шрифт — из общих CSS-переменных (`--color-blue`, `--font-h1`, Lato), а не хардкод.
- Кнопка "На главную" — общий `ButtonLink` (тот же компонент, что используют другие CTA на сайте).
- Иконка — существующая `document-search.svg` из общего набора icons, вместо эмодзи.
- Тест на рендер текста 404 и корректный href на главную с текущей локалью.

Linear: GS-104

## Test plan
- [x] `vitest run src/pages/NotFoundPage/NotFoundPage.test.tsx` — зелёный
- [x] `tsc --noEmit` — 0 новых ошибок
- [x] `eslint src/pages/NotFoundPage/` — чисто
- [ ] Живая проверка на стейдже после деплоя
