### PR TITLE
fix(GS-115): debounce empty-results notice against two-wave bounds refetch

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -899,7 +899,7 @@ describe("OffersMap", () => {
         // пустом результате он должен размонтироваться (а не остаться висеть со
         // старым содержимым), поэтому проверяем именно его отсутствие в дереве.
         await waitFor(() => expect(screen.queryByTestId("object-manager")).not.toBeInTheDocument());
-        expect(screen.getByText("По вашему запросу вакансий на карте не найдено")).toBeInTheDocument();
+        await waitFor(() => expect(screen.getByText("По вашему запросу вакансий на карте не найдено")).toBeInTheDocument());
     });
 
     it("отключает hideIconOnBalloonOpen у ObjectManager (регресс: Яндекс.Карты по умолчанию скрывают иконку "
@@ -947,7 +947,54 @@ describe("OffersMap", () => {
         );
 
         await waitFor(() => expect(onLoadCalls).toHaveBeenCalled());
-        expect(screen.getByText("По вашему запросу вакансий на карте не найдено")).toBeInTheDocument();
+        await waitFor(() => expect(screen.getByText("По вашему запросу вакансий на карте не найдено")).toBeInTheDocument());
+    });
+
+    it("не мигает уведомлением \"не найдено\", если пустой результат — лишь промежуточная волна "
+        + "bounds-рефетча за один pan (регресс: та же природа гонки, что и с уведомлением "
+        + "\"нет местоположения\" — итоговая непустая волна должна успеть прийти раньше, чем мелькнёт "
+        + "уведомление)", async () => {
+        const { rerender } = render(
+            <OffersMap
+                offersData={[offer({ id: 1 })]}
+                isOffersLoading={false}
+            />,
+        );
+        await waitFor(() => expect(capturedFeatures).toHaveLength(1));
+
+        vi.useFakeTimers();
+        try {
+            // Промежуточная волна во время pan — bounds на миг не содержат
+            // маркеров.
+            rerender(
+                <OffersMap
+                    offersData={[]}
+                    isOffersLoading={false}
+                />,
+            );
+            expect(screen.queryByText("По вашему запросу вакансий на карте не найдено")).not.toBeInTheDocument();
+
+            act(() => {
+                vi.advanceTimersByTime(200);
+            });
+
+            // Финальная волна — реальные маркеры под итоговые bounds пришли
+            // раньше истечения дебаунса.
+            rerender(
+                <OffersMap
+                    offersData={[offer({ id: 2 })]}
+                    isOffersLoading={false}
+                />,
+            );
+
+            act(() => {
+                vi.advanceTimersByTime(1000);
+            });
+
+            expect(screen.queryByText("По вашему запросу вакансий на карте не найдено")).not.toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it("не показывает «вакансий не найдено», пока карта ещё грузится", () => {

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -550,8 +550,25 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
     // Пустая карта (0 маркеров) отличается от карты, которая ещё грузится
     // или упала с ошибкой — без этого условия пользователь видел бы то же
     // самое молчаливое пустое место в обоих случаях.
-    const showEmptyNotice = !isOffersError && !isOffersLoading
+    const isEmptyResult = !isOffersError && !isOffersLoading
         && !!ymapState && features.length === 0;
+    const [showEmptyNotice, setShowEmptyNotice] = useState(false);
+
+    useEffect(() => {
+        if (!isEmptyResult) {
+            setShowEmptyNotice(false);
+            return undefined;
+        }
+        // Дебаунс, а не мгновенный показ: bounds-дебаунс может дать ДВЕ волны
+        // обновления маркеров за один pan/zoom (см. тот же комментарий у
+        // openBalloon выше) — промежуточная волна иногда на миг отдаёт пустой
+        // результат (например, пан через область карты без вакансий), прежде
+        // чем финальная волна приносит реальный набор маркеров под итоговые
+        // bounds. Без задержки здесь уведомление "не найдено" успевало бы
+        // мигнуть между этими волнами, даже когда вакансии на самом деле есть.
+        const timeoutId = setTimeout(() => setShowEmptyNotice(true), BOUNDS_CHANGE_DEBOUNCE_MS);
+        return () => clearTimeout(timeoutId);
+    }, [isEmptyResult]);
 
     // См. комментарий у OBJECT_MANAGER_OPTIONS/OBJECT_MANAGER_OBJECTS выше —
     // тот же принцип: без useMemo этот объект (и вложенные createClass())


### PR DESCRIPTION
## Summary
User reported still occasionally seeing "По вашему запросу вакансий на карте не найдено" — a different notice than the two already fixed in GS-115 (loading overlay, no-location notice). Same underlying race class: `showEmptyNotice` was derived synchronously from `features.length === 0`, and a pan/zoom's intermediate bounds-refetch wave (bounds debounce can produce two waves per pan — an already-documented behavior elsewhere in this file) can transiently return zero results before the final wave's real marker set arrives.

Converted to debounced state (matching `BOUNDS_CHANGE_DEBOUNCE_MS`), same pattern as the other two fixes in this issue.

## Test plan
- [x] New regression test: intermediate empty wave → final non-empty wave never shows the notice
- [x] Updated two existing tests to await the debounce instead of asserting synchronously
- [x] Full `OffersMap.test.tsx` suite (33/33 passing)
- [x] revert-and-confirm-fails on the new test
- [x] `npx eslint` + `npx tsc --noEmit -p .` clean
- [ ] Live-verify on staging