### PR TITLE
fix(GS-115): debounce location-notice flash + fix invisible balloon close button

### DIFF
--- a/src/widgets/Donation/DonationsMap/yandex-map-restyle-ballon.scss
+++ b/src/widgets/Donation/DonationsMap/yandex-map-restyle-ballon.scss
@@ -4,3 +4,20 @@
 .ymaps-2-1-79-b-cluster-content__header {
     display: none !important;
 }
+
+// Тот же фикс, что и в OffersMap.tsx — карточка .balloonWrapper начинается
+// сразу с фото на всю ширину, и дефолтный полупрозрачный (opacity: 0.3)
+// тёмный крестик Яндекса на нём практически не виден. Непрозрачная тёмная
+// подложка-кружок + выбеленный через filter: invert крестик держат контраст
+// независимо от содержимого фото под кнопкой.
+.ymaps-2-1-79-balloon__close-button {
+    opacity: 1 !important;
+    background-color: rgba(0, 0, 0, 0.55) !important;
+    background-size: 10px 10px !important;
+    filter: invert(1);
+    border-radius: 50%;
+    width: 22px !important;
+    height: 22px !important;
+    margin: 8px 8px 0 0;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -194,17 +194,81 @@ describe("OffersMap", () => {
     });
 
     it("показывает подсказку вместо тишины, если координаты точно отсутствуют (null)", () => {
-        render(
-            <OffersMap
-                offersData={[offer({ id: 1 })]}
-                isOffersLoading={false}
-                selectedOfferId={999}
-                selectedOfferCoordinates={null}
-            />,
-        );
+        vi.useFakeTimers();
+        try {
+            render(
+                <OffersMap
+                    offersData={[offer({ id: 1 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={999}
+                    selectedOfferCoordinates={null}
+                />,
+            );
 
-        expect(setCenter).not.toHaveBeenCalled();
-        expect(screen.getByText("У этой вакансии не указано местоположение на карте")).toBeInTheDocument();
+            expect(setCenter).not.toHaveBeenCalled();
+            // Показ уведомления намеренно отложен (см. регресс-тест ниже) —
+            // сразу после рендера его ещё нет.
+            expect(screen.queryByText("У этой вакансии не указано местоположение на карте")).not.toBeInTheDocument();
+
+            act(() => {
+                vi.advanceTimersByTime(350);
+            });
+
+            expect(screen.getByText("У этой вакансии не указано местоположение на карте")).toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("не мигает подсказкой \"нет местоположения\" при переключении на другую вакансию, у которой "
+        + "координаты есть (регресс: selectedOfferCoordinates мог на короткий момент вычислиться как null "
+        + "раньше, чем повторный фоновый рефетч координат страницы в родителе успевал подтвердить реальные "
+        + "координаты — уведомление успевало мигнуть на экране до появления маркера с табличкой)", () => {
+        vi.useFakeTimers();
+        try {
+            const { rerender } = render(
+                <OffersMap
+                    offersData={[offer({ id: 1 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={1}
+                    selectedOfferCoordinates={{ latitude: 55.75, longitude: 37.61 }}
+                />,
+            );
+            expect(screen.queryByText(/местоположение/)).not.toBeInTheDocument();
+
+            // Переключились на другую вакансию — координаты на мгновение null
+            // (типичная стадия рефетча в родителе), но затем сразу приходят
+            // реальные координаты ДО истечения задержки уведомления.
+            rerender(
+                <OffersMap
+                    offersData={[offer({ id: 1 }), offer({ id: 2 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={2}
+                    selectedOfferCoordinates={null}
+                />,
+            );
+            expect(screen.queryByText(/местоположение/)).not.toBeInTheDocument();
+
+            act(() => {
+                vi.advanceTimersByTime(200);
+            });
+            rerender(
+                <OffersMap
+                    offersData={[offer({ id: 1 }), offer({ id: 2 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={2}
+                    selectedOfferCoordinates={{ latitude: 60, longitude: 30 }}
+                />,
+            );
+
+            act(() => {
+                vi.advanceTimersByTime(1000);
+            });
+
+            expect(screen.queryByText(/местоположение/)).not.toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it("не показывает подсказку, пока координаты ещё не разрешены (undefined)", () => {

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -409,8 +409,13 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     };
 
     useEffect(() => {
+        // Скрываем уведомление сразу при любой смене выбора/пересчёте
+        // координат — его текст относится к КОНКРЕТНОЙ вакансии, нельзя
+        // оставлять его от предыдущего выбора, пока решается, что показать
+        // для нового.
+        setShowNoLocationNotice(false);
+
         if (!selectedOfferId || selectedOfferCoordinates === undefined) {
-            setShowNoLocationNotice(false);
             pendingBalloonOfferIdRef.current = null;
             panActionEndedRef.current = false;
             return undefined;
@@ -420,8 +425,24 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         // геокодирован) — карте попросту нечем "сфокусироваться". Раньше
         // клик по такой карточке в списке просто ничего не делал молча,
         // что выглядело как баг; показываем явную причину вместо тишины.
-        setShowNoLocationNotice(selectedOfferCoordinates === null);
-        if (!selectedOfferCoordinates || !mapRef.current) return undefined;
+        if (selectedOfferCoordinates === null) {
+            pendingBalloonOfferIdRef.current = null;
+            panActionEndedRef.current = false;
+            // Небольшая задержка перед показом: при переключении между
+            // элементами списка selectedOfferCoordinates пересчитывается
+            // синхронно и почти всегда сразу верный, но родитель (см.
+            // fetchPageOffersLocation в OffersSearchFilter.tsx) на КАЖДЫЙ
+            // выбор заново запускает фоновый рефетч координат страницы —
+            // без задержки здесь уведомление успело бы мигнуть, если этот
+            // рефетч на миг отдаст устаревший/пустой результат раньше, чем
+            // подтвердит реальные координаты. Если у вакансии действительно
+            // нет координат, задержка не страшна — null никуда не денется,
+            // и уведомление просто появится чуть позже.
+            const timeoutId = setTimeout(() => setShowNoLocationNotice(true), 350);
+            return () => clearTimeout(timeoutId);
+        }
+
+        if (!mapRef.current) return undefined;
 
         const currentZoom = mapRef.current.getZoom();
         mapRef.current.setCenter(

--- a/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
@@ -30,6 +30,25 @@
     display: none !important;
 }
 
+// Дефолтная кнопка закрытия balloon у Яндекса — тёмный "×" с opacity: 0.3,
+// рассчитанный на светлый фон обычного balloon. Наша карточка (.balloonWrapper)
+// начинается сразу с фото на всю ширину — та же кнопка ложится прямо на фото и
+// на тёмных/пёстрых снимках становится практически невидимой (а на светлых —
+// почти невидимой и без фото). Даём ей непрозрачную тёмную подложку-кружок и
+// выбеливаем сам крестик через filter: invert — тогда контраст гарантирован
+// независимо от того, что происходит на фото под ней.
+.ymaps-2-1-79-balloon__close-button {
+    opacity: 1 !important;
+    background-color: rgba(0, 0, 0, 0.55) !important;
+    background-size: 10px 10px !important;
+    filter: invert(1);
+    border-radius: 50%;
+    width: 22px !important;
+    height: 22px !important;
+    margin: 8px 8px 0 0;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
 // Zoom control (+/- slider): Yandex positions it via an inline `inset`
 // (right/top offsets in px), which only ever anchors it to a corner — and
 // its own positioning parent, .controls-pane, is collapsed to 0 height via


### PR DESCRIPTION
## Summary
- `showNoLocationNotice` could theoretically flash true→false when switching between list items with real coordinates, since it was set synchronously off a value that briefly recomputes as null in the parent's per-selection refetch. Debounced by 350ms; genuine no-location offers just show the notice slightly later (no functional regression there).
- The Yandex balloon's default close button (30%-opacity black "×") is nearly invisible against our full-bleed photo card header. Gave it an opaque dark circular backdrop + inverted (white) glyph for guaranteed contrast, fixed in both `OffersMap` and `DonationsMap`.

Full writeup in GS-115 (Linear), including notes on the unsuccessful reproduction attempts for bug #1 (couldn't force the exact race on staging's fast network, but the fix is a standard defensive debounce matching the same pattern used for the loading-overlay flash in GS-114).

## Test plan
- [x] New regression test: rapid null→real-coordinates switch never renders the notice
- [x] Updated existing "shows notice for null coordinates" test to account for the debounce
- [x] Full `OffersMap.test.tsx` suite (32/32 passing)
- [x] revert-and-confirm-fails on both new/updated tests
- [x] `npx eslint` + `npx tsc --noEmit -p .` clean
- [x] Live-confirmed the close-button bug on staging (screenshot showed a real photo where the "×" was fully invisible) before fixing
- [ ] Live-verify close button visibility + no notice flash on staging