### PR TITLE
fix(GS-114): keep marker visible while its balloon is open (deep-link)

### DIFF
--- a/src/widgets/Donation/DonationsMap/DonationsMap.tsx
+++ b/src/widgets/Donation/DonationsMap/DonationsMap.tsx
@@ -126,6 +126,9 @@ export const DonationsMap: FC<DonationsMapProps> = memo((props: DonationsMapProp
                         }}
                         objects={{
                             openBalloonOnClick: true,
+                            // Яндекс.Карты по умолчанию скрывают иконку маркера, пока
+                            // открыт его balloon — см. тот же фикс в OffersMap.tsx.
+                            hideIconOnBalloonOpen: false,
                         }}
                         clusters={{
                             iconLayout: "default#imageWithContent",

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -17,6 +17,7 @@ const onLoadCalls = vi.fn();
 const balloonOpen = vi.fn().mockResolvedValue(undefined);
 const getById = vi.fn((): object | undefined => ({}));
 let capturedFeatures: any[] = [];
+let capturedObjectsOptions: Record<string, unknown> | undefined;
 // Тесты на тайм-аут/onError загрузки карты не должны давать моку Map
 // самому вызывать onLoad — иначе карта "успевает" загрузиться раньше, чем
 // успеет сработать проверяемое поведение.
@@ -67,9 +68,14 @@ vi.mock("@pbe/react-yandex-maps", () => ({
     },
     ZoomControl: () => null,
     // eslint-disable-next-line react/no-unused-prop-types
-    ObjectManager: (props: { features: unknown[]; instanceRef?: { current: unknown } }) => {
-        const { features, instanceRef } = props;
+    ObjectManager: (props: {
+        features: unknown[];
+        instanceRef?: { current: unknown };
+        objects?: Record<string, unknown>;
+    }) => {
+        const { features, instanceRef, objects } = props;
         capturedFeatures = features;
+        capturedObjectsOptions = objects;
         if (instanceRef) {
             instanceRef.current = { objects: { balloon: { open: balloonOpen }, getById } };
         }
@@ -100,6 +106,7 @@ describe("OffersMap", () => {
         getById.mockImplementation(() => ({}));
         boundsChangeHandlers.length = 0;
         capturedFeatures = [];
+        capturedObjectsOptions = undefined;
         skipAutoLoad = false;
         capturedOnError = undefined;
     });
@@ -651,6 +658,21 @@ describe("OffersMap", () => {
         // старым содержимым), поэтому проверяем именно его отсутствие в дереве.
         await waitFor(() => expect(screen.queryByTestId("object-manager")).not.toBeInTheDocument());
         expect(screen.getByText("По вашему запросу вакансий на карте не найдено")).toBeInTheDocument();
+    });
+
+    it("отключает hideIconOnBalloonOpen у ObjectManager (регресс: Яндекс.Карты по умолчанию скрывают иконку "
+        + "маркера, пока открыт его balloon — при заходе по прямой ссылке на вакансию balloon открывается "
+        + "программно сразу же, и без этого флага маркер оставался невидимым, пока пользователь сам не "
+        + "закрывал balloon вручную)", async () => {
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedObjectsOptions).toBeDefined());
+        expect(capturedObjectsOptions?.hideIconOnBalloonOpen).toBe(false);
     });
 
     it("показывает отдельное сообщение об ошибке (не «вакансий не найдено»), если загрузка маркеров упала, "

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -491,6 +491,14 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                         }}
                         objects={{
                             openBalloonOnClick: true,
+                            // Яндекс.Карты по умолчанию скрывают иконку маркера, пока
+                            // открыт его balloon (hideIconOnBalloonOpen: true) — обычно
+                            // незаметно, т.к. balloon перекрывает то же место. Но при
+                            // заходе по прямой ссылке на конкретную вакансию balloon
+                            // открывается программно сразу при загрузке карты, и без
+                            // этого флага маркер остаётся невидимым навсегда, пока
+                            // пользователь сам не закроет balloon вручную.
+                            hideIconOnBalloonOpen: false,
                         }}
                         clusters={{
                             iconLayout: "default#imageWithContent",


### PR DESCRIPTION
## Summary
Second, independent root cause behind the invisible-marker bug (on top of #509's double-YMaps race). Confirmed live on staging: closing the balloon manually made the marker's colored circle appear instantly — the icon was being built correctly all along, just hidden.

Yandex Maps' ObjectManager `objects` config defaults `hideIconOnBalloonOpen` to `true`. Normally invisible since the balloon covers the same spot the marker would be — but a direct link to a vacancy (`?offerId=...`) opens the balloon programmatically as soon as the map loads, so the marker is hidden from the very first frame and stays that way until the user manually closes the balloon.

Fix: explicit `hideIconOnBalloonOpen: false` on both `OffersMap` and `DonationsMap` (same ObjectManager config pattern in both).

## Test plan
- [x] New regression test: renders OffersMap, asserts `ObjectManager`'s `objects.hideIconOnBalloonOpen === false`
- [x] revert-and-confirm-fails: test fails without the fix
- [x] `npx vitest run` — 367/367 passing
- [x] lint/tsc clean
- [ ] Live-verify on staging: `?offerId=...` deep link shows the marker immediately, no manual balloon-close needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)