### PR TITLE
fix(GS-108): offers-map marker click doesn't open balloon + blurry photo

### DIFF
--- a/src/entities/Offer/model/types/offer.ts
+++ b/src/entities/Offer/model/types/offer.ts
@@ -199,10 +199,7 @@ export interface OfferMap {
     latitude: number;
     longitude: number;
     name: string;
-    image: {
-        id: string;
-        contentUrl: string;
-    }
+    image: Image;
     categories: {
         name: string;
         color: string;

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -323,12 +323,12 @@ describe("OffersMap", () => {
             expect(attempt).toBe(1);
 
             act(() => {
-                vi.advanceTimersByTime(200);
+                vi.advanceTimersByTime(300);
             });
             expect(attempt).toBe(2);
 
             act(() => {
-                vi.advanceTimersByTime(200);
+                vi.advanceTimersByTime(300);
             });
             expect(attempt).toBe(3);
             expect(balloonOpen).toHaveLastReturnedWith(Promise.resolve());
@@ -404,5 +404,44 @@ describe("OffersMap", () => {
         expect(balloonContent).toContain("balloonImageLink");
         expect(balloonContent).toContain("balloonImage");
         expect(balloonContent).toContain("/ru/offers/1");
+    });
+
+    it("использует MEDIUM-превью в balloon, а не крошечный SMALL (56x56, размывается при показе крупнее)", async () => {
+        render(
+            <OffersMap
+                offersData={[offer({
+                    id: 1,
+                    image: {
+                        id: "1",
+                        contentUrl: "https://example.com/original.jpg",
+                        thumbnails: {
+                            small: "https://example.com/small.webp",
+                            medium: "https://example.com/medium.webp",
+                            large: "https://example.com/large.webp",
+                        },
+                    },
+                })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+        const { balloonContent } = capturedFeatures[0].properties;
+        expect(balloonContent).toContain("https://example.com/medium.webp");
+        expect(balloonContent).not.toContain("https://example.com/small.webp");
+    });
+
+    it("держит iconContentSize/Offset в том же фрейме, что и iconImageSize/Offset, иначе видимый маркер и его кликабельная область (iconShape) расходятся", async () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+        const { options } = capturedFeatures[0];
+        expect(options.iconContentSize).toEqual(options.iconImageSize);
+        expect(options.iconContentOffset).toEqual(options.iconImageOffset);
     });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -87,7 +87,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 const balloonContent = `
           <div class="${styles.balloonWrapper}">
             <a href="${offerUrl}" class="${styles.balloonImageLink}">
-              <img class="${styles.balloonImage}" src="${getMediaContent(imgSrc, "SMALL") ?? defaultImage}" />
+              <img class="${styles.balloonImage}" src="${getMediaContent(imgSrc, "MEDIUM") ?? defaultImage}" />
             </a>
             <div class="${styles.text}">
               <div class="${styles.balloonTitle}">${title}</div>
@@ -112,14 +112,28 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                         iconContentLayout: ymapState?.templateLayoutFactory.createClass(
                             `<div style="background-color: ${categoryColor || "var(--accent-color)"};" class="${styles.customPlacemarkIcon}"></div>`,
                         ),
+                        // iconContentSize/Offset must mirror iconImageSize/Offset:
+                        // без iconContentSize Яндекс.Карты по умолчанию заводят под
+                        // content крошечный 10x10 контейнер (наш div визуально
+                        // растягивался до 30x30 через CSS, перекрывая границы), а
+                        // без iconContentOffset контент кладётся в его собственный
+                        // угол, а не туда же, где числится iconImageOffset. Из-за
+                        // этого видимый кружок и реальная кликабельная область
+                        // (iconShape, привязанный к фрейму iconImageOffset)
+                        // расходились на добрый десяток пикселей — клик по
+                        // видимому маркеру мимо своей же hit-зоны молча ничего не
+                        // делал.
+                        iconContentSize: [30, 30],
+                        iconContentOffset: [-15, -15],
                         iconImageSize: [30, 30],
                         iconImageOffset: [-15, -15],
                         // Без iconShape Яндекс.Карты по умолчанию считают форму
                         // маркера прямоугольным пином, а не нашим кастомным
                         // кружком — из-за этого хвостик balloon указывал не в
                         // центр маркера. Круг тех же размеров/центра, что и сама
-                        // иконка (без учёта iconImageOffset — как в
-                        // clusterIconShape ниже).
+                        // иконка, в том же фрейме, что и iconContentOffset/
+                        // iconImageOffset выше (см. clusterIconShape ниже — там
+                        // тот же принцип, но со своим независимым слоем).
                         iconShape: {
                             type: "Circle",
                             coordinates: [15, 15],
@@ -191,12 +205,16 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 // объекта пока нет на карте — попробуем ещё раз чуть позже
             }
             if (attemptsLeft <= 0) return;
-            retryTimeoutId = setTimeout(() => tryOpenBalloon(attemptsLeft - 1), 200);
+            retryTimeoutId = setTimeout(() => tryOpenBalloon(attemptsLeft - 1), 300);
         };
 
         const openBalloon = () => {
             map.events.remove("actionend", openBalloon);
-            tryOpenBalloon(10);
+            // 30 попыток по 300мс — с запасом перекрывает 400мс bounds-дебаунс
+            // + реальный сетевой round-trip до vacancy/for-map/list, который
+            // раньше (10 попыток по 200мс = 2с) иногда не укладывался, и
+            // табличка молча не появлялась.
+            tryOpenBalloon(30);
         };
         map.events.add("actionend", openBalloon);
         return () => {


### PR DESCRIPTION
## Summary
- Marker click/hover didn't register at all — `iconContentSize`/`iconContentOffset` were never set, so Yandex Maps defaulted the content hit-region to 10x10 while our CSS rendered the visible marker at 30x30, offsetting the actual clickable area from the visible one (confirmed live via DOM inspection + hover probing, not guessed)
- List-card click → focus-then-balloon flow could silently fail to show the balloon: retry budget (10×200ms=2s) sometimes ran out before the bounds-debounced marker refetch (400ms debounce + real network round-trip) completed — bumped to 30×300ms
- Balloon photo was blurry: SMALL thumbnail (56x56) stretched ~4x via CSS to ~200x120 — switched to MEDIUM (307x222)
- Fixed `OfferMap.image` TS type to include `thumbnails` (it silently didn't, relying on structural typing to compile)

Closes GS-108.

## Test plan
- [x] `OffersMap.test.tsx`: 2 new tests (iconContentSize/Offset match iconImageSize/Offset; balloon uses MEDIUM not SMALL) + existing retry-interval test updated for 300ms
- [x] revert-and-confirm-fails: both new tests fail without the fix
- [x] Full suite green (343 tests), typecheck clean
- [ ] Live-verify on staging: click a marker directly (opens balloon), click a list card (pans + balloon appears), balloon photo is sharp
