### PR TITLE
fix(chat): fix auth-state hydration gap and add realtime fallback (GS-126)

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -50,15 +50,27 @@ async function setup(): Promise<void> {
             throw new Error(`Логин ${account.email} не удался: ${loginResp.status()}`);
         }
 
-        const { accessToken, roles } = await loginResp.json();
+        const { accessToken, mercureToken, roles } = await loginResp.json();
 
-        // Записываем токен в localStorage так, как ожидает приложение
+        // Записываем токен в localStorage так, как ожидает приложение —
+        // userSlice.initAuthData() хидрирует authData только если ВСЕ
+        // четыре ключа на месте (user/token/mercureToken/roles), иначе
+        // PrivateRouteGuard считает сессию разлогиненной и уводит на
+        // /signin, даже если JWT в localStorage валидный.
         await ctx.addInitScript(
-            ({ t, r }: { t: string; r: string[] }) => {
+            ({
+                email, t, mt, r,
+            }: {
+                email: string; t: string; mt: string; r: string[];
+            }) => {
+                localStorage.setItem('user', JSON.stringify({ username: email }));
                 localStorage.setItem('token', JSON.stringify(t));
+                localStorage.setItem('mercureToken', JSON.stringify(mt));
                 localStorage.setItem('roles', JSON.stringify(r));
             },
-            { t: accessToken, r: roles ?? [] },
+            {
+                email: account.email, t: accessToken, mt: mercureToken, r: roles ?? [],
+            },
         );
 
         // Открываем главную, чтобы localStorage "осел" в origin

--- a/src/entities/Chat/api/chatApi.ts
+++ b/src/entities/Chat/api/chatApi.ts
@@ -43,6 +43,13 @@ export const chatApi = createApi({
                 method: "POST",
                 body,
             }),
+            // Отправленное сообщение появляется в открытом чате только через
+            // Mercure-подписку (useGetChatMessages) — своего локального
+            // добавления в список нет. Если SSE-пуш задержится/оборвётся,
+            // отправитель не увидит собственное сообщение без перезагрузки
+            // страницы. invalidatesTags форсирует рефетч списка сообщений
+            // как страховку, не завязанную на реальное время.
+            invalidatesTags: ["chat"],
         }),
         readMessage: build.mutation<ChatType, MessageRequest>({
             query: (data) => ({

--- a/src/entities/Chat/lib/useGetChatMessages.test.tsx
+++ b/src/entities/Chat/lib/useGetChatMessages.test.tsx
@@ -2,12 +2,13 @@ import React from "react";
 import {
     describe, it, expect, beforeEach,
 } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { rest } from "msw";
 import { server } from "@/mocks/server";
 import { setupStore } from "@/store/store";
 import { useGetChatMessages } from "./useGetChatMessages";
+import { useCreateMessageMutation } from "../api/chatApi";
 
 /**
  * Регресс-guard: страница «Вы подали заявку» (`/messenger/create/{offerId}`)
@@ -51,5 +52,69 @@ describe("useGetChatMessages — пропуск запроса для create-з�
         await waitFor(() => {
             expect(requestedUrls).toContain("/api/v1/chats/42/messages");
         });
+    });
+});
+
+/**
+ * Отправленное сообщение появляется в открытом чате только через
+ * Mercure-подписку (EventSource) — у createMessage нет ни оптимистичного
+ * добавления в список, ни invalidatesTags-страховки не было. Если SSE-пуш
+ * задержится/оборвётся, отправитель не увидит собственное сообщение без
+ * перезагрузки страницы. Проверяем, что отправка сообщения форсирует
+ * рефетч списка сообщений независимо от Mercure.
+ */
+describe("createMessage — рефетч списка сообщений после отправки", () => {
+    it("успешная отправка инвалидирует и обновляет getMessagesByChatId", async () => {
+        let callCount = 0;
+        server.use(
+            rest.get("*/chats/:chatId/messages", (req, res, ctx) => {
+                callCount += 1;
+                if (callCount === 1) {
+                    return res(ctx.status(200), ctx.json([
+                        {
+                            id: 1, author: "/api/v1/users/other", text: "Привет", createdAt: "2026-08-06T10:00:00+00:00", viewed: true, applicationForm: null,
+                        },
+                    ]));
+                }
+                return res(ctx.status(200), ctx.json([
+                    {
+                        id: 1, author: "/api/v1/users/other", text: "Привет", createdAt: "2026-08-06T10:00:00+00:00", viewed: true, applicationForm: null,
+                    },
+                    {
+                        id: 2, author: "/api/v1/users/me", text: "Живой ответ", createdAt: "2026-08-06T10:01:00+00:00", viewed: true, applicationForm: null,
+                    },
+                ]));
+            }),
+            rest.post("*/messages", (req, res, ctx) => res(
+                ctx.status(201),
+                ctx.json({
+                    id: 2, author: "/api/v1/users/me", text: "Живой ответ", chat: "/api/v1/chats/42", createdAt: "2026-08-06T10:01:00+00:00", applicationForm: null, attachments: [], readByUserIds: [],
+                }),
+            )),
+        );
+
+        const store = setupStore();
+        const messagesHook = renderHook(
+            () => useGetChatMessages("42", null, "profile-1"),
+            { wrapper: ({ children }) => <Provider store={store}>{children}</Provider> },
+        );
+        const mutationHook = renderHook(
+            () => useCreateMessageMutation(),
+            { wrapper: ({ children }) => <Provider store={store}>{children}</Provider> },
+        );
+
+        await waitFor(() => {
+            expect(messagesHook.result.current.messages).toHaveLength(1);
+        });
+
+        const [createMessage] = mutationHook.result.current;
+        await act(async () => {
+            await createMessage({ chat: "/api/v1/chats/42", text: "Живой ответ", attachments: [] }).unwrap();
+        });
+
+        await waitFor(() => {
+            expect(messagesHook.result.current.messages).toHaveLength(2);
+        });
+        expect(callCount).toBeGreaterThanOrEqual(2);
     });
 });


### PR DESCRIPTION
## Summary
- `e2e/global-setup.ts` only ever seeded `token`/`roles` into localStorage, but `userSlice.initAuthData()` requires all four keys (`user`, `token`, `mercureToken`, `roles`) to hydrate `authData` — missing keys make `PrivateRouteGuard` treat a genuinely valid session as logged-out and bounce to `/signin`. Fixed the seeding to match what a real login (`AuthByEmailForm`) actually writes.
- `chatApi.createMessage` had no fallback if the Mercure SSE push is delayed, drops, or reconnects: no optimistic update, no `invalidatesTags`. The sender would not see their own just-sent message without a manual reload. Added `invalidatesTags: ["chat"]` so the message list refetches independent of realtime push.

Found while building a live-authenticated browser harness to audit the chat/messenger UI on staging — this was blocking that audit until traced to these two gaps.

## Test plan
- [x] New unit test in `useGetChatMessages.test.tsx`: confirms `createMessage` triggers a refetch that surfaces the new message; reverted the `invalidatesTags` fix and confirmed the test fails with the expected assertion error, then restored it and confirmed it passes.
- [x] Full `vitest run` suite: 384/384 passing on this branch (fresh off master).
- [x] `npm run type-check`: clean.
- [x] `npm run lint`: no new warnings/errors (27 pre-existing warnings elsewhere, untouched).
- [x] Live-verified on staging with real Alice/Bob test accounts: chat list, opening a conversation, and sending a message all render correctly once the auth-hydration fix is applied (confirmed via a local Playwright harness, not committed — contains a hardcoded IAP bypass token).