### PR TITLE
fix(GS-105): guard synchronous throw from balloon.open on OffersMap

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -259,6 +259,36 @@ describe("OffersMap", () => {
         await waitFor(() => expect(screen.getByTestId("object-manager")).toHaveTextContent("1"));
     });
 
+    it("не падает, если balloon.open синхронно бросает (регресс: карта разваливалась при быстром переключении между вакансиями в списке)", async () => {
+        // Реальный Яндекс.Карты SDK бросает TypeError синхронно (не reject),
+        // когда объект ещё не попал в ObjectManager — маркеры viewport-scoped
+        // и приходят отдельным bounds-запросом с дебаунсом ПОСЛЕ actionend,
+        // так что быстрый клик по следующей вакансии в списке легко успевает
+        // раньше. .catch() на промисе тут не спасает.
+        balloonOpen.mockImplementationOnce(() => {
+            throw new TypeError("Cannot read properties of null (reading 'geometry')");
+        });
+
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+                selectedOfferId={1}
+                selectedOfferCoordinates={{ latitude: 55.75, longitude: 37.61 }}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+        expect(() => {
+            act(() => {
+                boundsChangeHandlers.forEach((handler) => handler());
+            });
+        }).not.toThrow();
+
+        expect(balloonOpen).toHaveBeenCalledWith("1");
+    });
+
     it("даёт маркеру круглую iconShape, совпадающую с кастомной иконкой, чтобы balloon указывал точно на неё", async () => {
         render(
             <OffersMap

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -167,7 +167,21 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
 
         const openBalloon = () => {
             map.events.remove("actionend", openBalloon);
-            objectManager.objects.balloon.open(selectedOfferId.toString()).catch(() => {});
+            // Даже после actionend объект может ещё не попасть в ObjectManager:
+            // маркеры viewport-scoped (см. features выше) и приходят отдельным
+            // bounds-запросом с 400мс дебаунсом ПОСЛЕ actionend, так что при
+            // быстром переключении между вакансиями в списке (клик #1, клик #2
+            // до того как домаунтился набор маркеров под клик #1) balloon.open
+            // синхронно бросает TypeError ("Cannot read properties of null
+            // (reading 'geometry')") внутри самого Яндекс.Карт SDK — .catch()
+            // тут не помогает, потому что это не отклонённый Promise, а
+            // синхронный throw. Без try/catch это разносило карту целиком.
+            try {
+                objectManager.objects.balloon.open(selectedOfferId.toString())?.catch(() => {});
+            } catch {
+                // объекта ещё нет на карте — тихо пропускаем, пользователь всё
+                // равно уже увидел итог pan'а к нужным координатам
+            }
         };
         map.events.add("actionend", openBalloon);
         return () => {


### PR DESCRIPTION
## Что не так

На `/offers-map` карта визуально разваливалась (пользователь: "моргает при перемещении по списку"), воспроизведено живьём на стейдже: быстрый клик по нескольким карточкам вакансий в списке подряд.

## Причина

Маркеры viewport-scoped, приходят отдельным bounds-запросом с 400мс дебаунсом уже **после** `actionend`. Если кликнуть по следующей вакансии раньше, чем маркер под предыдущий клик успел попасть в `ObjectManager`, вызов

```js
objectManager.objects.balloon.open(selectedOfferId.toString()).catch(() => {});
```

падает **синхронным** `TypeError: Cannot read properties of null (reading 'geometry')` внутри самого Яндекс.Карты SDK — `.catch()` тут не помогает, это не reject промиса. Подтверждено консолью на стейдже, коррелирует с полным сносом и пересозданием `<ymaps>`-контейнера.

## Фикс

Оборачиваю вызов в `try/catch`. Регресс-тест мокает синхронный throw из `balloon.open` и проверяет, что рендер не падает — без фикса тест воспроизводимо красный с той же ошибкой (revert-and-confirm-fails).

Linear: GS-105

## Test plan
- [x] `vitest run OffersMap.test.tsx` — зелёный (11/11), новый тест ловит регресс без фикса
- [x] `tsc --noEmit` — 0 новых ошибок
- [x] `eslint` — чисто
- [ ] Живая проверка на стейдже после деплоя (быстрый клик по 3+ карточкам подряд)
