### PR TITLE
fix(offers-slider): destructure isLoading from RTK Query result object

### DIFF
--- a/src/widgets/OffersSlider/ui/OffersSlider/OffersSlider.test.tsx
+++ b/src/widgets/OffersSlider/ui/OffersSlider/OffersSlider.test.tsx
@@ -33,12 +33,17 @@ vi.mock("@/entities/Offer", async () => {
     const actual = await vi.importActual<typeof import("@/entities/Offer")>("@/entities/Offer");
     return {
         ...actual,
-        useLazyGetOffersQuery: () => [getOffersData, mockOffersIsLoading],
+        // useLazyQuery's second tuple element is the full RTK Query result
+        // object (isLoading is a property on it, not the element itself) —
+        // mocked with the same shape here on purpose, so a regression to
+        // `const [trigger, isLoading] = useLazyGetOffersQuery()` (destructuring
+        // the whole object as a boolean, always truthy) gets caught.
+        useLazyGetOffersQuery: () => [getOffersData, { isLoading: mockOffersIsLoading }],
     };
 });
 
 vi.mock("../Offer/Offer", () => ({
-    default: () => null,
+    default: ({ offer }: { offer: { id: number } }) => <div data-testid={`offer-${offer.id}`} />,
 }));
 
 vi.mock("@/shared/ui/MiniLoader/MiniLoader", () => ({
@@ -65,6 +70,15 @@ describe("OffersSlider", () => {
         render(<OffersSlider />);
 
         expect(screen.getByTestId("mini-loader")).toBeInTheDocument();
+    });
+
+    it("после загрузки показывает вакансии, а не лоадер вечно", async () => {
+        getOffersData.mockReturnValue(okResult([1, 2]));
+
+        render(<OffersSlider />);
+
+        await waitFor(() => expect(screen.getByTestId("offer-1")).toBeInTheDocument());
+        expect(screen.queryByTestId("mini-loader")).not.toBeInTheDocument();
     });
 
     it("для анонимного пользователя сразу берёт admin isFeatured, не запрашивая категории", async () => {

--- a/src/widgets/OffersSlider/ui/OffersSlider/OffersSlider.tsx
+++ b/src/widgets/OffersSlider/ui/OffersSlider/OffersSlider.tsx
@@ -26,7 +26,7 @@ export const OffersSlider: FC<OffersSliderProps> = (props) => {
     const [prevEl, setPrevEl] = useState<HTMLElement | null>(null);
     const [nextEl, setNextEl] = useState<HTMLElement | null>(null);
     const [offers, setOffers] = useState<OfferApi[]>([]);
-    const [getOffersData, isLoading] = useLazyGetOffersQuery();
+    const [getOffersData, { isLoading }] = useLazyGetOffersQuery();
     const { locale } = useLocale();
 
     const isAuth = useAppSelector(getUserAuthData);


### PR DESCRIPTION
## Summary
- Urgent follow-up to GS-124, currently live on staging: the earlier `return`-missing fix in `OffersSlider.tsx` exposed a pre-existing, deeper bug — `const [getOffersData, isLoading] = useLazyGetOffersQuery();` destructures `isLoading` as the **entire RTK Query result object**, not the boolean. That object is always truthy, so the loading branch now always short-circuits the render — the "Интересные вакансии" section is currently stuck on an infinite spinner in production, never showing offers, even though the API returns real data.
- Fixed by destructuring the boolean out: `const [getOffersData, { isLoading }] = useLazyGetOffersQuery();`
- Found by building a proper live-verification harness (Playwright, browser-context route interception forwarding `api-staging.goodsurfing.org` requests through a *separate* unauthenticated request context — mixing the main site's IAP `Authorization` header into API calls collides with the API's own IAP check) to actually confirm the previous fix worked on staging, rather than trusting the unit test in isolation.

## Test plan
- [x] Rewrote the `useLazyGetOffersQuery` test mock to match RTK Query's real tuple shape (`[trigger, resultObject]`, not `[trigger, boolean]`) — the old mock shape matched the bug's assumption and couldn't have caught it
- [x] New test: offers actually render (not just that the loader appears) once loading finishes
- [x] revert-and-confirm-fails: reverting just this destructuring fix reproduces the exact currently-live regression (loader never clears, `getByTestId('offer-1')` times out)
- [x] Full frontend suite: 383/383 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)