### PR TITLE
fix(GS-114): stop map loading overlay from flashing on every pan

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -330,6 +330,52 @@ describe("OffersMap", () => {
         await waitFor(() => expect(screen.getByTestId("object-manager")).toHaveTextContent("1"));
     });
 
+    it("не показывает оверлей-спиннер поверх карты во время фонового bounds-рефетча, только на самом первом "
+        + "заходе (регресс: isOffersLoading = isLoading || isFetching у родителя, т.е. становится true и на "
+        + "КАЖДОМ последующем bounds-рефетче после pan — оверлей закрывал всю карту полупрозрачным белым на миг "
+        + "при любом движении, хотя сами маркеры уже не терялись благодаря анти-мигающему кэшу)", async () => {
+        const { rerender } = render(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading
+            />,
+        );
+
+        expect(screen.getByRole("progressbar")).toBeInTheDocument();
+
+        rerender(
+            <OffersMap
+                offersData={[offer({ id: 1 }), offer({ id: 2 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId("object-manager")).toHaveTextContent("2"));
+        expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+        // Пользователь подвинул карту -> onBoundsChange -> родитель начал
+        // фоновый bounds-рефетч: isOffersLoading снова true, но карта уже
+        // показывала маркеры раньше — спиннер поверх нее больше не нужен.
+        rerender(
+            <OffersMap
+                offersData={[]}
+                isOffersLoading
+            />,
+        );
+
+        expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+        rerender(
+            <OffersMap
+                offersData={[offer({ id: 3 })]}
+                isOffersLoading={false}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId("object-manager")).toHaveTextContent("1"));
+        expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    });
+
     it("не падает и повторяет попытку, если balloon.open синхронно бросает даже когда объект уже числится в ObjectManager (регресс: getById подтверждал существование объекта раньше, чем его геометрия готова для balloon — пойманное исключение раньше тихо считалось успехом, и табличка так и не появлялась, хотя маркер по прямому клику уже открывался)", async () => {
         balloonOpen.mockImplementationOnce(() => {
             throw new TypeError("Cannot read properties of null (reading 'geometry')");

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -106,6 +106,16 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     const objectManagerRef = useRef<any>(null);
     const onBoundsChangeRef = useRef(onBoundsChange);
     onBoundsChangeRef.current = onBoundsChange;
+    // isOffersLoading — это isLoading || isFetching у родителя, т.е. становится
+    // true не только на самом первом заходе, но и на КАЖДОМ последующем
+    // фоновом рефетче маркеров при bounds-change (после любого pan/zoom).
+    // Сами маркеры уже переживают такой рефетч без моргания (см.
+    // lastFeaturesRef ниже) — а вот оверлей-спиннер ниже раньше показывался
+    // при каждом isOffersLoading===true без разбора, перекрывая всю карту
+    // полупрозрачным белым (.loadingPlaceholder) на миг при любом движении.
+    // Показываем его только пока карта не показала маркеры вообще ни разу.
+    const hasLoadedOnceRef = useRef(false);
+    if (!isOffersLoading) hasLoadedOnceRef.current = true;
 
     useEffect(() => {
         if (ymapState) return undefined;
@@ -596,7 +606,7 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                     </div>
                 </div>
             )}
-            {!mapLoadTimedOut && isOffersLoading && (
+            {!mapLoadTimedOut && isOffersLoading && !hasLoadedOnceRef.current && (
                 <div className={styles.loadingPlaceholder}>
                     <MiniLoader />
                 </div>


### PR DESCRIPTION
## Summary
- The map's semi-transparent `loadingPlaceholder` overlay showed on every `isOffersLoading===true`, but that flag is `isLoading || isFetching` from the parent's RTK Query hook — true on the first load AND on every subsequent background bounds-refetch after a pan/zoom.
- Confirmed via frame-by-frame screenshots on staging: the whole basemap (not just markers) flashes semi-transparent white for ~150ms exactly once after each drag ends, in sync with the 400ms bounds-change debounce.
- Fix: `hasLoadedOnceRef` — once `isOffersLoading` goes false the first time, the overlay never shows again, matching the stale-while-revalidate behavior the markers themselves already had.

Full writeup in GS-114 (Linear).

## Test plan
- [x] New regression test: spinner shows on first load, disappears once markers load, and does NOT reappear during a simulated background bounds-refetch
- [x] Full `OffersMap.test.tsx` suite (31/31 passing)
- [x] revert-and-confirm-fails on the fix
- [x] `npx eslint` + `npx tsc --noEmit -p .` clean
- [ ] Live-verify on staging: drag the map and confirm no white flash