### PR TITLE
fix(GS-114): memoize ObjectManager props to stop flash on every map movement

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -18,6 +18,8 @@ const balloonOpen = vi.fn().mockResolvedValue(undefined);
 const getById = vi.fn((): object | undefined => ({}));
 let capturedFeatures: any[] = [];
 let capturedObjectsOptions: Record<string, unknown> | undefined;
+let capturedOptionsProp: Record<string, unknown> | undefined;
+let capturedClustersProp: Record<string, unknown> | undefined;
 // Тесты на тайм-аут/onError загрузки карты не должны давать моку Map
 // самому вызывать onLoad — иначе карта "успевает" загрузиться раньше, чем
 // успеет сработать проверяемое поведение.
@@ -76,10 +78,16 @@ vi.mock("@pbe/react-yandex-maps", () => ({
     ObjectManager: (props: {
         instanceRef?: { current: unknown } | ((instance: unknown) => void);
         objects?: Record<string, unknown>;
+        options?: Record<string, unknown>;
+        clusters?: Record<string, unknown>;
     }) => {
-        const { instanceRef, objects } = props;
+        const {
+            instanceRef, objects, options, clusters,
+        } = props;
         const [mounted, setMounted] = useState<any[]>([]);
         capturedObjectsOptions = objects;
+        capturedOptionsProp = options;
+        capturedClustersProp = clusters;
 
         // useLayoutEffect (не useEffect) — реальный react-yandex-maps
         // регистрирует инстанс синхронно в componentDidMount, т.е. раньше,
@@ -138,6 +146,8 @@ describe("OffersMap", () => {
         boundsChangeHandlers.length = 0;
         capturedFeatures = [];
         capturedObjectsOptions = undefined;
+        capturedOptionsProp = undefined;
+        capturedClustersProp = undefined;
         skipAutoLoad = false;
         capturedOnError = undefined;
     });
@@ -676,6 +686,39 @@ describe("OffersMap", () => {
         // ObjectManager делал remove()+add() по всей коллекции (старое
         // поведение), это был бы новый объект и тест бы упал.
         expect(capturedFeatures.find((f: any) => f.id === "2")).toBe(unchangedFeature);
+    });
+
+    it("держит те же ссылки на options/objects/clusters у ObjectManager между рендерами (регресс: инлайновые "
+        + "объектные литералы в JSX пересоздаются на КАЖДЫЙ рендер компонента, включая каждое движение карты "
+        + "— react-yandex-maps сравнивает эти пропы по ссылке и на любое изменение зовёт .options.set() на "
+        + "реальном инстансе, из-за чего кластеры на мгновение сбрасывались к дефолтному белому кружку без "
+        + "цвета и тут же перерисовывались обратно — видимое моргание при любом движении карты, а не только "
+        + "при реальном изменении набора маркеров)", async () => {
+        const { rerender } = render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(capturedOptionsProp).toBeDefined());
+        const firstOptions = capturedOptionsProp;
+        const firstObjects = capturedObjectsOptions;
+        const firstClusters = capturedClustersProp;
+
+        // Ре-рендер с абсолютно тем же содержимым — именно так выглядит любое
+        // движение карты, которое не меняет набор маркеров (bounds ещё не
+        // успели дебаунситься/дойти до бэкенда).
+        rerender(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        expect(capturedOptionsProp).toBe(firstOptions);
+        expect(capturedObjectsOptions).toBe(firstObjects);
+        expect(capturedClustersProp).toBe(firstClusters);
     });
 
     it("строит маркер с реальным iconContentLayout (не пустым), даже если offersData уже пришли ДО того, "

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -25,6 +25,40 @@ const FOCUS_ZOOM = 10;
 const BOUNDS_CHANGE_DEBOUNCE_MS = 400;
 const MAP_LOAD_TIMEOUT_MS = 15_000;
 
+// Модульные константы, а не инлайновые объекты в JSX — react-yandex-maps
+// сравнивает props объекта ObjectManager (options/objects/clusters) ПО
+// ССЫЛКЕ и на любое изменение зовёт .options.set() на реальном инстансе.
+// Инлайновый литерал в JSX создаёт новую ссылку на КАЖДЫЙ рендер компонента
+// (а он перерендеривается при каждом движении карты), из-за чего кластеры
+// и маркеры на мгновение сбрасывались к дефолтному виду (белый кружок без
+// цвета) и тут же перерисовывались обратно — то самое видимое моргание при
+// любом движении карты, а не только при реальном изменении набора маркеров.
+const OBJECT_MANAGER_OPTIONS = { clusterize: true, gridSize: 64 };
+const OBJECT_MANAGER_OBJECTS = {
+    openBalloonOnClick: true,
+    // Яндекс.Карты по умолчанию скрывают иконку маркера, пока открыт его
+    // balloon (hideIconOnBalloonOpen: true) — обычно незаметно, т.к. balloon
+    // перекрывает то же место. Но при заходе по прямой ссылке на конкретную
+    // вакансию balloon открывается программно сразу при загрузке карты, и
+    // без этого флага маркер остаётся невидимым навсегда, пока пользователь
+    // сам не закроет balloon вручную.
+    hideIconOnBalloonOpen: false,
+};
+const MAP_OPTIONS = {
+    suppressMapOpenBlock: true,
+    restrictMapArea: [
+        [83.23618, -178.9],
+        [-73.87011, 181],
+    ],
+    maxZoom: 18,
+    copyrightProvidersVisible: false,
+    copyrightLogoVisible: false,
+    copyrightUaVisible: false,
+    yandexMapDisablePoiInteractivity: false,
+    suppressObsoleteBrowserNotifier: false,
+};
+const ZOOM_CONTROL_OPTIONS = { position: { right: 10, top: 10 } };
+
 export interface MapViewportBounds {
     boundsSwLat: number;
     boundsSwLng: number;
@@ -470,6 +504,38 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const showEmptyNotice = !isOffersError && !isOffersLoading
         && !!ymapState && features.length === 0;
 
+    // См. комментарий у OBJECT_MANAGER_OPTIONS/OBJECT_MANAGER_OBJECTS выше —
+    // тот же принцип: без useMemo этот объект (и вложенные createClass())
+    // пересоздавался бы на каждый рендер, и клaстеры мигали бы дефолтной
+    // иконкой при любом движении карты, даже если реально ничего не менялось.
+    const clusters = useMemo(() => (ymapState?.templateLayoutFactory ? {
+        iconLayout: "default#imageWithContent",
+        clusterIconLayout: ymapState.templateLayoutFactory.createClass(
+            `<div class="${styles.customClusterIcon}">
+                {{ properties.geoObjects.length }}
+            </div>`,
+        ),
+        clusterIconShape: {
+            type: "Circle",
+            coordinates: [20, 20],
+            radius: 20,
+        },
+        clusterIconSize: [40, 40],
+        clusterIconOffset: [-20, -20],
+        clusterBalloonContentLayout: ymapState.templateLayoutFactory.createClass(`
+            <div class="${styles.clusterBalloon}">
+                <h3>${vacancyListTitle}</h3>
+                <ul>
+                    {% for geoObject in properties.geoObjects %}
+                        <li> <a href="{{geoObject.properties.url}}">{{ geoObject.properties.name }}</a></li>
+                    {% endfor %}
+                </ul>
+            </div>
+        `),
+        clusterBalloonPanelMaxMapArea: Infinity,
+        clusterBalloonContentLayoutHeight: 200,
+    } : undefined), [ymapState?.templateLayoutFactory, vacancyListTitle]);
+
     return (
         <div className={cn(className, styles.wrapper)}>
             {mapLoadTimedOut && (
@@ -521,19 +587,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 width="100%"
                 height="100%"
                 instanceRef={mapRef}
-                options={{
-                    suppressMapOpenBlock: true,
-                    restrictMapArea: [
-                        [83.23618, -178.9],
-                        [-73.87011, 181],
-                    ],
-                    maxZoom: 18,
-                    copyrightProvidersVisible: false,
-                    copyrightLogoVisible: false,
-                    copyrightUaVisible: false,
-                    yandexMapDisablePoiInteractivity: false,
-                    suppressObsoleteBrowserNotifier: false,
-                }}
+                options={MAP_OPTIONS}
                 onLoad={(ymap) => {
                     setYmapState(ymap);
                 }}
@@ -547,54 +601,14 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 onError={() => setMapLoadTimedOut(true)}
                 className={cn(styles.map, classNameMap)}
             >
-                <ZoomControl options={{ position: { right: 10, top: 10 } }} />
-                {(ymapState && (features.length > 0)) && (
+                <ZoomControl options={ZOOM_CONTROL_OPTIONS} />
+                {(ymapState && clusters && (features.length > 0)) && (
                     <ObjectManager
                         instanceRef={setObjectManagerRef}
                         features={objectManagerFeaturesSeedRef.current}
-                        options={{
-                            clusterize: true,
-                            gridSize: 64,
-                        }}
-                        objects={{
-                            openBalloonOnClick: true,
-                            // Яндекс.Карты по умолчанию скрывают иконку маркера, пока
-                            // открыт его balloon (hideIconOnBalloonOpen: true) — обычно
-                            // незаметно, т.к. balloon перекрывает то же место. Но при
-                            // заходе по прямой ссылке на конкретную вакансию balloon
-                            // открывается программно сразу при загрузке карты, и без
-                            // этого флага маркер остаётся невидимым навсегда, пока
-                            // пользователь сам не закроет balloon вручную.
-                            hideIconOnBalloonOpen: false,
-                        }}
-                        clusters={{
-                            iconLayout: "default#imageWithContent",
-                            clusterIconLayout: ymapState.templateLayoutFactory.createClass(
-                                `<div class="${styles.customClusterIcon}">
-                                    {{ properties.geoObjects.length }}
-                                </div>`,
-                            ),
-                            clusterIconShape: {
-                                type: "Circle",
-                                coordinates: [20, 20],
-                                radius: 20,
-                            },
-                            clusterIconSize: [40, 40],
-                            clusterIconOffset: [-20, -20],
-                            clusterBalloonContentLayout: ymapState.templateLayoutFactory.createClass(`
-                        <div class="${styles.clusterBalloon}">
-                            <h3>${vacancyListTitle}</h3>
-                            <ul>
-                                {% for geoObject in properties.geoObjects %}
-                                    <li> <a href="{{geoObject.properties.url}}">{{ geoObject.properties.name }}</a></li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                    `),
-                            clusterBalloonPanelMaxMapArea: Infinity,
-                            clusterBalloonContentLayoutHeight: 200,
-                        }}
-
+                        options={OBJECT_MANAGER_OPTIONS}
+                        objects={OBJECT_MANAGER_OBJECTS}
+                        clusters={clusters}
                     />
                 )}
             </Map>


### PR DESCRIPTION
## Summary
Found by taking frame-by-frame screenshots during a live drag on staging: right after a pan settles, cluster icons briefly render as plain white circles (Yandex's default) before their custom colored template reapplies ~300ms later — a visible flash on **every single map movement**, not just when the marker set actually changes.

Root cause: `options`/`objects`/`clusters` were passed to `<ObjectManager>` (and `options` to `<Map>`) as inline object literals in JSX. `react-yandex-maps` compares these props **by reference** and calls the real ObjectManager's `.options.set()` whenever the reference changes — which is every render, since JSX literals get a fresh object identity each time, and `clusters` additionally called `templateLayoutFactory.createClass()` fresh each render too. `OffersMap` re-renders on every bounds change (i.e. every pan), so this fired constantly, forcing Yandex to briefly reset cluster icons to their default appearance and repaint.

Fix: hoisted the fully-static configs to module-level constants and wrapped the `ymapState`-dependent `clusters` config in `useMemo`, so these props keep the same reference across renders unless their actual inputs change.

## Test plan
- [x] New regression test: asserts `options`/`objects`/`clusters` props passed to `ObjectManager` stay the exact same reference across a re-render with unrelated/unchanged props
- [x] revert-and-confirm-fails: test fails without the fix
- [x] `npx vitest run` — 369/369 passing
- [x] lint/tsc clean
- [ ] Live-verify on staging: frame-by-frame screenshot during a drag, confirm no white-flash on cluster icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)