### PR TITLE
fix(GS-108): keep retrying balloon open after success, don't mark done

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -400,6 +400,43 @@ describe("OffersMap", () => {
         }
     });
 
+    it("переоткрывает balloon при следующем обновлении маркеров даже после уже успешного open() (регресс: bounds-дебаунс иногда даёт две волны обновления за один pan — промежуточную и финальную; второй remove()+add() в ObjectManager молча закрывал уже открытый balloon, а код считал задачу выполненной и больше не пытался)", async () => {
+        getById.mockImplementation(() => ({}));
+        const coordinates = { latitude: 55.75, longitude: 37.61 };
+
+        const { rerender } = render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+                selectedOfferId={1}
+                selectedOfferCoordinates={coordinates}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+        act(() => {
+            boundsChangeHandlers.forEach((handler) => handler());
+        });
+        expect(balloonOpen).toHaveBeenCalledTimes(1);
+
+        // Вторая волна маркеров под тот же самый pan (та самая "финальная"
+        // bounds-загрузка) — balloon должен попытаться открыться снова, а не
+        // молчать, потому что "уже открывали один раз".
+        act(() => {
+            rerender(
+                <OffersMap
+                    offersData={[offer({ id: 1, name: "Ещё одно обновление" })]}
+                    isOffersLoading={false}
+                    selectedOfferId={1}
+                    selectedOfferCoordinates={coordinates}
+                />,
+            );
+        });
+
+        expect(balloonOpen).toHaveBeenCalledTimes(2);
+    });
+
     it("прекращает попытки открыть balloon после разумного числа неудач, а не бесконечно (объекта у вакансии в принципе никогда не будет)", async () => {
         getById.mockImplementation(() => undefined);
 

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -165,8 +165,8 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const panActionEndedRef = useRef(false);
 
     // Пытается открыть balloon прямо сейчас. Возвращает true, если маркер уже
-    // зарегистрирован в ObjectManager (успех или редкая гонка на open()) —
-    // тогда дальше можно не пытаться. false — маркера пока нет, надо ждать.
+    // зарегистрирован в ObjectManager и open() не бросил — таймер-цикл ниже
+    // на этом остановится. false — маркера пока нет, надо ждать/повторить.
     const attemptOpenBalloon = (offerId: number): boolean => {
         const objectManager = objectManagerRef.current;
         if (!objectManager) return false;
@@ -198,7 +198,19 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         } catch {
             return false;
         }
-        pendingBalloonOfferIdRef.current = null;
+        // Шестое живое наблюдение на стейдже: даже успешный open() не значит
+        // "готово навсегда". Bounds-дебаунс может дать ДВЕ волны обновления
+        // маркеров за один pan (промежуточная позиция во время анимации +
+        // финальная после actionend) — второй remove()+add() в ObjectManager
+        // молча закрывает уже открытый balloon. Раньше pendingBalloonOfferIdRef
+        // обнулялся сразу по первому успеху, и реактивный эффект переставал
+        // реагировать на дальнейшие обновления features — balloon закрывался
+        // и больше никогда не переоткрывался, хотя код считал задачу
+        // выполненной. НЕ обнуляем pending здесь: пока выбрана та же вакансия,
+        // каждое следующее обновление маркеров просто попробует открыть
+        // balloon ещё раз (дёшево и идемпотентно, если он и так уже открыт).
+        // pending сбрасывается только когда меняется сам выбор (см. эффект
+        // ниже) — реального смысла "мы наконец закончили" здесь больше нет.
         return true;
     };
 


### PR DESCRIPTION
## Summary
Sixth live-verification round on staging: even after #501, direct React fiber inspection showed `pendingBalloonOfferIdRef` already `null` and `panActionEndedRef` true — the code believed it had opened the balloon — yet the balloon pane was empty in the DOM.

A single pan can trigger two waves of bounds-scoped marker updates ~400ms apart (mid-animation + post-settle). `attemptOpenBalloon` can succeed on the first wave, but the second wave's `remove()`+`add()` cycle in the ObjectManager silently closes the just-opened balloon, and since pending was already cleared, nothing re-opens it.

Fix: stop clearing `pendingBalloonOfferIdRef` on success. As long as the same offer stays selected, every subsequent `features` update just retries opening the balloon — cheap and idempotent if already open, and now survives being closed by a later marker refresh.

## Test plan
- [x] New test: a second `features` update after a successful open() calls `balloon.open` again
- [x] revert-and-confirm-fails: fails without the fix, all others still pass (17 total)
- [x] Full suite + typecheck clean
- [ ] Live-verify on staging: list-card click reliably shows the balloon, confirmed via direct React fiber inspection this time, not just visual wait
