### PR TITLE
fix(GS-114): stop double-loading Yandex Maps SDK (nested <YMaps> race)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,8 +19,7 @@ export const App: FC = () => {
     return (
         <YMaps query={{
             apikey: import.meta.env.VITE_API_YANDEX_KEY,
-            ns: "use-load-option",
-            load: "Map,Placemark,control.ZoomControl,geocode,geoObject.addon.hint",
+            load: "package.full",
         }}
         >
             <div className="app app_default_theme">

--- a/src/widgets/Donation/DonationsMap/DonationsMap.tsx
+++ b/src/widgets/Donation/DonationsMap/DonationsMap.tsx
@@ -1,5 +1,5 @@
 import {
-    Map, ObjectManager, YMaps,
+    Map, ObjectManager,
 } from "@pbe/react-yandex-maps";
 import cn from "classnames";
 import React, {
@@ -91,75 +91,73 @@ export const DonationsMap: FC<DonationsMapProps> = memo((props: DonationsMapProp
 
     return (
         <div className={cn(className, styles.wrapper)}>
-            <YMaps query={{ apikey: import.meta.env.VITE_API_YANDEX_KEY, load: "package.full" }}>
-                <Map
-                    defaultState={{
-                        center: [50, 50], zoom: 2.05, controls: ["zoomControl"],
-                    }}
-                    width="100%"
-                    height="100%"
-                    instanceRef={mapRef}
-                    options={{
-                        suppressMapOpenBlock: true,
-                        restrictMapArea: [
-                            [83.23618, -178.9],
-                            [-73.87011, 181],
-                        ],
-                        maxZoom: 18,
-                        copyrightProvidersVisible: false,
-                        copyrightLogoVisible: false,
-                        copyrightUaVisible: false,
-                        yandexMapDisablePoiInteractivity: false,
-                        suppressObsoleteBrowserNotifier: false,
-                    }}
-                    onLoad={(ymap) => {
-                        setYmapState(ymap);
-                    }}
-                    className={cn(styles.map, classNameMap)}
-                >
-                    {(ymapState && (features.length > 0)) && (
-                        <ObjectManager
-                            instanceRef={objectManagerRef}
-                            features={features}
-                            options={{
-                                clusterize: true,
-                                gridSize: 64,
-                            }}
-                            objects={{
-                                openBalloonOnClick: true,
-                            }}
-                            clusters={{
-                                iconLayout: "default#imageWithContent",
-                                clusterIconLayout: ymapState.templateLayoutFactory.createClass(
-                                    `<div class="${styles.customClusterIcon}">
-                                        {{ properties.geoObjects.length }}
-                                    </div>`,
-                                ),
-                                clusterIconShape: {
-                                    type: "Circle",
-                                    coordinates: [20, 20],
-                                    radius: 20,
-                                },
-                                clusterIconSize: [40, 40],
-                                clusterIconOffset: [-20, -20],
-                                clusterBalloonContentLayout: ymapState.templateLayoutFactory.createClass(`
-                            <div class="${styles.clusterBalloon}">
-                                <h3>Список вакансий:</h3>
-                                <ul>
-                                    {% for geoObject in properties.geoObjects %}
-                                        <li> <a href="{{geoObject.properties.url}}">{{ geoObject.properties.name }}</a></li>
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                        `),
-                                clusterBalloonPanelMaxMapArea: Infinity,
-                                clusterBalloonContentLayoutHeight: 200,
-                            }}
+            <Map
+                defaultState={{
+                    center: [50, 50], zoom: 2.05, controls: ["zoomControl"],
+                }}
+                width="100%"
+                height="100%"
+                instanceRef={mapRef}
+                options={{
+                    suppressMapOpenBlock: true,
+                    restrictMapArea: [
+                        [83.23618, -178.9],
+                        [-73.87011, 181],
+                    ],
+                    maxZoom: 18,
+                    copyrightProvidersVisible: false,
+                    copyrightLogoVisible: false,
+                    copyrightUaVisible: false,
+                    yandexMapDisablePoiInteractivity: false,
+                    suppressObsoleteBrowserNotifier: false,
+                }}
+                onLoad={(ymap) => {
+                    setYmapState(ymap);
+                }}
+                className={cn(styles.map, classNameMap)}
+            >
+                {(ymapState && (features.length > 0)) && (
+                    <ObjectManager
+                        instanceRef={objectManagerRef}
+                        features={features}
+                        options={{
+                            clusterize: true,
+                            gridSize: 64,
+                        }}
+                        objects={{
+                            openBalloonOnClick: true,
+                        }}
+                        clusters={{
+                            iconLayout: "default#imageWithContent",
+                            clusterIconLayout: ymapState.templateLayoutFactory.createClass(
+                                `<div class="${styles.customClusterIcon}">
+                                    {{ properties.geoObjects.length }}
+                                </div>`,
+                            ),
+                            clusterIconShape: {
+                                type: "Circle",
+                                coordinates: [20, 20],
+                                radius: 20,
+                            },
+                            clusterIconSize: [40, 40],
+                            clusterIconOffset: [-20, -20],
+                            clusterBalloonContentLayout: ymapState.templateLayoutFactory.createClass(`
+                        <div class="${styles.clusterBalloon}">
+                            <h3>Список вакансий:</h3>
+                            <ul>
+                                {% for geoObject in properties.geoObjects %}
+                                    <li> <a href="{{geoObject.properties.url}}">{{ geoObject.properties.name }}</a></li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    `),
+                            clusterBalloonPanelMaxMapArea: Infinity,
+                            clusterBalloonContentLayoutHeight: 200,
+                        }}
 
-                        />
-                    )}
-                </Map>
-            </YMaps>
+                    />
+                )}
+            </Map>
         </div>
     );
 });

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -1,5 +1,5 @@
 import {
-    Map, ObjectManager, YMaps, ZoomControl,
+    Map, ObjectManager, ZoomControl,
 } from "@pbe/react-yandex-maps";
 import cn from "classnames";
 import React, {
@@ -447,84 +447,82 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
             {showNoLocationNotice && (
                 <div className={styles.noLocationNotice}>{noLocationText}</div>
             )}
-            <YMaps query={{ apikey: import.meta.env.VITE_API_YANDEX_KEY, load: "package.full" }}>
-                <Map
-                    defaultState={{
-                        center: [50, 50], zoom: 2.05, controls: [],
-                    }}
-                    width="100%"
-                    height="100%"
-                    instanceRef={mapRef}
-                    options={{
-                        suppressMapOpenBlock: true,
-                        restrictMapArea: [
-                            [83.23618, -178.9],
-                            [-73.87011, 181],
-                        ],
-                        maxZoom: 18,
-                        copyrightProvidersVisible: false,
-                        copyrightLogoVisible: false,
-                        copyrightUaVisible: false,
-                        yandexMapDisablePoiInteractivity: false,
-                        suppressObsoleteBrowserNotifier: false,
-                    }}
-                    onLoad={(ymap) => {
-                        setYmapState(ymap);
-                    }}
-                    // react-yandex-maps сам оборачивает Map в Error Boundary —
-                    // без onError падение внутри неё (например, сбой самого
-                    // Яндекс.Карт SDK при рендере) тихо съедалось бы этим
-                    // boundary, и карта осталась бы пустым местом без единого
-                    // сигнала. Переиспользуем тот же оверлей, что и для
-                    // тайм-аута загрузки — с точки зрения пользователя это
-                    // один и тот же "карта не работает".
-                    onError={() => setMapLoadTimedOut(true)}
-                    className={cn(styles.map, classNameMap)}
-                >
-                    <ZoomControl options={{ position: { right: 10, top: 10 } }} />
-                    {(ymapState && (features.length > 0)) && (
-                        <ObjectManager
-                            instanceRef={objectManagerRef}
-                            features={features}
-                            options={{
-                                clusterize: true,
-                                gridSize: 64,
-                            }}
-                            objects={{
-                                openBalloonOnClick: true,
-                            }}
-                            clusters={{
-                                iconLayout: "default#imageWithContent",
-                                clusterIconLayout: ymapState.templateLayoutFactory.createClass(
-                                    `<div class="${styles.customClusterIcon}">
-                                        {{ properties.geoObjects.length }}
-                                    </div>`,
-                                ),
-                                clusterIconShape: {
-                                    type: "Circle",
-                                    coordinates: [20, 20],
-                                    radius: 20,
-                                },
-                                clusterIconSize: [40, 40],
-                                clusterIconOffset: [-20, -20],
-                                clusterBalloonContentLayout: ymapState.templateLayoutFactory.createClass(`
-                            <div class="${styles.clusterBalloon}">
-                                <h3>${vacancyListTitle}</h3>
-                                <ul>
-                                    {% for geoObject in properties.geoObjects %}
-                                        <li> <a href="{{geoObject.properties.url}}">{{ geoObject.properties.name }}</a></li>
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                        `),
-                                clusterBalloonPanelMaxMapArea: Infinity,
-                                clusterBalloonContentLayoutHeight: 200,
-                            }}
+            <Map
+                defaultState={{
+                    center: [50, 50], zoom: 2.05, controls: [],
+                }}
+                width="100%"
+                height="100%"
+                instanceRef={mapRef}
+                options={{
+                    suppressMapOpenBlock: true,
+                    restrictMapArea: [
+                        [83.23618, -178.9],
+                        [-73.87011, 181],
+                    ],
+                    maxZoom: 18,
+                    copyrightProvidersVisible: false,
+                    copyrightLogoVisible: false,
+                    copyrightUaVisible: false,
+                    yandexMapDisablePoiInteractivity: false,
+                    suppressObsoleteBrowserNotifier: false,
+                }}
+                onLoad={(ymap) => {
+                    setYmapState(ymap);
+                }}
+                // react-yandex-maps сам оборачивает Map в Error Boundary —
+                // без onError падение внутри неё (например, сбой самого
+                // Яндекс.Карт SDK при рендере) тихо съедалось бы этим
+                // boundary, и карта осталась бы пустым местом без единого
+                // сигнала. Переиспользуем тот же оверлей, что и для
+                // тайм-аута загрузки — с точки зрения пользователя это
+                // один и тот же "карта не работает".
+                onError={() => setMapLoadTimedOut(true)}
+                className={cn(styles.map, classNameMap)}
+            >
+                <ZoomControl options={{ position: { right: 10, top: 10 } }} />
+                {(ymapState && (features.length > 0)) && (
+                    <ObjectManager
+                        instanceRef={objectManagerRef}
+                        features={features}
+                        options={{
+                            clusterize: true,
+                            gridSize: 64,
+                        }}
+                        objects={{
+                            openBalloonOnClick: true,
+                        }}
+                        clusters={{
+                            iconLayout: "default#imageWithContent",
+                            clusterIconLayout: ymapState.templateLayoutFactory.createClass(
+                                `<div class="${styles.customClusterIcon}">
+                                    {{ properties.geoObjects.length }}
+                                </div>`,
+                            ),
+                            clusterIconShape: {
+                                type: "Circle",
+                                coordinates: [20, 20],
+                                radius: 20,
+                            },
+                            clusterIconSize: [40, 40],
+                            clusterIconOffset: [-20, -20],
+                            clusterBalloonContentLayout: ymapState.templateLayoutFactory.createClass(`
+                        <div class="${styles.clusterBalloon}">
+                            <h3>${vacancyListTitle}</h3>
+                            <ul>
+                                {% for geoObject in properties.geoObjects %}
+                                    <li> <a href="{{geoObject.properties.url}}">{{ geoObject.properties.name }}</a></li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    `),
+                            clusterBalloonPanelMaxMapArea: Infinity,
+                            clusterBalloonContentLayoutHeight: 200,
+                        }}
 
-                        />
-                    )}
-                </Map>
-            </YMaps>
+                    />
+                )}
+            </Map>
         </div>
     );
 });


### PR DESCRIPTION
## Summary
Root cause of the live bug reported after #507/#508: `App.tsx` wraps the whole app in one `<YMaps ns="use-load-option" load="Map,Placemark,...">`, but `OffersMap.tsx` and `DonationsMap.tsx` each additionally mounted their own second `<YMaps load="package.full">` (default/different namespace) directly inside it.

`react-yandex-maps` tracks script-load state per namespace — mismatched `ns` between the two nested providers means the library injects **two independent** `<script src="https://api-maps.yandex.ru/...">` tags. When the map widget mounts immediately on page load (e.g. a direct link with `?offerId=...`, which opens the map tab right away), both scripts load and initialize concurrently and corrupt the SDK's own bundle loader — reproducibly (2/2) throwing `Uncaught TypeError: Cannot read properties of undefined (reading '__provideBundle')` from inside the Yandex Maps bundle itself, leaving the marker invisible or the whole map crashed.

Fix: removed the nested `<YMaps>` providers from `OffersMap.tsx` and `DonationsMap.tsx` — they now rely on the single app-level `<YMaps>` context, whose `load` list is widened to `"package.full"` to cover what the child widgets need (ObjectManager, Clusterer, etc. — previously missing from the narrower top-level list).

GS-114: https://linear.app/voknil/issue/GS-114/karta-dvojnaya-zagruzka-yandekskart-sdk-lomaet-vidzhet-krashnevidimyj

## Test plan
- [x] `npx vitest run` — 366/366 passing
- [x] lint/tsc clean
- [x] Reproduced live on prod (2/2 loads of `?offerId=7204` crashed with the SDK error; confirmed disappears without `offerId` — consistent with a mount-timing race)
- [ ] Live-verify on staging: repeat `?offerId=...` deep link multiple times, confirm marker renders and no crash
- [ ] Live-verify on staging: drag/pan the map repeatedly, confirm no flicker regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)