### PR TITLE
fix(GS-117): don't open balloon over a still-clustered marker

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -10,12 +10,14 @@ import { OffersMap } from "./OffersMap";
 import { OfferMap } from "@/entities/Offer";
 
 const setCenter = vi.fn();
+const setZoom = vi.fn();
 const getZoom = vi.fn(() => 5);
 const getBounds = vi.fn(() => [[54, 36], [57, 39]]);
 const boundsChangeHandlers: Array<() => void> = [];
 const onLoadCalls = vi.fn();
 const balloonOpen = vi.fn().mockResolvedValue(undefined);
 const getById = vi.fn((): object | undefined => ({}));
+const getObjectState = vi.fn((): { isClustered: boolean } => ({ isClustered: false }));
 // Симулирует нативный клик по маркеру (или наш собственный balloon.open()) —
 // см. подписку OffersMap на "balloonopen" в objects.events.
 const objectsBalloonOpenHandlers: Array<(e: { get: (key: string) => unknown }) => void> = [];
@@ -57,6 +59,7 @@ vi.mock("@pbe/react-yandex-maps", () => ({
         } = props;
         instanceRef.current = {
             setCenter,
+            setZoom,
             getZoom,
             getBounds,
             events: {
@@ -107,6 +110,7 @@ vi.mock("@pbe/react-yandex-maps", () => ({
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useLayoutEffect(() => {
             const instance = {
+                getObjectState,
                 objects: {
                     balloon: { open: balloonOpen },
                     getById,
@@ -158,7 +162,9 @@ const offer = (overrides: Partial<OfferMap> = {}): OfferMap => ({
 describe("OffersMap", () => {
     beforeEach(() => {
         setCenter.mockClear();
+        setZoom.mockClear();
         getZoom.mockClear();
+        getZoom.mockReturnValue(5);
         getBounds.mockReset();
         getBounds.mockReturnValue([[54, 36], [57, 39]]);
         onLoadCalls.mockClear();
@@ -166,6 +172,8 @@ describe("OffersMap", () => {
         balloonOpen.mockResolvedValue(undefined);
         getById.mockClear();
         getById.mockImplementation(() => ({}));
+        getObjectState.mockClear();
+        getObjectState.mockReturnValue({ isClustered: false });
         boundsChangeHandlers.length = 0;
         objectsBalloonOpenHandlers.length = 0;
         capturedFeatures = [];
@@ -211,6 +219,58 @@ describe("OffersMap", () => {
 
         expect(balloonOpen).toHaveBeenCalledWith("1");
     });
+
+    it(
+        "дозумируется, а не открывает balloon поверх кластера, если выбранная вакансия всё ещё "
+        + "смёржена в кластер (регресс: ?offerId= на вакансию с соседями открывал balloon.open() "
+        + "успешно, но табличка повисала над безликим числовым кружком-кластером вместо своего "
+        + "реального маркера — выглядело как баг)",
+        async () => {
+            getObjectState.mockReturnValue({ isClustered: true });
+            const coordinates = { latitude: 55.75, longitude: 37.61 };
+
+            vi.useFakeTimers();
+            try {
+                const { rerender } = render(
+                    <OffersMap
+                        offersData={[offer({ id: 1 })]}
+                        isOffersLoading={false}
+                        selectedOfferId={1}
+                        selectedOfferCoordinates={coordinates}
+                    />,
+                );
+
+                await vi.waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+                act(() => {
+                    boundsChangeHandlers.forEach((handler) => handler());
+                });
+
+                expect(balloonOpen).not.toHaveBeenCalled();
+                expect(setZoom).toHaveBeenCalledWith(7, { duration: 400, checkZoomRange: true });
+
+                // Кластер расклеился (например, после того как карта
+                // дозумилась и новые bounds-scoped маркеры пришли) —
+                // реактивный триггер на изменившиеся features должен
+                // подхватить это сразу, не дожидаясь тика таймера-ретрая.
+                getObjectState.mockReturnValue({ isClustered: false });
+                act(() => {
+                    rerender(
+                        <OffersMap
+                            offersData={[offer({ id: 1, name: "Обновлённое название" })]}
+                            isOffersLoading={false}
+                            selectedOfferId={1}
+                            selectedOfferCoordinates={coordinates}
+                        />,
+                    );
+                });
+
+                expect(balloonOpen).toHaveBeenCalledWith("1");
+            } finally {
+                vi.useRealTimers();
+            }
+        },
+    );
 
     it("показывает подсказку вместо тишины, если координаты точно отсутствуют (null)", () => {
         vi.useFakeTimers();

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -24,6 +24,13 @@ import { getMediaContent } from "@/shared/lib/getMediaContent";
 const FOCUS_ZOOM = 10;
 const BOUNDS_CHANGE_DEBOUNCE_MS = 400;
 const MAP_LOAD_TIMEOUT_MS = 15_000;
+// На сколько уровней зумить, если выбранная вакансия всё ещё смёржена в
+// кластер (см. attemptOpenBalloon) — шаг, а не целевой зум, т.к. заранее
+// неизвестно, сколько зума нужно конкретной паре/группе маркеров, чтобы
+// разъехаться (gridSize у кластеризатора считается в экранных пикселях, не
+// в метрах). Подбирается повторно на каждой попытке, пока не раскластерится
+// или не упрёмся в MAP_OPTIONS.maxZoom.
+const DECLUSTER_ZOOM_STEP = 2;
 
 // Модульные константы, а не инлайновые объекты в JSX — react-yandex-maps
 // сравнивает props объекта ObjectManager (options/objects/clusters) ПО
@@ -378,6 +385,26 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         // не повторял попытку, табличка так и не появлялась. getById даёт
         // однозначный ответ вместо гадания по побочному эффекту open().
         if (!objectManager.objects.getById(offerId.toString())) return false;
+        // Объект зарегистрирован, но может всё ещё визуально быть смёржен в
+        // кластер (например, ссылка с ?offerId= на вакансию, у которой рядом
+        // есть соседи, — FOCUS_ZOOM сам по себе не гарантирует расклайстеринг
+        // именно этой пары/группы, т.к. gridSize кластеризатора считается в
+        // экранных пикселях, а не в метрах). open() в этом случае технически
+        // срабатывает, но balloon повисает над безликим кружком-кластером
+        // ("2" и т.п.) вместо своего реального маркера — выглядит как баг.
+        // Дозумируемся и ждём следующей попытки вместо того чтобы открывать
+        // balloon в таком виде.
+        if (objectManager.getObjectState(offerId.toString())?.isClustered) {
+            const map = mapRef.current;
+            const currentZoom = map?.getZoom();
+            if (map && typeof currentZoom === "number" && currentZoom < MAP_OPTIONS.maxZoom) {
+                map.setZoom(
+                    Math.min(currentZoom + DECLUSTER_ZOOM_STEP, MAP_OPTIONS.maxZoom),
+                    { duration: 400, checkZoomRange: true },
+                );
+            }
+            return false;
+        }
         // Пятое живое наблюдение на стейдже: getById может подтвердить, что
         // объект уже числится в коллекции, ДО того как его геометрия/DOM
         // реально готовы для показа balloon — open() в этот момент всё ещё


### PR DESCRIPTION
## Problem
`?offerId=` deep links (e.g. `/ru/offers-map?offerId=7199`) open the vacancy's balloon successfully, but the balloon hangs disconnected over a generic numbered cluster bubble instead of its own marker, when the target offer is still visually merged into a cluster.

## Root cause
`objectManager.objects.getById(id)` confirms the object is registered, and `objects.balloon.open(id)` technically succeeds even while the object is still merged into a cluster on screen (clustering is a purely visual layer over `.objects`). `FOCUS_ZOOM` (10) doesn't guarantee any specific pair/group of markers de-clusters — the clusterer's `gridSize` is measured in screen pixels, not meters.

## Fix
`attemptOpenBalloon` now checks `objectManager.getObjectState(id).isClustered` before opening the balloon. If still clustered, it zooms in by `DECLUSTER_ZOOM_STEP` (2) and returns false, letting the existing retry loop (timer + reactive trigger on `features`) pick it back up once the marker splits off.

## Testing
- New regression test: forces `isClustered: true`, asserts the balloon does NOT open and the map zooms in instead; once de-clustered, the existing retry mechanism opens it.
- revert-and-confirm-fails: removing the check makes exactly this new test fail, all other 34 stay green.
- `npx eslint`, `npx tsc --noEmit -p .`, and the full `npx vitest run` suite (379 tests) all pass.

## Linear
GS-117