### PR TITLE
fix(GS-119): style the cluster balloon's tab list — was invisible/transparent

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
@@ -30,6 +30,51 @@
     display: none !important;
 }
 
+// Balloon кластера (открывается кликом по кружку с числом на карте) на деле
+// НЕ использует наш clusterBalloonContentLayout из OffersMap.tsx —
+// Яндекс.Карты по умолчанию рендерят мультиобъектный balloon через СВОЙ
+// собственный layout "b-cluster-tabs": слева список вакансий (табы), справа
+// превью выбранной (нашим же balloonContent — та карточка с фото уже
+// стилизована нормально). clusterBalloonContentLayout попросту не
+// вызывается этим дефолтным layout'ом — вся конфигурация в JS была мёртвым
+// кодом.
+//
+// .ymaps-2-1-79-balloon__layout выше намеренно сделан прозрачным (наша
+// собственная карточка справа уже рисует свой фон/тень) — но у списка слева
+// СВОЕГО фона никогда не было, и он наследовал эту прозрачность: голый
+// текст без подложки, повисший прямо на карте поверх тайлов — та самая
+// "прозрачная хуйня", которую поймал пользователь.
+.ymaps-2-1-79-b-cluster-tabs__section_type_nav {
+    background-color: var(--color-white);
+    overflow-y: auto;
+}
+
+.ymaps-2-1-79-b-cluster-tabs__menu-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    border-bottom: 1px solid var(--bg-field);
+    transition: background-color 0.15s ease-in-out;
+}
+
+.ymaps-2-1-79-b-cluster-tabs__menu-item:hover {
+    background-color: var(--bg-field);
+}
+
+.ymaps-2-1-79-b-cluster-tabs__menu-item_current_yes {
+    background-color: var(--accent-color);
+}
+
+.ymaps-2-1-79-b-cluster-tabs__menu-item-text {
+    font-family: "Lato", sans-serif;
+    font-size: 13px;
+    line-height: 1.3;
+    color: var(--color-black-primary);
+}
+
+.ymaps-2-1-79-b-cluster-tabs__menu-item_current_yes .ymaps-2-1-79-b-cluster-tabs__menu-item-text {
+    color: var(--color-white);
+}
+
 // Дефолтная кнопка закрытия balloon у Яндекса — тёмный "×" с opacity: 0.3,
 // рассчитанный на светлый фон обычного balloon. Наша карточка (.balloonWrapper)
 // начинается сразу с фото на всю ширину — та же кнопка ложится прямо на фото и


### PR DESCRIPTION
## Problem
Clicking a marker cluster on the map opens a balloon where the left side (list of cluster members) is completely unstyled/transparent — bare text floating directly over the map tiles, no background box. Looks broken.

## Root cause
Live DOM inspection on staging showed the multi-item cluster balloon doesn't use our `clusterBalloonContentLayout` config at all — it's dead code, never invoked. Yandex Maps renders cluster balloons through its own default two-pane `b-cluster-tabs` layout regardless: a nav list of member titles on the left (`.ymaps-2-1-79-b-cluster-tabs__section_type_nav`), and each member's own `balloonContent` (our already-correctly-styled card) on the right when selected.

`.ymaps-2-1-79-balloon__layout` is intentionally set to `background: transparent` so our individual-offer card can draw its own background/shadow — but the nav list section has no background of its own, so it inherited that transparency.

## Fix
Give the nav list section its own white background, padding-friendly list items with hover/active states (using the app's existing `--accent-color`/`--bg-field` theme variables), matching the visual polish of the card on the right.

## Testing
This is a pure CSS restyle of third-party (Yandex Maps SDK) DOM output that only exists at runtime — not producible in jsdom/vitest. Verified via live DOM inspection + computed styles on staging (see PR follow-up comment / Linear GS-119).

## Linear
GS-119 (supersedes the earlier, incorrect diagnosis in GS-118)