### PR TITLE
fix(GS-105): retry opening the offer balloon instead of giving up once

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -289,6 +289,92 @@ describe("OffersMap", () => {
         expect(balloonOpen).toHaveBeenCalledWith("1");
     });
 
+    it("повторяет попытку открыть balloon, пока маркер не появится в ObjectManager (регресс: табличка молча не появлялась, был виден только маркер)", async () => {
+        // Первые несколько попыток проваливаются (маркер под только что
+        // выбранную вакансию ещё не подъехал с bounds-запросом), но объект
+        // рано или поздно появляется — balloon должен открыться, а не
+        // молча остаться закрытым после первой неудачи.
+        let attempt = 0;
+        balloonOpen.mockImplementation(() => {
+            attempt += 1;
+            if (attempt < 3) {
+                throw new TypeError("Cannot read properties of null (reading 'geometry')");
+            }
+            return Promise.resolve();
+        });
+
+        vi.useFakeTimers();
+        try {
+            render(
+                <OffersMap
+                    offersData={[offer({ id: 1 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={1}
+                    selectedOfferCoordinates={{ latitude: 55.75, longitude: 37.61 }}
+                />,
+            );
+
+            await vi.waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+            act(() => {
+                boundsChangeHandlers.forEach((handler) => handler());
+            });
+
+            expect(attempt).toBe(1);
+
+            act(() => {
+                vi.advanceTimersByTime(200);
+            });
+            expect(attempt).toBe(2);
+
+            act(() => {
+                vi.advanceTimersByTime(200);
+            });
+            expect(attempt).toBe(3);
+            expect(balloonOpen).toHaveLastReturnedWith(Promise.resolve());
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("прекращает попытки открыть balloon после разумного числа неудач, а не бесконечно (объекта у вакансии в принципе никогда не будет)", async () => {
+        balloonOpen.mockImplementation(() => {
+            throw new TypeError("Cannot read properties of null (reading 'geometry')");
+        });
+
+        vi.useFakeTimers();
+        try {
+            render(
+                <OffersMap
+                    offersData={[offer({ id: 1 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={1}
+                    selectedOfferCoordinates={{ latitude: 55.75, longitude: 37.61 }}
+                />,
+            );
+
+            await vi.waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+            act(() => {
+                boundsChangeHandlers.forEach((handler) => handler());
+            });
+
+            act(() => {
+                vi.advanceTimersByTime(30_000);
+            });
+
+            const callsAfterLongWait = balloonOpen.mock.calls.length;
+
+            act(() => {
+                vi.advanceTimersByTime(30_000);
+            });
+
+            expect(balloonOpen.mock.calls.length).toBe(callsAfterLongWait);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("даёт маркеру круглую iconShape, совпадающую с кастомной иконкой, чтобы balloon указывал точно на неё", async () => {
         render(
             <OffersMap

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -165,26 +165,43 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         const objectManager = objectManagerRef.current;
         if (!objectManager) return undefined;
 
-        const openBalloon = () => {
-            map.events.remove("actionend", openBalloon);
+        let retryTimeoutId: ReturnType<typeof setTimeout> | undefined;
+        let cancelled = false;
+
+        const tryOpenBalloon = (attemptsLeft: number) => {
+            if (cancelled) return;
             // Даже после actionend объект может ещё не попасть в ObjectManager:
             // маркеры viewport-scoped (см. features выше) и приходят отдельным
-            // bounds-запросом с 400мс дебаунсом ПОСЛЕ actionend, так что при
-            // быстром переключении между вакансиями в списке (клик #1, клик #2
-            // до того как домаунтился набор маркеров под клик #1) balloon.open
-            // синхронно бросает TypeError ("Cannot read properties of null
-            // (reading 'geometry')") внутри самого Яндекс.Карт SDK — .catch()
-            // тут не помогает, потому что это не отклонённый Promise, а
-            // синхронный throw. Без try/catch это разносило карту целиком.
+            // bounds-запросом с 400мс дебаунсом ПОСЛЕ actionend, так что клик по
+            // вакансии в списке почти всегда обгоняет собственный набор
+            // маркеров под новые bounds. balloon.open в этом случае синхронно
+            // бросает TypeError ("Cannot read properties of null (reading
+            // 'geometry')") внутри самого Яндекс.Карт SDK — .catch() тут не
+            // помогает (это не отклонённый Promise, а синхронный throw), и без
+            // try/catch раньше разносило карту целиком. Вместо того чтобы
+            // просто проглатывать ошибку (тогда табличка молча не появляется),
+            // повторяем попытку, пока маркеры не подъедут — данные точно
+            // придут, т.к. mapBoundsRef уже включает координаты вакансии
+            // (карта туда запанилась) и есть их явный запрос по id (см.
+            // fetchPageOffersLocation в OffersSearchFilter).
             try {
                 objectManager.objects.balloon.open(selectedOfferId.toString())?.catch(() => {});
+                return;
             } catch {
-                // объекта ещё нет на карте — тихо пропускаем, пользователь всё
-                // равно уже увидел итог pan'а к нужным координатам
+                // объекта пока нет на карте — попробуем ещё раз чуть позже
             }
+            if (attemptsLeft <= 0) return;
+            retryTimeoutId = setTimeout(() => tryOpenBalloon(attemptsLeft - 1), 200);
+        };
+
+        const openBalloon = () => {
+            map.events.remove("actionend", openBalloon);
+            tryOpenBalloon(10);
         };
         map.events.add("actionend", openBalloon);
         return () => {
+            cancelled = true;
+            if (retryTimeoutId) clearTimeout(retryTimeoutId);
             map.events.remove("actionend", openBalloon);
         };
         // ymapState в зависимостях намеренно: ObjectManager монтируется


### PR DESCRIPTION
## Что не так

После прошлого фикса (try/catch вокруг `balloon.open`) карта перестала разваливаться, но и табличка (balloon) с превью вакансии перестала появляться вообще — виден только маркер/точка. Подтверждено живьём на стейдже скриншотом: клик по карточке в списке, карта панится к точке, но balloon не открывается.

## Причина

Та же гонка: маркер под только что выбранную вакансию попадает в `ObjectManager` НЕМНОГО позже, чем срабатывает `actionend` (маркеры viewport-scoped, приходят отдельным дебаунснутым bounds-запросом). Единственная попытка открыть balloon сразу после `actionend` почти всегда промахивается мимо ещё не подъехавшего маркера — а раньше мы просто тихо глотали ошибку и не пробовали снова.

## Фикс

Retry с интервалом 200мс, до 10 попыток (∼2 сек) — этого достаточно с запасом на дебаунс bounds-запроса + round-trip. Если маркера так и не будет (по какой-то причине), попытки останавливаются, не крутятся бесконечно.

Regression-тесты (revert-and-confirm-fails):
- "повторяет попытку..." — без retry-логики падает на первой же проверке (`attempt` остаётся 1 вместо 2)
- "прекращает попытки после разумного числа неудач" — гарантирует отсутствие бесконечного retry-цикла

Linear: GS-105

## Test plan
- [x] `vitest run OffersMap.test.tsx` — 13/13 зелёных
- [x] `tsc --noEmit` — 0 новых ошибок
- [x] `eslint` — чисто
- [ ] Живая проверка на стейдже после деплоя (клик по карточке → появляется и точка, и табличка)
