### PR TITLE
fix(GS-113): clear stale map markers on genuinely empty search result

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -625,6 +625,34 @@ describe("OffersMap", () => {
         expect(capturedFeatures[0].options.iconContentLayout).toBeTruthy();
     });
 
+    it("очищает маркеры на карте, если новый результат поиска/фильтра пришёл пустым (регресс: анти-мигающий "
+        + "кэш последнего набора features отдавал старые маркеры и тогда, когда offersData реально стал "
+        + "пустым и загрузка уже завершилась — не только во время загрузки, для которой кэш и задумывался; "
+        + "карта продолжала показывать результаты предыдущего запроса, а новое пустое уведомление не "
+        + "успевало сработать, потому что features так и не становился пустым)", async () => {
+        const { rerender } = render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+
+        rerender(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading={false}
+            />,
+        );
+
+        // ObjectManager рендерится только при features.length > 0 — при реально
+        // пустом результате он должен размонтироваться (а не остаться висеть со
+        // старым содержимым), поэтому проверяем именно его отсутствие в дереве.
+        await waitFor(() => expect(screen.queryByTestId("object-manager")).not.toBeInTheDocument());
+        expect(screen.getByText("По вашему запросу вакансий на карте не найдено")).toBeInTheDocument();
+    });
+
     it("показывает отдельное сообщение об ошибке (не «вакансий не найдено»), если загрузка маркеров упала, "
         + "и кнопка «Попробовать снова» вызывает onRetry", async () => {
         const onRetry = vi.fn();

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -110,7 +110,10 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const reloadPageText = t("Обновить страницу");
 
     const features = useMemo(() => {
-        if (isOffersLoading || !offersData.length) return lastFeaturesRef.current;
+        // Не путать "ещё грузится" с "загрузилось и оказалось пусто" — во втором
+        // случае нужно реально очистить карту (и дать сработать пустому
+        // уведомлению), а не бесконечно показывать маркеры предыдущего запроса.
+        if (isOffersLoading) return lastFeaturesRef.current;
 
         const relevantOffers = offersData
             .filter((offer) => typeof offer.latitude === "number" && typeof offer.longitude === "number");


### PR DESCRIPTION
## Summary
Found while live-verifying #507 on staging: searching for a nonexistent query correctly emptied the offers list but the map kept showing all the old markers/clusters. Root cause is a pre-existing anti-flicker cache in `OffersMap`'s `features` memo (from #464) that returned the previous marker set whenever `offersData` was empty — not distinguishing "still loading" (where reusing stale markers is correct, avoids flicker) from "loaded and confirmed empty" (where the map should actually clear). Since `features` never became empty, the new empty-map notice from #507 could never trigger either.

Fix: only reuse the stale features cache while `isOffersLoading` is true.

## Test plan
- [x] New regression test in `OffersMap.test.tsx`: render with 1 offer, rerender with `offersData=[]`, assert `ObjectManager` unmounts (markers cleared) and the empty notice shows
- [x] revert-and-confirm-fails: new test fails without the fix
- [x] `npx vitest run` — 366/366 passing
- [x] lint/tsc clean
- [ ] Live-verify on staging: search for a nonsense query, confirm the map actually clears and shows "По вашему запросу вакансий на карте не найдено"

🤖 Generated with [Claude Code](https://claude.com/claude-code)