### PR TITLE
fix(GS-113): map/list resilience for API errors, empty results, map load failures

### DIFF
--- a/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilter/OffersSearchFilter.tsx
@@ -39,11 +39,13 @@ const OFFERS_PER_PAGE = 20;
 export const OffersSearchFilter = () => {
     const [isMapOpened, setMapOpened] = useState<boolean>(true);
     const [searchParams, setSearchParams] = useSearchParams();
-    const [fetchOffers, { data: offersData, isLoading, isFetching }] = useLazyGetOffersQuery();
+    const [fetchOffers, {
+        data: offersData, isLoading, isFetching, isError: isOffersListError,
+    }] = useLazyGetOffersQuery();
     const [fetchAllOffersMap,
         {
             data: allOffersMap = [], isLoading: isAllOffersMapLoading,
-            isFetching: isAllOffersMapFetching,
+            isFetching: isAllOffersMapFetching, isError: isAllOffersMapError,
         }] = useLazyGetAllOffersMapQuery();
     // Отдельный вызов того же эндпоинта по конкретным id вместо bounds —
     // даёт координаты/наличие локации именно для карточек текущей страницы
@@ -95,9 +97,11 @@ export const OffersSearchFilter = () => {
         fetchAllOffersMap({ ...params, ...(mapBoundsRef.current ?? {}) });
     }, [fetchAllOffersMap]);
 
-    const handleBoundsChange = useCallback((bounds: MapViewportBounds) => {
-        mapBoundsRef.current = bounds;
-
+    // Общий путь и для обычного обновления (смена bounds/фильтров), и для
+    // повторной попытки после ошибки — кнопка "Попробовать снова" должна
+    // повторить именно ПОСЛЕДНИЙ реальный запрос (те же bounds/фильтры/поиск),
+    // а не какой-то дефолтный, иначе после смены фильтров retry вернёт не то.
+    const refetchOffersMap = useCallback(() => {
         const watchData = watch();
         const preparedData = offersFilterApiAdapter(watchData);
         if (currentSearchRef.current) {
@@ -107,7 +111,12 @@ export const OffersSearchFilter = () => {
         }
     }, [watch, fetchOffersMapWithBounds]);
 
-    useEffect(() => {
+    const handleBoundsChange = useCallback((bounds: MapViewportBounds) => {
+        mapBoundsRef.current = bounds;
+        refetchOffersMap();
+    }, [refetchOffersMap]);
+
+    const refetchOffersList = useCallback(() => {
         if (currentSearchRef.current) {
             fetchOffers({
                 sort: OfferSort.UpdatedDesc,
@@ -120,12 +129,14 @@ export const OffersSearchFilter = () => {
             const preparedData = offersFilterApiAdapter(watchData);
             fetchOffers({ ...preparedData, limit: OFFERS_PER_PAGE, page: currentPage });
         }
+    }, [currentPage, fetchOffers, watch]);
+
+    useEffect(() => {
+        refetchOffersList();
     }, [currentPage]);
 
     useEffect(() => {
-        const watchData = watch();
-        const preparedData = offersFilterApiAdapter(watchData);
-        fetchOffersMapWithBounds({ ...preparedData });
+        refetchOffersMap();
     }, []);
 
     useEffect(() => {
@@ -368,6 +379,8 @@ export const OffersSearchFilter = () => {
                         <OffersList
                             data={offersData?.data}
                             isLoading={isLoading || isFetching}
+                            isError={isOffersListError}
+                            onRetry={refetchOffersList}
                             className={cn(styles.offersList)}
                             onChangeMapOpen={handleMapOpen}
                             mapOpenValue={isMapOpened}
@@ -384,6 +397,8 @@ export const OffersSearchFilter = () => {
                         <OffersMap
                             offersData={allOffersMap}
                             isOffersLoading={isAllOffersMapLoading || isAllOffersMapFetching}
+                            isOffersError={isAllOffersMapError}
+                            onRetry={refetchOffersMap}
                             className={styles.offersMap}
                             classNameMap={styles.offersMap}
                             selectedOfferId={selectedOfferId}
@@ -396,7 +411,11 @@ export const OffersSearchFilter = () => {
                     data={offersData?.data}
                     allOffersMapData={allOffersMap}
                     isLoadingAllOffersMap={isAllOffersMapLoading || isAllOffersMapFetching}
+                    isMapError={isAllOffersMapError}
+                    onRetryMap={refetchOffersMap}
                     isLoading={isLoading || isFetching}
+                    isError={isOffersListError}
+                    onRetry={refetchOffersList}
                     className={styles.mobile}
                     onApplySearch={onApplySearch}
                     onSubmit={onApplyFilters}

--- a/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.module.scss
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.module.scss
@@ -74,6 +74,14 @@
     width: 100%;
     text-align: center;
     padding: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.retryButton {
+    margin-top: 8px;
 }
 
 .miniLoader {

--- a/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.test.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.test.tsx
@@ -164,4 +164,24 @@ describe("OffersSearchFilterMobile", () => {
 
         expect(latestOffersMapProps.current.onBoundsChange).toBe(onBoundsChange);
     });
+
+    it("показывает отдельное сообщение об ошибке списка (не «вакансий не были найдены») и вызывает onRetry "
+        + "по кнопке", async () => {
+        const onRetry = vi.fn();
+        renderMobile({ isError: true, data: undefined, onRetry });
+
+        expect(screen.getByText("Не удалось загрузить вакансии")).toBeInTheDocument();
+        expect(screen.queryByText("Вакансии не были найдены")).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByText("Попробовать снова"));
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it("передаёт isMapError/onRetryMap в мобильную OffersMap как isOffersError/onRetry", () => {
+        const onRetryMap = vi.fn();
+        renderMobile({ selectedOfferId: 1, isMapError: true, onRetryMap });
+
+        expect(latestOffersMapProps.current.isOffersError).toBe(true);
+        expect(latestOffersMapProps.current.onRetry).toBe(onRetryMap);
+    });
 });

--- a/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.tsx
+++ b/src/pages/OffersMapPage/ui/OffersSearchFilterMobile/OffersSearchFilterMobile.tsx
@@ -23,6 +23,7 @@ import { OfferApi, OfferMap } from "@/entities/Offer";
 // import { getUserAuthData } from "@/entities/User";
 import searchIcon from "@/shared/assets/icons/search-icon.svg";
 // import { useAppSelector } from "@/shared/hooks/redux";
+import Button from "@/shared/ui/Button/Button";
 import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 import { SquareButton } from "@/shared/ui/SquareButton/SquareButton";
 import { Text } from "@/shared/ui/Text/Text";
@@ -36,8 +37,12 @@ interface OffersSearchFilterMobileProps {
     className?: string;
     allOffersMapData: OfferMap[];
     isLoadingAllOffersMap: boolean;
+    isMapError?: boolean;
+    onRetryMap?: () => void;
     data?: OfferApi[];
     isLoading: boolean;
+    isError?: boolean;
+    onRetry?: () => void;
     onApplySearch: (search: string) => void;
     onSubmit: () => void;
     onResetFilters: () => void;
@@ -60,7 +65,11 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
     data,
     allOffersMapData,
     isLoadingAllOffersMap,
+    isMapError,
+    onRetryMap,
     isLoading,
+    isError,
+    onRetry,
     onApplySearch,
     onSubmit,
     onResetFilters,
@@ -143,6 +152,31 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
     );
 
     const renderOfferCards = useMemo(() => {
+        if (isError) {
+            return (
+                <div className={styles.error}>
+                    <Text
+                        textSize="primary"
+                        text={t("Не удалось загрузить вакансии")}
+                    />
+                    <Text
+                        textSize="secondary"
+                        text={t("Проверьте соединение и попробуйте ещё раз")}
+                    />
+                    {onRetry && (
+                        <Button
+                            className={styles.retryButton}
+                            color="BLUE"
+                            size="MEDIUM"
+                            variant="OUTLINE"
+                            onClick={onRetry}
+                        >
+                            {t("Попробовать снова")}
+                        </Button>
+                    )}
+                </div>
+            );
+        }
         if (isLoading || isPending) {
             return (
                 <div className={cn(styles.wrapper, className)}>
@@ -187,7 +221,7 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
         ));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
-        locale, t, isLoading, isPending, data, selectedOfferId,
+        locale, t, isLoading, isPending, isError, onRetry, data, selectedOfferId,
         handleSelectOffer, offerIdsWithoutLocation,
     ]);
 
@@ -282,6 +316,8 @@ export const OffersSearchFilterMobile: FC<OffersSearchFilterMobileProps> = ({
                 <OffersMap
                     offersData={allOffersMapData}
                     isOffersLoading={isLoadingAllOffersMap}
+                    isOffersError={isMapError}
+                    onRetry={onRetryMap}
                     className={styles.offersMap}
                     classNameMap={styles.offersMap}
                     selectedOfferId={selectedOfferId}

--- a/src/widgets/OffersMap/ui/OffersList/OffersList.module.scss
+++ b/src/widgets/OffersMap/ui/OffersList/OffersList.module.scss
@@ -59,6 +59,14 @@
     width: 100%;
     text-align: center;
     padding: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.retryButton {
+    margin-top: 8px;
 }
 
 .miniLoader {

--- a/src/widgets/OffersMap/ui/OffersList/OffersList.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersList/OffersList.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import {
+    describe, it, expect, vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { OffersList } from "./OffersList";
+import { OfferApi } from "@/entities/Offer";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/app/providers/LocaleProvider", () => ({
+    useLocale: () => ({ locale: "ru" }),
+}));
+
+vi.mock("../HeaderList/HeaderList", () => ({
+    HeaderList: () => <div data-testid="header-list" />,
+}));
+
+vi.mock("../OfferPagination/OfferPagination", () => ({
+    OfferPagination: () => <div data-testid="offer-pagination" />,
+}));
+
+vi.mock("../OfferCard/OfferCard", () => ({
+    OfferCard: ({ data }: { data: { id: number } }) => (
+        <div data-testid={`offer-card-${data.id}`} />
+    ),
+}));
+
+const offer = (id: number): OfferApi => ({
+    id,
+    title: `Test offer ${id}`,
+    shortDescription: "",
+    image: null,
+    categories: [],
+    address: "",
+    acceptedApplicationsCount: 0,
+    averageRating: 0,
+    reviewsCount: 0,
+    status: "active" as const,
+    organization: {
+        id: "1", name: "", type: "", otherType: "", shortDescription: "", image: { id: "1", contentUrl: "" },
+    },
+    isFullYearAcceptable: false,
+    isApplicableAtTheEnd: false,
+    durationMinDays: 0,
+    durationMaxDays: 0,
+    applicationEndDate: "",
+    periods: [],
+    updated: "",
+});
+
+const renderList = (props: Partial<React.ComponentProps<typeof OffersList>> = {}) => render(
+    <OffersList
+        mapOpenValue
+        onChangeMapOpen={() => {}}
+        data={[offer(1)]}
+        isLoading={false}
+        currentPage={1}
+        offersPerPage={20}
+        total={1}
+        onChangePage={() => {}}
+        {...props}
+    />,
+);
+
+describe("OffersList", () => {
+    it(
+        "показывает отдельное сообщение об ошибке загрузки (регресс: реальный сбой запроса "
+        + "500/обрыв сети выглядел так же, как «вакансии не были найдены» — человек решал, что "
+        + "раздела просто нет, вместо того чтобы попробовать обновить страницу)",
+        () => {
+            renderList({ isError: true, data: undefined });
+
+            expect(screen.getByText("Не удалось загрузить вакансии")).toBeInTheDocument();
+            expect(screen.queryByText("Вакансии не были найдены")).not.toBeInTheDocument();
+        },
+    );
+
+    it("не показывает ошибку, если данные загрузились штатно", () => {
+        renderList();
+
+        expect(screen.queryByText("Не удалось загрузить вакансии")).not.toBeInTheDocument();
+        expect(screen.getByTestId("offer-card-1")).toBeInTheDocument();
+    });
+
+    it("кнопка «Попробовать снова» вызывает onRetry", async () => {
+        const onRetry = vi.fn();
+        renderList({ isError: true, data: undefined, onRetry });
+
+        await userEvent.click(screen.getByText("Попробовать снова"));
+
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it("показывает спиннер, а не ошибку, пока идёт обычная загрузка (isError не задан)", () => {
+        renderList({ isLoading: true, data: undefined });
+
+        expect(screen.queryByText("Не удалось загрузить вакансии")).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/OffersMap/ui/OffersList/OffersList.tsx
+++ b/src/widgets/OffersMap/ui/OffersList/OffersList.tsx
@@ -9,6 +9,7 @@ import { useLocale } from "@/app/providers/LocaleProvider";
 import { OfferApi } from "@/entities/Offer";
 import { getOfferImagePath } from "./getOfferImagePath";
 
+import Button from "@/shared/ui/Button/Button";
 import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
 import { Text } from "@/shared/ui/Text/Text";
 
@@ -23,6 +24,8 @@ interface OffersListProps {
     onChangeMapOpen: () => void;
     data?: OfferApi[];
     isLoading: boolean;
+    isError?: boolean;
+    onRetry?: () => void;
     currentPage: number;
     offersPerPage: number;
     total: number;
@@ -43,6 +46,8 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
         total,
         onChangePage,
         isLoading,
+        isError,
+        onRetry,
         selectedOfferId,
         onSelectOffer,
         offerIdsWithoutLocation,
@@ -66,6 +71,35 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
     );
 
     const renderOfferCards = useMemo(() => {
+        // Отдельно от "вакансий не найдены": иначе реальный сбой запроса
+        // (500, обрыв сети) выглядит для человека так же, как "по вашим
+        // фильтрам ничего нет" — он решает, что раздела просто нет, а не
+        // пробует обновить страницу.
+        if (isError) {
+            return (
+                <div className={styles.error}>
+                    <Text
+                        textSize="primary"
+                        text={t("Не удалось загрузить вакансии")}
+                    />
+                    <Text
+                        textSize="secondary"
+                        text={t("Проверьте соединение и попробуйте ещё раз")}
+                    />
+                    {onRetry && (
+                        <Button
+                            className={styles.retryButton}
+                            color="BLUE"
+                            size="MEDIUM"
+                            variant="OUTLINE"
+                            onClick={onRetry}
+                        >
+                            {t("Попробовать снова")}
+                        </Button>
+                    )}
+                </div>
+            );
+        }
         if (isLoading || isPending) {
             return <MiniLoader className={styles.miniLoader} />;
         }
@@ -115,7 +149,7 @@ export const OffersList: FC<OffersListProps> = (props: OffersListProps) => {
         );
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
-        data, isLoading, locale, mapOpenValue, t, selectedOfferId,
+        data, isLoading, isError, onRetry, locale, mapOpenValue, t, selectedOfferId,
         onSelectOffer, offerIdsWithoutLocation,
     ]);
 

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
@@ -124,5 +124,29 @@
     font-size: 14px;
     font-weight: 500;
     color: var(--color-black-primary);
-    white-space: nowrap;
+    max-width: calc(100% - 32px);
+    text-align: center;
+}
+
+.errorContent {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    text-align: center;
+    padding: 0 16px;
+}
+
+.mapErrorOverlay {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    background-color: var(--color-white);
+    text-align: center;
+    padding: 0 16px;
 }

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import {
     render, screen, act, waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { OffersMap } from "./OffersMap";
 import { OfferMap } from "@/entities/Offer";
 
@@ -16,6 +17,11 @@ const onLoadCalls = vi.fn();
 const balloonOpen = vi.fn().mockResolvedValue(undefined);
 const getById = vi.fn((): object | undefined => ({}));
 let capturedFeatures: any[] = [];
+// Тесты на тайм-аут/onError загрузки карты не должны давать моку Map
+// самому вызывать onLoad — иначе карта "успевает" загрузиться раньше, чем
+// успеет сработать проверяемое поведение.
+let skipAutoLoad = false;
+let capturedOnError: (() => void) | undefined;
 
 vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
@@ -32,8 +38,11 @@ vi.mock("@pbe/react-yandex-maps", () => ({
         children: React.ReactNode;
         instanceRef: { current: unknown };
         onLoad?: (ymap: unknown) => void;
+        onError?: () => void;
     }) => {
-        const { children, instanceRef, onLoad } = props;
+        const {
+            children, instanceRef, onLoad, onError,
+        } = props;
         instanceRef.current = {
             setCenter,
             getZoom,
@@ -46,8 +55,10 @@ vi.mock("@pbe/react-yandex-maps", () => ({
                 },
             },
         };
+        capturedOnError = onError;
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
+            if (skipAutoLoad) return;
             onLoadCalls();
             onLoad?.({ templateLayoutFactory: { createClass: () => "layout-class-sentinel" } });
             // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -89,6 +100,8 @@ describe("OffersMap", () => {
         getById.mockImplementation(() => ({}));
         boundsChangeHandlers.length = 0;
         capturedFeatures = [];
+        skipAutoLoad = false;
+        capturedOnError = undefined;
     });
 
     it("фокусирует карту, если у выбранной вакансии известны координаты", () => {
@@ -610,5 +623,96 @@ describe("OffersMap", () => {
 
         await waitFor(() => expect(capturedFeatures).toHaveLength(1));
         expect(capturedFeatures[0].options.iconContentLayout).toBeTruthy();
+    });
+
+    it("показывает отдельное сообщение об ошибке (не «вакансий не найдено»), если загрузка маркеров упала, "
+        + "и кнопка «Попробовать снова» вызывает onRetry", async () => {
+        const onRetry = vi.fn();
+        render(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+                isOffersError
+                onRetry={onRetry}
+            />,
+        );
+
+        expect(screen.getByText("Не удалось загрузить вакансии")).toBeInTheDocument();
+        expect(screen.queryByText("По вашему запросу вакансий на карте не найдено")).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByText("Попробовать снова"));
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it("показывает «вакансий не найдено», если карта загрузилась, но маркеров нет и это не ошибка "
+        + "(регресс: пустой результат фильтров/поиска выглядел на карте как молчаливо пустое место, "
+        + "неотличимое от карты, которая просто ещё грузится)", async () => {
+        render(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(onLoadCalls).toHaveBeenCalled());
+        expect(screen.getByText("По вашему запросу вакансий на карте не найдено")).toBeInTheDocument();
+    });
+
+    it("не показывает «вакансий не найдено», пока карта ещё грузится", () => {
+        skipAutoLoad = true;
+        render(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+            />,
+        );
+
+        expect(screen.queryByText("По вашему запросу вакансий на карте не найдено")).not.toBeInTheDocument();
+    });
+
+    it("показывает «не удалось загрузить карту» с кнопкой перезагрузки страницы, если карта не "
+        + "загрузилась за разумное время (регресс: скрипт Яндекс.Карт грузится вне React-дерева — если он "
+        + "падает или зависает, никакой Error Boundary этого не ловит, карта молча остаётся пустым местом "
+        + "навсегда без единого сигнала)", () => {
+        vi.useFakeTimers();
+        try {
+            skipAutoLoad = true;
+            render(
+                <OffersMap
+                    offersData={[]}
+                    isOffersLoading={false}
+                />,
+            );
+
+            expect(screen.queryByText("Не удалось загрузить карту")).not.toBeInTheDocument();
+
+            act(() => {
+                vi.advanceTimersByTime(15_000);
+            });
+
+            expect(screen.getByText("Не удалось загрузить карту")).toBeInTheDocument();
+            expect(screen.getByText("Обновить страницу")).toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("показывает тот же оверлей сразу через onError, не дожидаясь тайм-аута, если карта падает "
+        + "при рендере (Error Boundary внутри react-yandex-maps)", () => {
+        skipAutoLoad = true;
+        render(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+            />,
+        );
+
+        expect(screen.queryByText("Не удалось загрузить карту")).not.toBeInTheDocument();
+
+        act(() => {
+            capturedOnError?.();
+        });
+
+        expect(screen.getByText("Не удалось загрузить карту")).toBeInTheDocument();
     });
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -15,12 +15,15 @@ import defaultImage from "@/shared/assets/images/default-offer-image.png";
 import "./yandex-map-restyle-ballon.scss";
 import { OfferMap } from "@/entities/Offer";
 import styles from "./OffersMap.module.scss";
+import Button from "@/shared/ui/Button/Button";
 import { MiniLoader } from "@/shared/ui/MiniLoader/MiniLoader";
+import { Text } from "@/shared/ui/Text/Text";
 import { getOfferPersonalPageUrl } from "@/shared/config/routes/AppUrls";
 import { getMediaContent } from "@/shared/lib/getMediaContent";
 
 const FOCUS_ZOOM = 10;
 const BOUNDS_CHANGE_DEBOUNCE_MS = 400;
+const MAP_LOAD_TIMEOUT_MS = 15_000;
 
 export interface MapViewportBounds {
     boundsSwLat: number;
@@ -43,21 +46,38 @@ interface OffersMapProps {
     // случая, которые раньше смешивались.
     selectedOfferCoordinates?: { latitude: number; longitude: number } | null;
     onBoundsChange?: (bounds: MapViewportBounds) => void;
+    isOffersError?: boolean;
+    onRetry?: () => void;
 }
 
 export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const {
         className, classNameMap, isOffersLoading,
         offersData, selectedOfferId, selectedOfferCoordinates, onBoundsChange,
+        isOffersError, onRetry,
     } = props;
     const { locale } = useLocale();
     const { t } = useTranslation();
     const [ymapState, setYmapState] = useState<YmapType | undefined>(undefined);
     const [showNoLocationNotice, setShowNoLocationNotice] = useState(false);
+    // Скрипт Яндекс.Карт грузится извне (<script> тег, не React-дерево) —
+    // если он падает или зависает (сеть, блокировщик, сбой самого сервиса),
+    // это происходит ВНЕ цикла рендера React, и никакой Error Boundary (в
+    // т.ч. встроенный в react-yandex-maps) это не поймает: onLoad просто
+    // никогда не вызывается, карта молча остаётся пустым местом навсегда.
+    // Тайм-аут — единственный надёжный способ вообще заметить эту ситуацию,
+    // независимо от конкретной причины сбоя.
+    const [mapLoadTimedOut, setMapLoadTimedOut] = useState(false);
     const mapRef = useRef<any>(null);
     const objectManagerRef = useRef<any>(null);
     const onBoundsChangeRef = useRef(onBoundsChange);
     onBoundsChangeRef.current = onBoundsChange;
+
+    useEffect(() => {
+        if (ymapState) return undefined;
+        const timeoutId = setTimeout(() => setMapLoadTimedOut(true), MAP_LOAD_TIMEOUT_MS);
+        return () => clearTimeout(timeoutId);
+    }, [ymapState]);
     // Пока идёт bounds-рефетч, offersData на мгновение становится [] —
     // если сразу же чистить markers, ObjectManager размонтируется и
     // смонтируется заново при приходе новых данных, и карта один раз
@@ -82,6 +102,12 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const learnMore = t("Подробнее");
     const vacancyListTitle = t("Список вакансий:");
     const noLocationText = t("У этой вакансии не указано местоположение на карте");
+    const noOffersOnMapText = t("По вашему запросу вакансий на карте не найдено");
+    const loadErrorTitle = t("Не удалось загрузить вакансии");
+    const loadErrorSubtitle = t("Проверьте соединение и попробуйте ещё раз");
+    const retryText = t("Попробовать снова");
+    const mapLoadErrorTitle = t("Не удалось загрузить карту");
+    const reloadPageText = t("Обновить страницу");
 
     const features = useMemo(() => {
         if (isOffersLoading || !offersData.length) return lastFeaturesRef.current;
@@ -368,12 +394,52 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         };
     }, [ymapState]);
 
+    // Пустая карта (0 маркеров) отличается от карты, которая ещё грузится
+    // или упала с ошибкой — без этого условия пользователь видел бы то же
+    // самое молчаливое пустое место в обоих случаях.
+    const showEmptyNotice = !isOffersError && !isOffersLoading
+        && !!ymapState && features.length === 0;
+
     return (
         <div className={cn(className, styles.wrapper)}>
-            {isOffersLoading && (
+            {mapLoadTimedOut && (
+                <div className={styles.mapErrorOverlay}>
+                    <Text textSize="primary" text={mapLoadErrorTitle} />
+                    <Button
+                        color="BLUE"
+                        size="MEDIUM"
+                        variant="OUTLINE"
+                        onClick={() => window.location.reload()}
+                    >
+                        {reloadPageText}
+                    </Button>
+                </div>
+            )}
+            {!mapLoadTimedOut && isOffersError && (
+                <div className={styles.loadingPlaceholder}>
+                    <div className={styles.errorContent}>
+                        <Text textSize="primary" text={loadErrorTitle} />
+                        <Text textSize="secondary" text={loadErrorSubtitle} />
+                        {onRetry && (
+                            <Button
+                                color="BLUE"
+                                size="MEDIUM"
+                                variant="OUTLINE"
+                                onClick={onRetry}
+                            >
+                                {retryText}
+                            </Button>
+                        )}
+                    </div>
+                </div>
+            )}
+            {!mapLoadTimedOut && isOffersLoading && (
                 <div className={styles.loadingPlaceholder}>
                     <MiniLoader />
                 </div>
+            )}
+            {showEmptyNotice && (
+                <div className={styles.noLocationNotice}>{noOffersOnMapText}</div>
             )}
             {showNoLocationNotice && (
                 <div className={styles.noLocationNotice}>{noLocationText}</div>
@@ -402,6 +468,14 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                     onLoad={(ymap) => {
                         setYmapState(ymap);
                     }}
+                    // react-yandex-maps сам оборачивает Map в Error Boundary —
+                    // без onError падение внутри неё (например, сбой самого
+                    // Яндекс.Карт SDK при рендере) тихо съедалось бы этим
+                    // boundary, и карта осталась бы пустым местом без единого
+                    // сигнала. Переиспользуем тот же оверлей, что и для
+                    // тайм-аута загрузки — с точки зрения пользователя это
+                    // один и тот же "карта не работает".
+                    onError={() => setMapLoadTimedOut(true)}
                     className={cn(styles.map, classNameMap)}
                 >
                     <ZoomControl options={{ position: { right: 10, top: 10 } }} />


### PR DESCRIPTION
## Summary
- Distinct error states (not confused with "nothing found") for `OffersList` and `OffersMap`, each with a "Попробовать снова" retry button wired to the underlying RTK Query fetch.
- Empty-map notice ("По вашему запросу вакансий на карте не найдено") for zero-result searches/filters, mirroring the existing list-side message.
- Yandex Maps load-failure fallback: 15s timeout + `onError` from `react-yandex-maps` → "Не удалось загрузить карту" overlay with a reload-page action. Needed because `react-yandex-maps`'s internal Error Boundary swallows render-time crashes without an `onError` prop, and script load failures never reach a React Error Boundary at all.
- Wired `isError`/`onRetry` for both the list and map fetches through the desktop `OffersSearchFilter` parent, including into the mobile tab component.

GS-113: https://linear.app/voknil/issue/GS-113/karta-ustojchivost-k-oshibkam-zagruzki-pustomu-rezultatu-i-krahu

## Test plan
- [x] `npx vitest run` — 365/365 passing
- [x] `npx eslint` on all changed files — clean
- [x] `npx tsc --noEmit -p .` — clean
- [x] revert-and-confirm-fails on every changed file (new/updated tests fail without the corresponding source change)
- [ ] Live-verify on staging: error state (simulated API failure) on list + map, desktop + mobile
- [ ] Live-verify on staging: empty-map notice for a zero-result search
- [ ] Sanity check normal map load still works (no regression from timeout/onError code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)