### PR TITLE
fix(GS-118): close the other balloon when opening one on the offers map

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -16,6 +16,8 @@ const getBounds = vi.fn(() => [[54, 36], [57, 39]]);
 const boundsChangeHandlers: Array<() => void> = [];
 const onLoadCalls = vi.fn();
 const balloonOpen = vi.fn().mockResolvedValue(undefined);
+const objectsBalloonClose = vi.fn();
+const clustersBalloonClose = vi.fn();
 const getById = vi.fn((): object | undefined => ({}));
 const getObjectState = vi.fn((): { isClustered: boolean } => ({ isClustered: false }));
 // Симулирует нативный клик по маркеру (или наш собственный balloon.open()) —
@@ -23,6 +25,13 @@ const getObjectState = vi.fn((): { isClustered: boolean } => ({ isClustered: fal
 const objectsBalloonOpenHandlers: Array<(e: { get: (key: string) => unknown }) => void> = [];
 const simulateBalloonOpen = (objectId: number | string) => {
     objectsBalloonOpenHandlers.forEach((handler) => handler({ get: (key) => (key === "objectId" ? objectId : undefined) }));
+};
+// Симулирует нативный клик по кластеру (открывает ЕГО собственный balloon
+// со списком вакансий) — см. подписку OffersMap на "balloonopen" в
+// clusters.events.
+const clustersBalloonOpenHandlers: Array<() => void> = [];
+const simulateClusterBalloonOpen = () => {
+    clustersBalloonOpenHandlers.forEach((handler) => handler());
 };
 let capturedFeatures: any[] = [];
 let capturedObjectsOptions: Record<string, unknown> | undefined;
@@ -112,7 +121,7 @@ vi.mock("@pbe/react-yandex-maps", () => ({
             const instance = {
                 getObjectState,
                 objects: {
-                    balloon: { open: balloonOpen },
+                    balloon: { open: balloonOpen, close: objectsBalloonClose },
                     getById,
                     events: {
                         add: (_event: string, handler: (e: any) => void) => {
@@ -121,6 +130,18 @@ vi.mock("@pbe/react-yandex-maps", () => ({
                         remove: (_event: string, handler: (e: any) => void) => {
                             const index = objectsBalloonOpenHandlers.indexOf(handler);
                             if (index !== -1) objectsBalloonOpenHandlers.splice(index, 1);
+                        },
+                    },
+                },
+                clusters: {
+                    balloon: { close: clustersBalloonClose },
+                    events: {
+                        add: (_event: string, handler: () => void) => {
+                            clustersBalloonOpenHandlers.push(handler);
+                        },
+                        remove: (_event: string, handler: () => void) => {
+                            const index = clustersBalloonOpenHandlers.indexOf(handler);
+                            if (index !== -1) clustersBalloonOpenHandlers.splice(index, 1);
                         },
                     },
                 },
@@ -170,12 +191,15 @@ describe("OffersMap", () => {
         onLoadCalls.mockClear();
         balloonOpen.mockClear();
         balloonOpen.mockResolvedValue(undefined);
+        objectsBalloonClose.mockClear();
+        clustersBalloonClose.mockClear();
         getById.mockClear();
         getById.mockImplementation(() => ({}));
         getObjectState.mockClear();
         getObjectState.mockReturnValue({ isClustered: false });
         boundsChangeHandlers.length = 0;
         objectsBalloonOpenHandlers.length = 0;
+        clustersBalloonOpenHandlers.length = 0;
         capturedFeatures = [];
         capturedObjectsOptions = undefined;
         capturedOptionsProp = undefined;
@@ -269,6 +293,81 @@ describe("OffersMap", () => {
             } finally {
                 vi.useRealTimers();
             }
+        },
+    );
+
+    it(
+        "закрывает balloon кластера, открывая balloon отдельной вакансии (регресс: пользователь "
+        + "кликал по кластеру — открывался его собственный balloon со списком вакансий — а затем "
+        + "открывался balloon конкретной вакансии из списка/deep-link: objects.balloon и "
+        + "clusters.balloon — это ДВЕ независимые коллекции у ObjectManager, открытие одной не "
+        + "закрывает другую саму по себе, обе таблички повисали на карте разом, одна поверх другой)",
+        async () => {
+            render(
+                <OffersMap
+                    offersData={[offer({ id: 1 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={1}
+                    selectedOfferCoordinates={{ latitude: 55.75, longitude: 37.61 }}
+                />,
+            );
+
+            await waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+            act(() => {
+                boundsChangeHandlers.forEach((handler) => handler());
+            });
+
+            expect(balloonOpen).toHaveBeenCalledWith("1");
+            expect(clustersBalloonClose).toHaveBeenCalledTimes(1);
+        },
+    );
+
+    it(
+        "закрывает balloon отдельной вакансии при клике по кластеру (симметричный случай — "
+        + "клик по кластеру открывает ЕГО собственный balloon нативно, минуя наш код, и должен "
+        + "убрать со сцены табличку конкретной вакансии, которая была открыта раньше)",
+        async () => {
+            const coordinates = { latitude: 55.75, longitude: 37.61 };
+            const { rerender } = render(
+                <OffersMap
+                    offersData={[offer({ id: 1 })]}
+                    isOffersLoading={false}
+                    selectedOfferId={1}
+                    selectedOfferCoordinates={coordinates}
+                />,
+            );
+
+            await waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+            act(() => {
+                boundsChangeHandlers.forEach((handler) => handler());
+            });
+            expect(balloonOpen).toHaveBeenCalledWith("1");
+            objectsBalloonClose.mockClear();
+
+            act(() => {
+                simulateClusterBalloonOpen();
+            });
+
+            expect(objectsBalloonClose).toHaveBeenCalledTimes(1);
+
+            // Следующее обновление маркеров (реактивный триггер на features)
+            // не должно молча переоткрыть табличку старой вакансии поверх
+            // того, что пользователь сейчас видит (список вакансий кластера)
+            // — отложенный выбор должен был сброситься.
+            balloonOpen.mockClear();
+            act(() => {
+                rerender(
+                    <OffersMap
+                        offersData={[offer({ id: 1, name: "Обновлённое название" })]}
+                        isOffersLoading={false}
+                        selectedOfferId={1}
+                        selectedOfferCoordinates={coordinates}
+                    />,
+                );
+            });
+            expect(balloonOpen).not.toHaveBeenCalled();
         },
     );
 

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -419,6 +419,18 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         } catch {
             return false;
         }
+        // objects и clusters — ДВЕ независимые balloon-коллекции у
+        // ObjectManager, каждая со своим открытым/закрытым состоянием.
+        // Открытие balloon отдельного маркера НЕ закрывает balloon кластера
+        // сам по себе, если тот уже был открыт раньше (например, пользователь
+        // только что кликнул по кластеру, увидел список вакансий, а потом
+        // сработал этот код) — обе таблички повисают на карте одновременно,
+        // одна поверх другой. Закрываем кластерную явно.
+        try {
+            objectManager.clusters.balloon.close();
+        } catch {
+            // no-op: balloon кластера мог и не быть открыт
+        }
         // Шестое живое наблюдение на стейдже: даже успешный open() не значит
         // "готово навсегда". Bounds-дебаунс может дать ДВЕ волны обновления
         // маркеров за один pan (промежуточная позиция во время анимации +
@@ -563,6 +575,34 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         objectManager.objects.events.add("balloonopen", handleBalloonOpen);
         return () => {
             objectManager.objects.events.remove("balloonopen", handleBalloonOpen);
+        };
+    }, [objectManagerMountTick]);
+
+    // Симметричный случай: клик по кластеру открывает ЕГО собственный
+    // balloon (список вакансий) — тоже целиком внутри Яндекс.Карт, тоже
+    // отдельная от objects.balloon коллекция. Если в этот момент уже была
+    // открыта табличка конкретной вакансии (например, из списка/deep-link),
+    // она никуда не девается сама — обе таблички оказываются на карте разом,
+    // одна поверх другой. Закрываем balloon отдельного маркера и сбрасываем
+    // отложенный выбор — раз пользователь сейчас смотрит на кластер, не
+    // нужно, чтобы следующий bounds-рефетч молча переоткрыл старую табличку
+    // поверх того, что он видит.
+    useEffect(() => {
+        const objectManager = objectManagerRef.current;
+        if (!objectManager) return undefined;
+
+        const handleClusterBalloonOpen = () => {
+            pendingBalloonOfferIdRef.current = null;
+            try {
+                objectManager.objects.balloon.close();
+            } catch {
+                // no-op: balloon отдельного маркера мог и не быть открыт
+            }
+        };
+
+        objectManager.clusters.events.add("balloonopen", handleClusterBalloonOpen);
+        return () => {
+            objectManager.clusters.events.remove("balloonopen", handleClusterBalloonOpen);
         };
     }, [objectManagerMountTick]);
 


### PR DESCRIPTION
## Problem
Screenshot from the user: two balloons visible on the map at once — a plain unstyled cluster balloon (list of vacancy names) and a styled individual offer balloon, stacked on top of each other.

## Root cause
`objects` and `clusters` are two independent balloon collections on ObjectManager, each with its own open/closed state. Opening one doesn't close the other by itself. Scenario: user clicks a cluster (natively opens its list balloon) → something else opens an individual offer's balloon (marker click, list selection, deep-link) → both stay open at once.

## Fix
- `attemptOpenBalloon`: closes `clusters.balloon` right after successfully opening `objects.balloon`.
- New symmetric `clusters.events "balloonopen"` listener: closes `objects.balloon` and resets the pending selection when a cluster balloon opens, so the next bounds refetch doesn't silently reopen a stale individual balloon over the cluster list the user is now looking at.

## Testing
- Two new regression tests covering both directions of the conflict.
- revert-and-confirm-fails: removing the fix makes exactly these two new tests fail, all other 35 stay green.
- `npx eslint`, `npx tsc --noEmit -p .`, and the full `npx vitest run` suite (381 tests) all pass.

## Linear
GS-118