### PR TITLE
fix(GS-108): drop iconContentOffset — it doubled the anchor shift

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -431,7 +431,7 @@ describe("OffersMap", () => {
         expect(balloonContent).not.toContain("https://example.com/small.webp");
     });
 
-    it("держит iconContentSize/Offset в том же фрейме, что и iconImageSize/Offset, иначе видимый маркер и его кликабельная область (iconShape) расходятся", async () => {
+    it("задаёт iconContentSize вровень с iconImageSize (иначе Яндекс.Карты по умолчанию заводят под content крошечный 10x10 хитбокс вместо видимых 30x30, и клик по маркеру мимо своей же кликабельной области ничего не делает)", async () => {
         render(
             <OffersMap
                 offersData={[offer({ id: 1 })]}
@@ -442,6 +442,9 @@ describe("OffersMap", () => {
         await waitFor(() => expect(capturedFeatures).toHaveLength(1));
         const { options } = capturedFeatures[0];
         expect(options.iconContentSize).toEqual(options.iconImageSize);
-        expect(options.iconContentOffset).toEqual(options.iconImageOffset);
+        // iconContentOffset намеренно не задаём: content уже сидит внутри
+        // контейнера image (который сам сдвинут на iconImageOffset) — если
+        // продублировать тот же сдвиг ещё и для content, он применится дважды.
+        expect(options.iconContentOffset).toBeUndefined();
     });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -112,19 +112,18 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                         iconContentLayout: ymapState?.templateLayoutFactory.createClass(
                             `<div style="background-color: ${categoryColor || "var(--accent-color)"};" class="${styles.customPlacemarkIcon}"></div>`,
                         ),
-                        // iconContentSize/Offset must mirror iconImageSize/Offset:
-                        // без iconContentSize Яндекс.Карты по умолчанию заводят под
+                        // Без iconContentSize Яндекс.Карты по умолчанию заводят под
                         // content крошечный 10x10 контейнер (наш div визуально
-                        // растягивался до 30x30 через CSS, перекрывая границы), а
-                        // без iconContentOffset контент кладётся в его собственный
-                        // угол, а не туда же, где числится iconImageOffset. Из-за
-                        // этого видимый кружок и реальная кликабельная область
-                        // (iconShape, привязанный к фрейму iconImageOffset)
-                        // расходились на добрый десяток пикселей — клик по
-                        // видимому маркеру мимо своей же hit-зоны молча ничего не
-                        // делал.
+                        // растягивался до 30x30 через CSS, перекрывая границы) —
+                        // из-за этого видимый кружок и реальная кликабельная
+                        // область (iconShape) расходились на добрый десяток
+                        // пикселей, клик по видимому маркеру мимо своей же
+                        // hit-зоны молча ничего не делал. iconContentOffset НЕ
+                        // трогаем (оставляем дефолт [0,0]): контейнер content уже
+                        // сам сидит внутри контейнера image, который и так
+                        // сдвинут на iconImageOffset — если продублировать тот же
+                        // сдвиг ещё и для content, смещение применится дважды.
                         iconContentSize: [30, 30],
-                        iconContentOffset: [-15, -15],
                         iconImageSize: [30, 30],
                         iconImageOffset: [-15, -15],
                         // Без iconShape Яндекс.Карты по умолчанию считают форму


### PR DESCRIPTION
## Summary
Follow-up to #496 (GS-108). Live-verified on staging after that PR deployed: `iconContentSize: [30,30]` alone did fix the hit-container size bug (confirmed via DOM: `image-with-content-content` went from 10x10 to 30x30), but the extra `iconContentOffset: [-15,-15]` I also added applied on top of the already-offset `image-with-content` parent, double-shifting content 15px further than the anchor/hit-shape. Removing it (leaving only `iconContentSize`) aligns content with the parent container it lives in.

## Test plan
- [x] Updated the relevant test to assert `iconContentOffset` stays unset
- [ ] Live-verify on staging: marker click/hover now lands exactly on the visible marker
