### PR TITLE
fix(GS-110): wire onBoundsChange to mobile offers-map too

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -409,6 +409,7 @@ export const OffersSearchFilter = () => {
                     onSelectOffer={handleSelectOffer}
                     selectedOfferCoordinates={selectedOfferCoordinates}
                     offerIdsWithoutLocation={offerIdsWithoutLocation}
+                    onBoundsChange={handleBoundsChange}
                 />
             </div>
         </FormProvider>

--- a/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.test.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.test.tsx
@@ -155,4 +155,13 @@ describe("OffersSearchFilterMobile", () => {
 
         expect(screen.getByTestId("offer-card-1")).toHaveAttribute("data-selected", "true");
     });
+
+    it("передаёт onBoundsChange в мобильную OffersMap (регресс: без него мобильная карта грузит "
+        + "весь неограниченный набор маркеров вместо viewport-scoped, из-за чего ObjectManager не успевает "
+        + "зарегистрировать маркер в бюджете ретраев открытия balloon)", () => {
+        const onBoundsChange = vi.fn();
+        renderMobile({ selectedOfferId: 1, onBoundsChange });
+
+        expect(latestOffersMapProps.current.onBoundsChange).toBe(onBoundsChange);
+    });
 });

--- a/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.tsx
@@ -13,6 +13,7 @@ import {
     OffersMap,
     SwitchClosedOffers,
 } from "@/widgets/OffersMap";
+import type { MapViewportBounds } from "@/widgets/OffersMap/ui/OffersMap/OffersMap";
 import { OfferCard } from "@/widgets/OffersMap/ui/OfferCard/OfferCard";
 import { SearchOffers } from "@/widgets/OffersMap/ui/SearchOffers/SearchOffers";
 import { SelectSort } from "@/widgets/OffersMap/ui/SelectSort/SelectSort";
@@ -48,6 +49,7 @@ interface OffersSearchFilterMobileProps {
     onSelectOffer?: (offerId: number) => void;
     selectedOfferCoordinates?: { latitude: number; longitude: number } | null;
     offerIdsWithoutLocation?: Set<number>;
+    onBoundsChange?: (bounds: MapViewportBounds) => void;
 }
 
 const MemoizedOfferCard = React.memo(OfferCard);
@@ -70,6 +72,7 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
     onSelectOffer,
     selectedOfferCoordinates,
     offerIdsWithoutLocation,
+    onBoundsChange,
 }) => {
     const { control } = useFormContext();
     const { t } = useTranslation("offers-map");
@@ -283,6 +286,7 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
                     classNameMap={styles.offersMap}
                     selectedOfferId={selectedOfferId}
                     selectedOfferCoordinates={selectedOfferCoordinates}
+                    onBoundsChange={onBoundsChange}
                 />
             )}
             {tabStates.isFilterTabOpened && (


### PR DESCRIPTION
Found while live-verifying GS-109 on a mobile viewport. After GS-109 wired `selectedOfferId`/`onSelect` through to mobile, the map correctly panned/zoomed to the selected offer, but the balloon never auto-opened via list-card selection (it did open via direct marker tap, and via landing on `?offerId=` through a full page load).

Root cause: mobile's `<OffersMap>` never received `onBoundsChange` (unlike desktop's). It's stuck on a single unbounded initial fetch (~1370 markers globally). Clustering that many features in ObjectManager is slow enough to miss the balloon-open retry budget (9s) when the map mounts fresh right after a tab switch — confirmed live via React-fiber inspection that the marker eventually did register, just well past the retry budget.

This also means mobile never got GS-86's bounds-filtering at all, always loading the full global marker set regardless of viewport.

Fix: pass `onBoundsChange={handleBoundsChange}` to mobile's `<OffersMap>` too, same as desktop. Both already share `mapBoundsRef`/`fetchOffersMapWithBounds`; the existing degenerate-bounds guard in `OffersMap.tsx` protects the CSS-hidden instance of whichever tree isn't currently visible.

Linear: GS-110