### PR TITLE
fix(e2e): update stale /api/v2 and /api/v3 references to /api/v1

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -42,7 +42,7 @@ async function setup(): Promise<void> {
         });
 
         // Получаем JWT через API
-        const loginResp = await ctx.request.post(`${API_URL}/api/v2/token`, {
+        const loginResp = await ctx.request.post(`${API_URL}/api/v1/token`, {
             data: { email: account.email, password: account.password },
         });
 
@@ -50,7 +50,7 @@ async function setup(): Promise<void> {
             throw new Error(`Логин ${account.email} не удался: ${loginResp.status()}`);
         }
 
-        const { token, roles } = await loginResp.json();
+        const { accessToken, roles } = await loginResp.json();
 
         // Записываем токен в localStorage так, как ожидает приложение
         await ctx.addInitScript(
@@ -58,7 +58,7 @@ async function setup(): Promise<void> {
                 localStorage.setItem('token', JSON.stringify(t));
                 localStorage.setItem('roles', JSON.stringify(r));
             },
-            { t: token, r: roles ?? [] },
+            { t: accessToken, r: roles ?? [] },
         );
 
         // Открываем главную, чтобы localStorage "осел" в origin

--- a/e2e/tests/application-flow.spec.ts
+++ b/e2e/tests/application-flow.spec.ts
@@ -21,7 +21,7 @@ import { API_URL, IAP_TOKEN } from '../config';
  * E2ETestFixtures::ORG_ID/VOL_ID/HOST_ID) молча игнорируется и никогда не
  * долетает до БД. Поэтому id организации хоста берём из его же профиля
  * (GET /api/v1/personal/profile → host — IRI), а вакансии находим по
- * названию через публичный GET /api/v3/vacancy/list/{organizationId}.
+ * названию через публичный GET /api/v1/vacancy/list/{organizationId}.
  *
  * Заявка на вакансию уникальна по паре (volunteer, vacancy), у Application
  * нет DELETE-операции — тесты не идемпотентны против уже созданных заявок.
@@ -46,9 +46,9 @@ test.describe('Волонтёр и хост: заявки на вакансию'
         : {};
 
     const login = async (api: APIRequestContext, email: string, password: string) => {
-        const resp = await api.post('/api/v2/token', { data: { email, password } });
+        const resp = await api.post('/api/v1/token', { data: { email, password } });
         expect(resp.ok(), await resp.text()).toBeTruthy();
-        return { Authorization: `Bearer ${(await resp.json()).token}` };
+        return { Authorization: `Bearer ${(await resp.json()).accessToken}` };
     };
 
     /**
@@ -89,7 +89,7 @@ test.describe('Волонтёр и хост: заявки на вакансию'
     };
 
     const findVacancyByTitle = async (api: APIRequestContext, orgId: string, title: string) => {
-        const resp = await api.get(`/api/v3/vacancy/list/${orgId}`);
+        const resp = await api.get(`/api/v1/vacancy/list/${orgId}`);
         expect(resp.ok(), await resp.text()).toBeTruthy();
         const list = await resp.json();
         const vacancies = Array.isArray(list) ? list : list.data ?? list['hydra:member'];


### PR DESCRIPTION
## Summary
- Fixes GS-122 (found while auditing the chat/messenger feature): `e2e/global-setup.ts` and `e2e/tests/application-flow.spec.ts` still called `/api/v2/token` and `/api/v3/vacancy/list/{orgId}`, both removed by an earlier API-versioning cleanup task. The login helper also destructured `.token` instead of the real `accessToken` field.
- Because e2e isn't part of CI, this silently broke the entire e2e suite's setup phase (and the application-flow spec's own login/lookup helpers) with no visible signal.
- Confirmed via curl against staging: `/api/v2/token` and `/api/v3/vacancy/list/1` both 404; `/api/v1/token` returns `{accessToken, mercureToken, refresh_token, roles}`; `/api/v1/vacancy/list/1` resolves (400 on bogus id, not 404).
- Not run through the full destructive `npm run e2e` (its global-setup calls `/api/test/reset`, which truncates ~50 tables) — verified via typecheck + direct endpoint-shape checks against staging instead.

## Test plan
- [x] `npx tsc --noEmit` — no errors in the touched e2e files
- [x] Live curl confirmation of endpoint shapes against staging (see above)
- [ ] Full `npm run e2e` run (destructive, not run automatically — recommend a manual maintainer run when convenient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)