### PR TITLE
fix(offers-map): disable native cluster balloon panel mode

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -704,7 +704,16 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 </ul>
             </div>
         `),
-        clusterBalloonPanelMaxMapArea: Infinity,
+        // Infinity forced Yandex to ALWAYS render clusters through its own
+        // native two-pane panel UI (a list of items + selected item's
+        // content) instead of ever calling clusterBalloonContentLayout
+        // above — that template was dead code. The native panel's list
+        // pane has no background of its own (relies on our .clusterBalloon
+        // styling that never applied to it), rendering as unstyled text
+        // floating over the map. 0 disables panel mode entirely, so
+        // clusters always go through our own fully-styled template instead
+        // of Yandex's version-pinned internal markup.
+        clusterBalloonPanelMaxMapArea: 0,
         clusterBalloonContentLayoutHeight: 200,
     } : undefined), [ymapState?.templateLayoutFactory, vacancyListTitle]);
 

--- a/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
+++ b/src/widgets/OffersMap/ui/OffersMap/yandex-map-restyle-ballon.scss
@@ -26,57 +26,26 @@
 .ymaps-2-1-79-map-copyrights-promo {
     display: none;
 }
-.ymaps-2-1-79-b-cluster-content__header {
-    display: none !important;
-}
 
-// Balloon кластера (открывается кликом по кружку с числом на карте) на деле
-// НЕ использует наш clusterBalloonContentLayout из OffersMap.tsx —
-// Яндекс.Карты по умолчанию рендерят мультиобъектный balloon через СВОЙ
-// собственный layout "b-cluster-tabs": слева список вакансий (табы), справа
-// превью выбранной (нашим же balloonContent — та карточка с фото уже
-// стилизована нормально). clusterBalloonContentLayout попросту не
-// вызывается этим дефолтным layout'ом — вся конфигурация в JS была мёртвым
-// кодом.
+// Balloon кластера (открывается кликом по кружку с числом на карте) при
+// clusterBalloonPanelMaxMapArea: Infinity (старое значение в OffersMap.tsx)
+// вообще НЕ использовал наш clusterBalloonContentLayout — Яндекс.Карты
+// рендерили мультиобъектный balloon через СВОЙ собственный layout
+// "b-cluster-tabs" (слева список вакансий-табов, справа превью выбранной),
+// и вся конфигурация clusterBalloonContentLayout в JS была мёртвым кодом.
+// Список слева наследовал прозрачность .ymaps-2-1-79-balloon__layout выше
+// (она задумывалась для нашей карточки справа, которая сама рисует фон) —
+// голый текст без подложки поверх тайлов карты, та самая "прозрачная
+// хуйня", которую поймал пользователь. Попытка стилизовать этот нативный
+// "b-cluster-tabs" layout напрямую (version-pinned классы вида
+// .ymaps-2-1-79-b-cluster-tabs__*) не решала проблему на практике.
 //
-// .ymaps-2-1-79-balloon__layout выше намеренно сделан прозрачным (наша
-// собственная карточка справа уже рисует свой фон/тень) — но у списка слева
-// СВОЕГО фона никогда не было, и он наследовал эту прозрачность: голый
-// текст без подложки, повисший прямо на карте поверх тайлов — та самая
-// "прозрачная хуйня", которую поймал пользователь.
-.ymaps-2-1-79-b-cluster-tabs__section_type_nav {
-    background-color: var(--color-white);
-    overflow-y: auto;
-}
-
-.ymaps-2-1-79-b-cluster-tabs__menu-item {
-    padding: 8px 12px;
-    cursor: pointer;
-    border-bottom: 1px solid var(--bg-field);
-    transition: background-color 0.15s ease-in-out;
-}
-
-// !important: Яндекс.Карты сами вешают фон на hover/current состояния
-// этого таба (по умолчанию серый) с той же или более высокой
-// специфичностью — без !important наши цвета проигрывают его собственным.
-.ymaps-2-1-79-b-cluster-tabs__menu-item:hover {
-    background-color: var(--bg-field) !important;
-}
-
-.ymaps-2-1-79-b-cluster-tabs__menu-item_current_yes {
-    background-color: var(--accent-color) !important;
-}
-
-.ymaps-2-1-79-b-cluster-tabs__menu-item-text {
-    font-family: "Lato", sans-serif;
-    font-size: 13px;
-    line-height: 1.3;
-    color: var(--color-black-primary);
-}
-
-.ymaps-2-1-79-b-cluster-tabs__menu-item_current_yes .ymaps-2-1-79-b-cluster-tabs__menu-item-text {
-    color: var(--color-white) !important;
-}
+// Финальный фикс: clusterBalloonPanelMaxMapArea: 0 в OffersMap.tsx
+// полностью отключает панельный режим — Яндекс всегда идёт через НАШ
+// clusterBalloonContentLayout (.clusterBalloon в OffersMap.module.scss,
+// полностью под нашим контролем и уже стилизован). b-cluster-tabs и
+// b-cluster-content__header больше никогда не рендерятся, поэтому
+// специфичных для панельного режима правил здесь больше нет.
 
 // Дефолтная кнопка закрытия balloon у Яндекса — тёмный "×" с opacity: 0.3,
 // рассчитанный на светлый фон обычного balloon. Наша карточка (.balloonWrapper)


### PR DESCRIPTION
## Summary
- Third and (hopefully) final attempt at GS-123: the first CSS fix targeted `.clusterBalloon` (our custom `clusterBalloonContentLayout` template), but that template turned out to be dead code — `clusterBalloonPanelMaxMapArea: Infinity` forces Yandex Maps to always render cluster balloons through its own native two-pane panel UI ("b-cluster-tabs") instead. A second, earlier attempt already in the codebase tried styling Yandex's version-pinned native classes directly — confirmed live that the class version matches what's actually loaded on staging, but it still didn't work in practice.
- Rather than keep chasing Yandex's internal markup, this disables panel mode entirely (`clusterBalloonPanelMaxMapArea: 0`), so every cluster always renders through our own fully-controlled, already-correctly-styled `clusterBalloonContentLayout` template. Removed the now-dead native panel CSS overrides in `yandex-map-restyle-ballon.scss`.

## Test plan
- [x] Typecheck + lint clean
- [x] Full `OffersMap` test suite: 66/66 passing, no regressions
- [ ] Visual confirmation on staging after deploy (automated Playwright click-through proved unreliable — clicks sometimes zoom instead of opening the balloon, or reset the map view — requesting manual visual confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)