### PR TITLE
fix(GS-112): don't reuse stale features built before map finished loading

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -49,7 +49,7 @@ vi.mock("@pbe/react-yandex-maps", () => ({
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
             onLoadCalls();
-            onLoad?.({ templateLayoutFactory: { createClass: () => undefined } });
+            onLoad?.({ templateLayoutFactory: { createClass: () => "layout-class-sentinel" } });
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }, []);
         return <div>{children}</div>;
@@ -593,5 +593,22 @@ describe("OffersMap", () => {
         );
 
         expect(capturedFeatures).not.toBe(firstFeatures);
+    });
+
+    it("строит маркер с реальным iconContentLayout (не пустым), даже если offersData уже пришли ДО того, "
+        + "как карта закончила грузиться (регресс: templateLayoutFactory становится доступен только после "
+        + "onLoad карты — если features успевают построиться раньше на пустой фабрике, а сигнатура "
+        + "стабильности не учитывает эту готовность, устаревший набор с пустым iconContentLayout "
+        + "переиспользуется навсегда, и цветной кружок маркера никогда не рисуется, хотя balloon по клику "
+        + "всё равно открывается)", async () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+        expect(capturedFeatures[0].options.iconContentLayout).toBeTruthy();
     });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -96,7 +96,17 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 offer.image?.contentUrl ?? "",
             ].join(":"))
             .sort()
-            .join("|");
+            .join("|")
+            // templateLayoutFactory становится доступен только после onLoad
+            // карты — если он ещё не готов на момент первого построения
+            // features (offersData уже пришли раньше), iconContentLayout
+            // маркера строится пустым (фабрики нет), и цветной кружок
+            // маркера никогда не рисуется. Без этого флага в сигнатуре
+            // переход "фабрика появилась" не отличался бы по содержимому от
+            // предыдущего рендера и результат с пустым iconContentLayout
+            // переиспользовался бы навсегда — маркер оставался бы невидимым
+            // даже после того как balloon уже открывался поверх него.
+            + (ymapState?.templateLayoutFactory ? "|ready" : "|pending");
         if (signature === lastFeaturesSignatureRef.current && lastFeaturesRef.current.length > 0) {
             return lastFeaturesRef.current;
         }


### PR DESCRIPTION
Regression from GS-111, found live on staging: balloon opens fine (photo/title/category) but the marker's own colored dot is invisible underneath.

`templateLayoutFactory` only becomes available after the map's `onLoad` fires. If `offersData` is already available before that (e.g. single-result search), `features` builds once with `iconContentLayout: undefined`. GS-111's stability signature only compared offer content (id/coords/name/category/image), so once `templateLayoutFactory` became ready and the memo re-ran, the signature looked unchanged and the stale, dot-less feature set kept getting reused forever.

Confirmed live: `objectManager.objects.getById('7201').options.iconContentLayout` was `undefined` for a selected marker whose balloon was open and visible.

Fix: include templateLayoutFactory readiness in the signature so that transition forces a rebuild. Also fixed the test mock, which always returned `undefined` from `createClass` — this hid the exact bug this PR fixes; no test would have caught it before.

Linear: GS-112