### PR TITLE
fix(offers-slider): return loading-state JSX instead of discarding it

### DIFF
--- a/src/widgets/OffersSlider/ui/OffersSlider/OffersSlider.test.tsx
+++ b/src/widgets/OffersSlider/ui/OffersSlider/OffersSlider.test.tsx
@@ -1,7 +1,7 @@
 import {
     describe, it, expect, vi, beforeEach,
 } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import { OffersSlider } from "./OffersSlider";
 
 /**
@@ -14,6 +14,7 @@ import { OffersSlider } from "./OffersSlider";
 let mockIsAuth: unknown;
 let mockProfileData: { favoriteCategories: number[] } | undefined;
 let mockProfileLoading: boolean;
+let mockOffersIsLoading: boolean;
 const getOffersData = vi.fn();
 
 vi.mock("@/shared/hooks/redux", () => ({
@@ -32,12 +33,16 @@ vi.mock("@/entities/Offer", async () => {
     const actual = await vi.importActual<typeof import("@/entities/Offer")>("@/entities/Offer");
     return {
         ...actual,
-        useLazyGetOffersQuery: () => [getOffersData, false],
+        useLazyGetOffersQuery: () => [getOffersData, mockOffersIsLoading],
     };
 });
 
 vi.mock("../Offer/Offer", () => ({
     default: () => null,
+}));
+
+vi.mock("@/shared/ui/MiniLoader/MiniLoader", () => ({
+    MiniLoader: () => <div data-testid="mini-loader" />,
 }));
 
 const okResult = (ids: number[]) => ({
@@ -49,8 +54,17 @@ describe("OffersSlider", () => {
         mockIsAuth = undefined;
         mockProfileData = undefined;
         mockProfileLoading = false;
+        mockOffersIsLoading = false;
         getOffersData.mockReset();
         getOffersData.mockReturnValue(okResult([1]));
+    });
+
+    it("показывает лоадер, пока идёт запрос вакансий", () => {
+        mockOffersIsLoading = true;
+
+        render(<OffersSlider />);
+
+        expect(screen.getByTestId("mini-loader")).toBeInTheDocument();
     });
 
     it("для анонимного пользователя сразу берёт admin isFeatured, не запрашивая категории", async () => {

--- a/src/widgets/OffersSlider/ui/OffersSlider/OffersSlider.tsx
+++ b/src/widgets/OffersSlider/ui/OffersSlider/OffersSlider.tsx
@@ -75,9 +75,11 @@ export const OffersSlider: FC<OffersSliderProps> = (props) => {
     }, [getOffersData, isProfileLoading, myProfileData]);
 
     if (isLoading) {
-        <div className={cn(className, styles.wrapper)}>
-            <MiniLoader />
-        </div>;
+        return (
+            <div className={cn(className, styles.wrapper)}>
+                <MiniLoader />
+            </div>
+        );
     }
 
     return (


### PR DESCRIPTION
## Summary
- Fixes GS-124, found during a full mobile-viewport audit of the homepage on staging: `OffersSlider`'s loading-state JSX was created but never returned (`if (isLoading) { <div>...</div>; }` — missing `return`), so it was dead code.
- Effect: the "Интересные вакансии" homepage section renders as an invisible empty box during the up-to-3 sequential fetches (personal → featured → recommendation fallback), with zero loading feedback — looks broken/missing on slower connections.

## Test plan
- [x] New test asserting `MiniLoader` renders when `isLoading` is true (mocked)
- [x] revert-and-confirm-fails: test fails against the pre-fix code (loader not found in DOM)
- [x] Full frontend suite: 382/382 passing (was 381, +1 new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)