### PR TITLE
fix(GS-109): wire selectedOfferId/onSelect through to mobile offers-map

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -405,6 +405,10 @@ export const OffersSearchFilter = () => {
                     offersPerPage={OFFERS_PER_PAGE}
                     total={offersData?.pagination.total ?? 0}
                     onChangePage={onChangePage}
+                    selectedOfferId={selectedOfferId}
+                    onSelectOffer={handleSelectOffer}
+                    selectedOfferCoordinates={selectedOfferCoordinates}
+                    offerIdsWithoutLocation={offerIdsWithoutLocation}
                 />
             </div>
         </FormProvider>

--- a/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.test.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.test.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormProvider, useForm } from "react-hook-form";
+import { OfferApi } from "@/entities/Offer";
+import { OffersSearchFilterMobile } from "./OffersSearchFilterMobile";
+
+const latestOffersMapProps: { current: Record<string, unknown> } = { current: {} };
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/widgets/OffersMap", () => ({
+    OfferPagination: () => <div />,
+    OffersMap: (props: Record<string, unknown>) => {
+        latestOffersMapProps.current = props;
+        return <div data-testid="offers-map" />;
+    },
+    SwitchClosedOffers: () => <div />,
+}));
+
+vi.mock("@/widgets/OffersMap/ui/OfferCard/OfferCard", () => ({
+    OfferCard: ({
+        data, isSelected, onSelect,
+    }: {
+        data: { id: number };
+        isSelected?: boolean;
+        onSelect?: (id: number) => void;
+    }) => (
+        <button
+            type="button"
+            data-testid={`offer-card-${data.id}`}
+            data-selected={isSelected ? "true" : "false"}
+            onClick={() => onSelect?.(data.id)}
+        >
+            offer
+            {data.id}
+        </button>
+    ),
+}));
+
+vi.mock("@/widgets/OffersMap/ui/SearchOffers/SearchOffers", () => ({
+    SearchOffers: () => <div />,
+}));
+
+vi.mock("@/widgets/OffersMap/ui/SelectSort/SelectSort", () => ({
+    SelectSort: () => <div />,
+}));
+
+vi.mock("../OffersMobileFilter/OffersMobileFilter", () => ({
+    OffersMobileFilter: () => <div />,
+}));
+
+const offer = (id: number): OfferApi => ({
+    id,
+    title: `Test offer ${id}`,
+    shortDescription: "",
+    image: null,
+    categories: [],
+    address: "",
+    acceptedApplicationsCount: 0,
+    averageRating: 0,
+    reviewsCount: 0,
+    status: "active" as const,
+    organization: {
+        id: "1", name: "", type: "", otherType: "", shortDescription: "", image: { id: "1", contentUrl: "" },
+    },
+    isFullYearAcceptable: false,
+    isApplicableAtTheEnd: false,
+    durationMinDays: 0,
+    durationMaxDays: 0,
+    applicationEndDate: "",
+    periods: [],
+    updated: "",
+});
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+    const form = useForm();
+    return <FormProvider {...form}>{children}</FormProvider>;
+};
+
+type MobileProps = Partial<React.ComponentProps<typeof OffersSearchFilterMobile>>;
+
+const renderMobile = (props: MobileProps = {}) => render(
+    <Wrapper>
+        <OffersSearchFilterMobile
+            allOffersMapData={[]}
+            isLoadingAllOffersMap={false}
+            data={[offer(1)]}
+            isLoading={false}
+            onApplySearch={() => {}}
+            onSubmit={() => {}}
+            onResetFilters={() => {}}
+            total={1}
+            currentPage={1}
+            offersPerPage={20}
+            onChangePage={() => {}}
+            {...props}
+        />
+    </Wrapper>,
+);
+
+describe("OffersSearchFilterMobile", () => {
+    it(
+        "открывает вкладку карты сразу, если вакансия уже выбрана через URL (регресс: клик по вакансии в списке "
+        + "никогда не подсвечивал/не центрировал мобильную карту — onSelect/selectedOfferId/selectedOfferCoordinates "
+        + "просто не были подключены к мобильному дереву)",
+        () => {
+            renderMobile({ selectedOfferId: 42 });
+
+            expect(screen.getByTestId("offers-map")).toBeInTheDocument();
+            expect(latestOffersMapProps.current.selectedOfferId).toBe(42);
+        },
+    );
+
+    it("по умолчанию (без выбранной вакансии) открывает вкладку списка, а не карты", () => {
+        renderMobile();
+
+        expect(screen.queryByTestId("offers-map")).not.toBeInTheDocument();
+        expect(screen.getByTestId("offer-card-1")).toBeInTheDocument();
+    });
+
+    it("клик по карточке в списке вызывает onSelectOffer и переключает на вкладку карты", async () => {
+        const onSelectOffer = vi.fn();
+        renderMobile({ onSelectOffer });
+
+        await userEvent.click(screen.getByTestId("offer-card-1"));
+
+        expect(onSelectOffer).toHaveBeenCalledWith(1);
+        expect(screen.getByTestId("offers-map")).toBeInTheDocument();
+    });
+
+    it("передаёт selectedOfferId/selectedOfferCoordinates в мобильную OffersMap, чтобы карта могла "
+        + "сфокусироваться и открыть balloon", () => {
+        const coordinates = { latitude: 55.75, longitude: 37.61 };
+        renderMobile({ selectedOfferId: 7, selectedOfferCoordinates: coordinates });
+
+        expect(latestOffersMapProps.current.selectedOfferId).toBe(7);
+        expect(latestOffersMapProps.current.selectedOfferCoordinates).toBe(coordinates);
+    });
+
+    it("отмечает выбранную карточку как isSelected", async () => {
+        renderMobile({ selectedOfferId: 1 });
+
+        // карта открыта по умолчанию (т.к. selectedOfferId задан) — переключаемся на список
+        await userEvent.click(screen.getByText("Список вакансий"));
+
+        expect(screen.getByTestId("offer-card-1")).toHaveAttribute("data-selected", "true");
+    });
+});

--- a/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.tsx
@@ -44,6 +44,10 @@ interface OffersSearchFilterMobileProps {
     currentPage: number;
     offersPerPage: number;
     onChangePage: (pageItem: number) => void;
+    selectedOfferId?: number;
+    onSelectOffer?: (offerId: number) => void;
+    selectedOfferCoordinates?: { latitude: number; longitude: number } | null;
+    offerIdsWithoutLocation?: Set<number>;
 }
 
 const MemoizedOfferCard = React.memo(OfferCard);
@@ -62,11 +66,20 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
     offersPerPage,
     total,
     onChangePage,
+    selectedOfferId,
+    onSelectOffer,
+    selectedOfferCoordinates,
+    offerIdsWithoutLocation,
 }) => {
     const { control } = useFormContext();
     const { t } = useTranslation("offers-map");
     const { locale } = useLocale();
-    const [selectedTab, setSelectedTab] = useState<SelectedTabType>("offers");
+    // Ссылка вида /offers-map?offerId=... (шеринг конкретной вакансии) должна
+    // сразу показывать её на карте — иначе человек попадает в список вакансий
+    // и должен ещё сам догадаться вручную переключиться на вкладку "Карта".
+    const [selectedTab, setSelectedTab] = useState<SelectedTabType>(
+        () => (selectedOfferId ? "map" : "offers"),
+    );
 
     const [isPending, startTransition] = useTransition();
 
@@ -104,6 +117,18 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
     const handleMapTab = useCallback(() => {
         setSelectedTab("map");
     }, []);
+
+    // На десктопе список и карта видны бок о бок, поэтому клик по карточке
+    // просто выделяет метку на уже открытой карте. На мобильном они на
+    // разных вкладках — без переключения на "Карта" клик по карточке в
+    // списке визуально не приводил бы ни к чему (карту пользователь тогда
+    // не видит), хотя выбор внутри состояния уже происходил бы. Тот же
+    // сценарий, что и на десктопе ("фокус на точке → табличка с фото"), но
+    // с явным переходом на вкладку карты вместо соседней колонки.
+    const handleSelectOffer = useCallback((offerId: number) => {
+        onSelectOffer?.(offerId);
+        setSelectedTab("map");
+    }, [onSelectOffer]);
 
     const tabStates = useMemo(
         () => ({
@@ -152,10 +177,16 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
                     reviewsCount: offer.reviewsCount,
                 }}
                 key={offer.id}
+                isSelected={offer.id === selectedOfferId}
+                onSelect={handleSelectOffer}
+                hasLocation={!offerIdsWithoutLocation?.has(offer.id)}
             />
         ));
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [locale, t, isLoading, isPending, data]);
+    }, [
+        locale, t, isLoading, isPending, data, selectedOfferId,
+        handleSelectOffer, offerIdsWithoutLocation,
+    ]);
 
     const totalPages = useMemo(
         () => (data ? Math.ceil(total / offersPerPage) : 1),
@@ -250,6 +281,8 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
                     isOffersLoading={isLoadingAllOffersMap}
                     className={styles.offersMap}
                     classNameMap={styles.offersMap}
+                    selectedOfferId={selectedOfferId}
+                    selectedOfferCoordinates={selectedOfferCoordinates}
                 />
             )}
             {tabStates.isFilterTabOpened && (


### PR DESCRIPTION
Followup to GS-108. All the balloon/focus fixes in that issue only landed on the desktop tree — `OffersSearchFilterMobile` never received `selectedOfferId`/`onSelectOffer`/`selectedOfferCoordinates`/`offerIdsWithoutLocation` at all, so on mobile:
- tapping a list card always navigated straight to the offer page instead of selecting it
- `?offerId=` in the URL never focused/opened a balloon on the mobile map

Fix threads the same 4 props already used on desktop through to `OffersSearchFilterMobile`, defaults to the "map" tab when `selectedOfferId` is present, and wires `OfferCard`'s existing `onSelect`/`isSelected` support into the mobile card list (same pattern `OffersList.tsx` already uses on desktop).

Confirmed live on staging with a Playwright mobile viewport (390x844) before this fix: map stayed zoomed-out, tap navigated away instead of selecting.

Linear: GS-109