### PR TITLE
fix(GS-111): stabilize features array reference to stop marker flicker

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -546,4 +546,52 @@ describe("OffersMap", () => {
         // продублировать тот же сдвиг ещё и для content, он применится дважды.
         expect(options.iconContentOffset).toBeUndefined();
     });
+
+    it("держит ту же ссылку на features, если пришедший offersData не меняет фактический набор маркеров "
+        + "(регресс: ObjectManager делает remove()+add() по ВСЕЙ коллекции на каждую новую ссылку features, "
+        + "даже если содержимое идентично — например повторный bounds-фетч тех же данных или лёгкий пан в "
+        + "пределах того же viewport — из-за чего все маркеры на карте видимо мигали при каждом таком апдейте)", async () => {
+        const { rerender } = render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+        const firstFeatures = capturedFeatures;
+
+        // Новый массив-литерал с offersData, но по содержимому — те же самые
+        // офферы: именно так выглядит повторный RTK Query fetch с тем же
+        // результатом (новая ссылка на массив/объекты при каждом success).
+        rerender(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        expect(capturedFeatures).toBe(firstFeatures);
+    });
+
+    it("строит новый набор features, если офферы реально изменились (координаты)", async () => {
+        const { rerender } = render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+        const firstFeatures = capturedFeatures;
+
+        rerender(
+            <OffersMap
+                offersData={[offer({ id: 1, latitude: 60 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        expect(capturedFeatures).not.toBe(firstFeatures);
+    });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -64,6 +64,17 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     // моргает при каждом перемещении. Держим последний непустой набор
     // маркеров на экране, пока не придут новые (stale-while-revalidate).
     const lastFeaturesRef = useRef<any[]>([]);
+    // ObjectManager (react-yandex-maps) на каждое изменение ССЫЛКИ features
+    // делает remove(старые) + add(новые) по ВСЕЙ коллекции разом — не diff.
+    // offersData после каждого bounds-рефетча приходит новым массивом от
+    // RTK Query, даже если набор маркеров не изменился ни на йоту (например,
+    // повторный fetch с теми же bounds или лёгкий pan в пределах того же
+    // viewport) — .filter().map() ниже тогда всё равно строит новый массив
+    // объектов, ObjectManager видит "новую" ссылку и на мгновение снимает и
+    // возвращает ВСЕ маркеры сразу — заметное мигание карты. Держим сигнатуру
+    // последнего построенного набора, чтобы при том же содержимом отдавать ту
+    // же ссылку на features и не трогать ObjectManager вовсе.
+    const lastFeaturesSignatureRef = useRef<string>("");
 
     const noTitle = t("Без названия");
     const noCategory = t("Без категории");
@@ -75,8 +86,23 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const features = useMemo(() => {
         if (isOffersLoading || !offersData.length) return lastFeaturesRef.current;
 
-        const computed = offersData
-            .filter((offer) => typeof offer.latitude === "number" && typeof offer.longitude === "number")
+        const relevantOffers = offersData
+            .filter((offer) => typeof offer.latitude === "number" && typeof offer.longitude === "number");
+
+        const signature = relevantOffers
+            .map((offer) => [
+                offer.id, offer.latitude, offer.longitude, offer.name,
+                offer.categories[0]?.name ?? "", offer.categories[0]?.color ?? "",
+                offer.image?.contentUrl ?? "",
+            ].join(":"))
+            .sort()
+            .join("|");
+        if (signature === lastFeaturesSignatureRef.current && lastFeaturesRef.current.length > 0) {
+            return lastFeaturesRef.current;
+        }
+        lastFeaturesSignatureRef.current = signature;
+
+        const computed = relevantOffers
             .map((offer) => {
                 const imgSrc = offer?.image ?? undefined;
                 const title = offer.name || noTitle;


### PR DESCRIPTION
Found live-testing GS-109/GS-110 on staging mobile — the map "constantly blinks" while browsing.

Root cause (confirmed by reading `@pbe/react-yandex-maps` source): `ObjectManager`'s wrapper does a full `remove(oldFeatures) + add(newFeatures)` over the ENTIRE marker collection whenever the `features` prop's array *reference* changes — not a diff. Our `features` useMemo always built a brand-new array on every bounds-triggered refetch, even when the result was byte-identical to before (RTK Query returns a new reference on every fetch success). So essentially every pan caused all markers to blink off and back on.

This has always existed on desktop (which already had `onBoundsChange` wired), but GS-110 made mobile hit the same refetch-on-pan path for the first time, and mobile users pan by touch-drag far more, making it obvious.

Fix: compute a cheap content signature (id/coords/name/category/image) for the fetched marker set and reuse the previous `features` array reference when it's unchanged, so `ObjectManager`'s own reference check skips the remove+add.

Linear: GS-111