### PR TITLE
fix(GS-114): stop ObjectManager permanently failing to mount deep-link marker

### DIFF
--- a/src/widgets/Donation/DonationsMap/DonationsMap.tsx
+++ b/src/widgets/Donation/DonationsMap/DonationsMap.tsx
@@ -69,7 +69,11 @@ export const DonationsMap: FC<DonationsMapProps> = memo((props: DonationsMapProp
                     },
                     options: {
                         iconLayout: "default#imageWithContent",
-                        iconContentLayout: ymapState?.templateLayoutFactory.createClass(
+                        // Второй ?. обязателен: ymapState может быть truthy
+                        // (onLoad уже сработал), но templateLayoutFactory
+                        // на нём — ещё нет. Без него .createClass бросал бы
+                        // TypeError прямо во время рендера.
+                        iconContentLayout: ymapState?.templateLayoutFactory?.createClass(
                             `<div style="background-color: ${categoryColor || "var(--accent-color)"};" class="${styles.customPlacemarkIcon}"></div>`,
                         ),
                         iconImageSize: [30, 30],
@@ -132,7 +136,12 @@ export const DonationsMap: FC<DonationsMapProps> = memo((props: DonationsMapProp
                         }}
                         clusters={{
                             iconLayout: "default#imageWithContent",
-                            clusterIconLayout: ymapState.templateLayoutFactory.createClass(
+                            // ?. на templateLayoutFactory обязателен: ymapState
+                            // здесь уже точно truthy, но само
+                            // templateLayoutFactory на нём может быть ещё не
+                            // готово — без него .createClass бросал бы
+                            // TypeError прямо во время рендера, роняя всю карту.
+                            clusterIconLayout: ymapState.templateLayoutFactory?.createClass(
                                 `<div class="${styles.customClusterIcon}">
                                     {{ properties.geoObjects.length }}
                                 </div>`,
@@ -144,7 +153,7 @@ export const DonationsMap: FC<DonationsMapProps> = memo((props: DonationsMapProp
                             },
                             clusterIconSize: [40, 40],
                             clusterIconOffset: [-20, -20],
-                            clusterBalloonContentLayout: ymapState.templateLayoutFactory.createClass(`
+                            clusterBalloonContentLayout: ymapState.templateLayoutFactory?.createClass(`
                         <div class="${styles.clusterBalloon}">
                             <h3>Список вакансий:</h3>
                             <ul>

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -25,6 +25,9 @@ let capturedClustersProp: Record<string, unknown> | undefined;
 // успеет сработать проверяемое поведение.
 let skipAutoLoad = false;
 let capturedOnError: (() => void) | undefined;
+// Симулирует GS-112/GS-114-race: onLoad карты срабатывает, но
+// templateLayoutFactory ещё не готов на этом же тике.
+let onLoadWithoutTemplateFactory = false;
 
 vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
@@ -63,7 +66,9 @@ vi.mock("@pbe/react-yandex-maps", () => ({
         useEffect(() => {
             if (skipAutoLoad) return;
             onLoadCalls();
-            onLoad?.({ templateLayoutFactory: { createClass: () => "layout-class-sentinel" } });
+            onLoad?.(onLoadWithoutTemplateFactory
+                ? {}
+                : { templateLayoutFactory: { createClass: () => "layout-class-sentinel" } });
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }, []);
         return <div>{children}</div>;
@@ -150,6 +155,7 @@ describe("OffersMap", () => {
         capturedClustersProp = undefined;
         skipAutoLoad = false;
         capturedOnError = undefined;
+        onLoadWithoutTemplateFactory = false;
     });
 
     it("фокусирует карту, если у выбранной вакансии известны координаты", () => {
@@ -719,6 +725,26 @@ describe("OffersMap", () => {
         expect(capturedOptionsProp).toBe(firstOptions);
         expect(capturedObjectsOptions).toBe(firstObjects);
         expect(capturedClustersProp).toBe(firstClusters);
+    });
+
+    it("монтирует ObjectManager (и показывает маркер), даже если templateLayoutFactory ещё не готов в момент "
+        + "onLoad карты (регресс: мемоизированный clusters временно вычисляется как undefined, пока фабрика не "
+        + "готова — если условие монтирования ObjectManager зависит от truthy clusters, а не только от "
+        + "ymapState/features, виджет мог навсегда остаться немонтированным без единой ошибки, потому что "
+        + "ymapState как ссылка на объект после onLoad больше не меняется и без ДРУГОГО повода для ре-рендера "
+        + "переоценить условие просто нечем — маркер и balloon молча пропадали бы навсегда при заходе по "
+        + "прямой ссылке на вакансию)", async () => {
+        onLoadWithoutTemplateFactory = true;
+        render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(onLoadCalls).toHaveBeenCalled());
+        await waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+        expect(capturedFeatures).toHaveLength(1);
     });
 
     it("строит маркер с реальным iconContentLayout (не пустым), даже если offersData уже пришли ДО того, "

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -218,7 +218,15 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                     },
                     options: {
                         iconLayout: "default#imageWithContent",
-                        iconContentLayout: ymapState?.templateLayoutFactory.createClass(
+                        // Второй ?. здесь обязателен: ymapState может быть truthy
+                        // (onLoad уже сработал), но само templateLayoutFactory —
+                        // ещё нет (см. комментарий у clusters ниже). Без него
+                        // .createClass бросал бы TypeError прямо во время
+                        // рендера, и всё дерево карты падало бы вместо того чтобы
+                        // просто временно остаться без цветной иконки до
+                        // следующего пересчёта (см. |ready"/"|pending" в
+                        // сигнатуре ниже).
+                        iconContentLayout: ymapState?.templateLayoutFactory?.createClass(
                             `<div style="background-color: ${categoryColor || "var(--accent-color)"};" class="${styles.customPlacemarkIcon}"></div>`,
                         ),
                         // Без iconContentSize Яндекс.Карты по умолчанию заводят под
@@ -278,11 +286,21 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const mountedSignaturesRef = useRef<Record<string, string>>({});
     const objectManagerFeaturesSeedRef = useRef<any[]>([]);
 
+    // Триггерим пересчёт эффекта ниже не только при смене features, но и
+    // при (пере)монтировании самого ObjectManager: ymapState появляется
+    // асинхронно (эффект внутри <Map>), поэтому <ObjectManager> нередко
+    // монтируется ПОЗЖЕ первого рендера, на котором features уже посчитан
+    // и получил тот же самый (мемоизированный) объект — без этого тика
+    // эффект ниже не перезапустился бы и свежесмонтированный ObjectManager
+    // остался бы без единого маркера.
+    const [objectManagerMountTick, setObjectManagerMountTick] = useState(0);
+
     const setObjectManagerRef = useCallback((instance: any) => {
         objectManagerRef.current = instance;
         if (instance) {
             mountedFeaturesRef.current = {};
             mountedSignaturesRef.current = {};
+            setObjectManagerMountTick((tick) => tick + 1);
         }
     }, []);
 
@@ -318,7 +336,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
             features.map((feature) => [feature.id, feature]),
         );
         mountedSignaturesRef.current = { ...nextSignatures };
-    }, [features]);
+    }, [features, objectManagerMountTick]);
 
     // Оффер, для которого нужно открыть balloon, как только его маркер
     // реально появится в ObjectManager. null — нечего открывать / уже открыли.
@@ -508,6 +526,15 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     // тот же принцип: без useMemo этот объект (и вложенные createClass())
     // пересоздавался бы на каждый рендер, и клaстеры мигали бы дефолтной
     // иконкой при любом движении карты, даже если реально ничего не менялось.
+    // Намеренно НЕ участвует в условии монтирования ObjectManager ниже (по
+    // аналогии с GS-112: templateLayoutFactory иногда ещё не готов к моменту
+    // onLoad) — если бы монтирование зависело от truthy clusters, и
+    // templateLayoutFactory оказался бы не готов именно на этом рендере,
+    // ObjectManager мог бы навсегда остаться немонтированным: ymapState как
+    // ссылка на объект после onLoad больше не меняется, и без дальнейших
+    // ре-рендеров (например, если пользователь просто открыл карту по прямой
+    // ссылке и не трогал её) переоценить условие было бы просто нечем —
+    // маркер и balloon молча пропадали бы навсегда, без единой ошибки.
     const clusters = useMemo(() => (ymapState?.templateLayoutFactory ? {
         iconLayout: "default#imageWithContent",
         clusterIconLayout: ymapState.templateLayoutFactory.createClass(
@@ -602,7 +629,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 className={cn(styles.map, classNameMap)}
             >
                 <ZoomControl options={ZOOM_CONTROL_OPTIONS} />
-                {(ymapState && clusters && (features.length > 0)) && (
+                {(ymapState && (features.length > 0)) && (
                     <ObjectManager
                         instanceRef={setObjectManagerRef}
                         features={objectManagerFeaturesSeedRef.current}


### PR DESCRIPTION
## Summary
- Fixes a regression introduced by #512: gating `ObjectManager`'s mount condition on the memoized `clusters` value could permanently leave the map marker-less (no error) if `templateLayoutFactory` wasn't ready on the render `ymapState` first became truthy — reproduced live on staging (2/4 fresh `?offerId=7204` loads).
- Fixes an unsafe single `?.` on `ymapState?.templateLayoutFactory.createClass(...)` that throws instead of degrading gracefully; applied the same fix to `DonationsMap.tsx`, which had the identical unsafe pattern (undiscovered until now).
- Fixes a related bug in the incremental `ObjectManager` diff effect (#511): it only re-ran on `features` reference changes, so if `ObjectManager` mounts on a later render than the one where `features` was last computed, the freshly-mounted instance never got populated. Added an `objectManagerMountTick` state bump on mount to the effect's deps.

Full writeup in GS-114 (Linear).

## Test plan
- [x] New regression test reproducing "onLoad fires before templateLayoutFactory is ready" — fails without the fix (`capturedFeatures` length 0), passes with it
- [x] Full `OffersMap.test.tsx` suite (30/30 passing)
- [x] revert-and-confirm-fails on the mount-tick fix specifically
- [x] `npx eslint` + `npx tsc --noEmit -p .` clean
- [ ] Live-verify on staging: repeat `?offerId=7204` fresh loads 5+ times, confirm marker+balloon appear every time