### PR TITLE
fix(offers-map): style cluster balloon list container

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.module.scss
@@ -54,9 +54,42 @@
     transition: all 0.3s ease;
 }
 
-.clusterBalloon  a {
+.clusterBalloon {
+    display: flex;
+    flex-direction: column;
+    width: 220px;
+    max-height: 300px;
+    overflow-y: auto;
+    background: var(--color-white);
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
+}
+
+.clusterBalloon h3 {
+    margin: 0 0 8px;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.clusterBalloon ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.clusterBalloon a {
     text-decoration: none;
     color: var(--text-primary-1);
+    font-size: 13px;
+}
+
+.clusterBalloon a:hover {
+    text-decoration: underline;
 }
 
 .balloonImage {


### PR DESCRIPTION
## Summary
- Fixes GS-123, found from a user-reported screenshot on staging: the vacancy-cluster popup on `/offers-map` renders its list with zero container styling — no background, padding, radius, or shadow — so the text floats unreadably on top of the map instead of sitting in a panel.
- `.clusterBalloon` only ever styled the link color; the container itself, and the injected `ul`/`h3`, were never styled (unlike the neighboring `.balloonWrapper` single-offer card, which has full styling).
- Pre-existing bug, unrelated to today's other work in this repo — added a white background, border-radius + shadow matching `.balloonWrapper`, padding, `max-height`+scroll for long lists, and reset default `ul`/`li` spacing.

## Test plan
- [x] Pure CSS change, no logic — not unit-testable meaningfully in jsdom
- [ ] Visual confirmation on staging after deploy (clicking a marker cluster on `/offers-map`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)