### PR TITLE
fix(GS-115): disable browser autofill on map search inputs

### DIFF
--- a/src/widgets/Donation/SearchDonations/SearchDonations.tsx
+++ b/src/widgets/Donation/SearchDonations/SearchDonations.tsx
@@ -147,7 +147,13 @@ export const SearchDonations = forwardRef<SearchDonationsRef, SearchDonationsPro
                                 handleSubmit();
                             }
                         }}
-                        inputProps={{ "aria-label": t("Поиск сборов") }}
+                        // autoComplete: "off" — см. тот же фикс в
+                        // widgets/OffersMap/ui/SearchOffers/SearchOffers.tsx:
+                        // без него браузер сам предлагает нативный,
+                        // никак не стилизованный список автозаполнения
+                        // (прошлые значения этого поля), который может
+                        // наложиться на карту поверх открытого balloon.
+                        inputProps={{ "aria-label": t("Поиск сборов"), autoComplete: "off" }}
                     />
                     {searchInput.length > 0 && <CloseButton onClick={handleClear} />}
                     <IconButton onClick={handleSubmit} type="button" sx={{ p: "10px" }} aria-label="search">

--- a/src/widgets/OffersMap/ui/SearchOffers/SearchOffers.tsx
+++ b/src/widgets/OffersMap/ui/SearchOffers/SearchOffers.tsx
@@ -151,7 +151,16 @@ export const SearchOffers = forwardRef<SearchOffersRef, SearchOffersProps>(
                                 handleSubmit();
                             }
                         }}
-                        inputProps={{ "aria-label": t("Поиск вакансий") }}
+                        // autoComplete: "off" — без этого браузер копит и
+                        // потом сам предлагает СВОЙ нативный список
+                        // автозаполнения (прошлые введённые в это поле
+                        // значения), который рендерится ВНЕ нашего DOM, никак
+                        // не стилизован (обычные синие ссылки/системный шрифт)
+                        // и может визуально наложиться на карту с открытым
+                        // balloon — выглядит как сломанный кусок интерфейса,
+                        // хотя на деле это браузер, а не наш дропдаун с
+                        // подсказками (styles.dropdown ниже).
+                        inputProps={{ "aria-label": t("Поиск вакансий"), autoComplete: "off" }}
                     />
                     {searchInput.length > 0 && <CloseButton onClick={handleClear} />}
                     <IconButton onClick={handleSubmit} type="button" sx={{ p: "10px" }} aria-label="search">


### PR DESCRIPTION
## Summary
User reported a broken-looking unstyled box floating over the map next to an open balloon (screenshot). Root cause: the search inputs (`SearchOffers`, `SearchDonations`) had no `autoComplete` attribute, so browsers accumulate past typed values and later suggest them via their own native autocomplete dropdown — rendered outside our DOM/CSS entirely, so it shows as plain unstyled blue links with a native grey highlight, and can visually overlap page content since it's not part of our stacking context. Confirmed by content match: the "ghost" text was exactly offer titles the user had previously typed into that search box.

Fix: `autoComplete="off"` on both search inputs.

No unit test — this is browser-native behavior, not app logic; nothing in our render output changes.