### PR TITLE
fix(GS-108): open balloon reactively when markers update, not only by timer

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -337,6 +337,57 @@ describe("OffersMap", () => {
         }
     });
 
+    it("открывает balloon реактивно при обновлении маркеров, не дожидаясь следующего тика таймера-ретрая (регресс: на медленной сети/бэкенде реальный round-trip мог не уложиться в весь таймерный бюджет)", async () => {
+        // Маркера нет в ObjectManager после actionend — таймер уходит в
+        // ожидание следующей попытки (300мс, ещё не наступило). Затем маркер
+        // "приезжает" (features обновляются новым набором offersData), и
+        // getById внезапно начинает подтверждать существование объекта —
+        // balloon должен открыться СРАЗУ по этому событию, а не по таймеру.
+        getById.mockImplementation(() => undefined);
+        // Одна и та же ссылка на объект координат для обоих рендеров: если
+        // передавать новый литерал при каждом рендере, pan-эффект (у него в
+        // зависимостях selectedOfferCoordinates) перезапускался бы сам по
+        // себе и сбрасывал бы флаг "pan завершился" — тест проверял бы не то.
+        const coordinates = { latitude: 55.75, longitude: 37.61 };
+
+        vi.useFakeTimers();
+        try {
+            const { rerender } = render(
+                <OffersMap
+                    offersData={[offer({ id: 1 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={1}
+                    selectedOfferCoordinates={coordinates}
+                />,
+            );
+
+            await vi.waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+            act(() => {
+                boundsChangeHandlers.forEach((handler) => handler());
+            });
+            expect(balloonOpen).not.toHaveBeenCalled();
+
+            getById.mockImplementation(() => ({}));
+            act(() => {
+                rerender(
+                    <OffersMap
+                        offersData={[offer({ id: 1, name: "Обновлённое название" })]}
+                        isOffersLoading={false}
+                        selectedOfferId={1}
+                        selectedOfferCoordinates={coordinates}
+                    />,
+                );
+            });
+
+            // Ни один таймер не продвигался — если balloon всё равно открылся,
+            // значит сработал реактивный эффект на features, а не таймер.
+            expect(balloonOpen).toHaveBeenCalledWith("1");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("прекращает попытки открыть balloon после разумного числа неудач, а не бесконечно (объекта у вакансии в принципе никогда не будет)", async () => {
         getById.mockImplementation(() => undefined);
 

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -154,10 +154,52 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         noTitle, noCategory, offerWithoutName, learnMore,
     ]);
 
+    // Оффер, для которого нужно открыть balloon, как только его маркер
+    // реально появится в ObjectManager. null — нечего открывать / уже открыли.
+    const pendingBalloonOfferIdRef = useRef<number | null>(null);
+    // true — pan уже завершился (actionend), можно пробовать открыть balloon
+    // реактивно при каждом обновлении маркеров. Без этого флага реактивный
+    // эффект ниже (на features) стрелял бы balloon.open ещё ДО того, как
+    // карта закончит панорамирование — балун появлялся бы мгновенно вместо
+    // "сначала фокус, потом табличка".
+    const panActionEndedRef = useRef(false);
+
+    // Пытается открыть balloon прямо сейчас. Возвращает true, если маркер уже
+    // зарегистрирован в ObjectManager (успех или редкая гонка на open()) —
+    // тогда дальше можно не пытаться. false — маркера пока нет, надо ждать.
+    const attemptOpenBalloon = (offerId: number): boolean => {
+        const objectManager = objectManagerRef.current;
+        if (!objectManager) return false;
+        // Даже после actionend объект может ещё не попасть в ObjectManager:
+        // маркеры viewport-scoped (см. features выше) и приходят отдельным
+        // bounds-запросом с 400мс дебаунсом ПОСЛЕ actionend, так что клик по
+        // вакансии в списке почти всегда обгоняет собственный набор маркеров
+        // под новые bounds. Проверяем через getById, что объект уже
+        // зарегистрирован, ПЕРЕД тем как звать balloon.open — раньше звали
+        // open() вслепую и полагались на то, что она либо синхронно бросит
+        // TypeError ("Cannot read properties of null (reading 'geometry')")
+        // для отсутствующего объекта, либо успешно откроет balloon. На деле
+        // для отсутствующего объекта open() иногда просто молча возвращает
+        // falsy без throw — тогда старый код принимал это за успех и больше
+        // не повторял попытку, табличка так и не появлялась. getById даёт
+        // однозначный ответ вместо гадания по побочному эффекту open().
+        if (!objectManager.objects.getById(offerId.toString())) return false;
+        try {
+            objectManager.objects.balloon.open(offerId.toString())?.catch(() => {});
+        } catch {
+            // объект пропал между проверкой и открытием (редкая гонка) — не
+            // страшно, дальше повторять уже нечего
+        }
+        pendingBalloonOfferIdRef.current = null;
+        return true;
+    };
+
     useEffect(() => {
         if (!selectedOfferId || selectedOfferCoordinates === undefined) {
             setShowNoLocationNotice(false);
-            return;
+            pendingBalloonOfferIdRef.current = null;
+            panActionEndedRef.current = false;
+            return undefined;
         }
 
         // Часть вакансий физически не имеет координат в базе (адрес не
@@ -165,7 +207,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         // клик по такой карточке в списке просто ничего не делал молча,
         // что выглядело как баг; показываем явную причину вместо тишины.
         setShowNoLocationNotice(selectedOfferCoordinates === null);
-        if (!selectedOfferCoordinates || !mapRef.current) return;
+        if (!selectedOfferCoordinates || !mapRef.current) return undefined;
 
         const currentZoom = mapRef.current.getZoom();
         mapRef.current.setCenter(
@@ -180,47 +222,28 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         // завершится (actionend) — иначе ObjectManager может не найти
         // объект, если он ещё не попал в текущий кластер на новом месте.
         const map = mapRef.current;
-        const objectManager = objectManagerRef.current;
-        if (!objectManager) return undefined;
+        pendingBalloonOfferIdRef.current = selectedOfferId;
+        panActionEndedRef.current = false;
 
         let retryTimeoutId: ReturnType<typeof setTimeout> | undefined;
         let cancelled = false;
 
         const tryOpenBalloon = (attemptsLeft: number) => {
             if (cancelled) return;
-            // Даже после actionend объект может ещё не попасть в ObjectManager:
-            // маркеры viewport-scoped (см. features выше) и приходят отдельным
-            // bounds-запросом с 400мс дебаунсом ПОСЛЕ actionend, так что клик по
-            // вакансии в списке почти всегда обгоняет собственный набор
-            // маркеров под новые bounds. Проверяем через getById, что объект уже
-            // зарегистрирован, ПЕРЕД тем как звать balloon.open — раньше звали
-            // open() вслепую и полагались на то, что она либо синхронно бросит
-            // TypeError ("Cannot read properties of null (reading 'geometry')")
-            // для отсутствующего объекта, либо успешно откроет balloon. На деле
-            // для отсутствующего объекта open() иногда просто молча возвращает
-            // falsy без throw — тогда старый код принимал это за успех и больше
-            // не повторял попытку, табличка так и не появлялась. getById даёт
-            // однозначный ответ вместо гадания по побочному эффекту open().
-            if (!objectManager.objects.getById(selectedOfferId.toString())) {
-                if (attemptsLeft <= 0) return;
-                retryTimeoutId = setTimeout(() => tryOpenBalloon(attemptsLeft - 1), 300);
-                return;
-            }
-            try {
-                objectManager.objects.balloon.open(selectedOfferId.toString())?.catch(() => {});
-            } catch {
-                // объект пропал между проверкой и открытием (редкая гонка) — не
-                // страшно, дальше повторять уже нечего, пользователь либо увидит
-                // balloon с повторного клика, либо нет
-            }
+            if (attemptOpenBalloon(selectedOfferId)) return;
+            if (attemptsLeft <= 0) return;
+            retryTimeoutId = setTimeout(() => tryOpenBalloon(attemptsLeft - 1), 300);
         };
 
         const openBalloon = () => {
             map.events.remove("actionend", openBalloon);
-            // 30 попыток по 300мс — с запасом перекрывает 400мс bounds-дебаунс
-            // + реальный сетевой round-trip до vacancy/for-map/list, который
-            // раньше (10 попыток по 200мс = 2с) иногда не укладывался, и
-            // табличка молча не появлялась.
+            panActionEndedRef.current = true;
+            // Таймер-ретраи — подстраховка на случай если реактивный триггер
+            // ниже (эффект на features) почему-то не сработает. Основной путь
+            // быстрее: как только придут новые маркеры под bounds, тот эффект
+            // сразу попробует открыть balloon, не дожидаясь следующего тика
+            // таймера. 30 попыток по 300мс (9с) — щедрый запас поверх 400мс
+            // bounds-дебаунса на случай медленной сети.
             tryOpenBalloon(30);
         };
         map.events.add("actionend", openBalloon);
@@ -234,6 +257,22 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         // может случиться позже, чем этот эффект уже отработал на первом
         // рендере с уже выбранной вакансией (например, ?offerId= в URL).
     }, [selectedOfferId, selectedOfferCoordinates, ymapState]);
+
+    // Реактивный триггер: как только приходят новые (bounds-scoped) маркеры,
+    // сразу пробуем открыть balloon для отложенной вакансии — не дожидаясь
+    // следующего тика таймера выше. Раньше единственным путём был опрос по
+    // таймеру (300мс), и на медленной сети/бэкенде реальный round-trip до
+    // vacancy/for-map/list мог не уложиться в весь отведённый бюджет —
+    // табличка молча не появлялась, хотя маркер уже был на карте.
+    useEffect(() => {
+        // panActionEndedRef: не пытаться открыть balloon раньше, чем
+        // закончится сам pan — иначе табличка выскакивала бы мгновенно при
+        // клике, до того как карта успевала визуально долететь до маркера.
+        if (panActionEndedRef.current && pendingBalloonOfferIdRef.current !== null) {
+            attemptOpenBalloon(pendingBalloonOfferIdRef.current);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [features]);
 
     useEffect(() => {
         if (!ymapState || !mapRef.current) return undefined;


### PR DESCRIPTION
## Summary
Fourth live-verification round on staging: after #499 (getById gating), the list-card click flow still sometimes never showed the balloon within the 9s timer budget — real network latency on staging exceeded it, while direct marker clicks (confirming the data does eventually arrive) worked fine.

Adds a second effect reacting to `features` updates — the actual signal new markers landed — so the retry fires immediately when data arrives instead of waiting up to 300ms for the next timer tick. The timer stays as a fallback. A new `panActionEndedRef` guard prevents this reactive effect from firing before the pan animation completes (which would otherwise pop the balloon open instantly, breaking the intended "focus first, then table" sequence).

## Test plan
- [x] New test: balloon opens on a `features` update alone, without advancing any fake timers
- [x] revert-and-confirm-fails: new test fails without the fix, others still pass
- [x] Full suite + typecheck clean
- [ ] Live-verify on staging: list-card click → focus → balloon appears promptly and reliably
