### PR TITLE
feat(reviews): allow author self-delete of a vacancy review within 24h

### DIFF
--- a/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.test.tsx
+++ b/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.test.tsx
@@ -2,6 +2,8 @@ import {
     describe, it, expect, vi, beforeEach,
 } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import { OfferReviewsCard } from "./OfferReviewsCard";
 
 /**
@@ -20,27 +22,58 @@ vi.mock("@/app/providers/LocaleProvider", () => ({
     useLocale: () => ({ locale: "ru" }),
 }));
 
-const getReviewsData = vi.fn().mockReturnValue({
-    unwrap: () => Promise.resolve({ data: [], pagination: { total: 0, page: 1 } }),
+const AUTHOR_ID = "author-1";
+const OTHER_USER_ID = "other-2";
+
+type ReviewOverrides = { id: string; authorId: string; createdAt: string | null };
+
+const makeReview = (overrides: Partial<ReviewOverrides> = {}) => ({
+    id: overrides.id ?? "review-1",
+    author: {
+        id: overrides.authorId ?? AUTHOR_ID, firstName: "Аня", lastName: "Тест", image: null,
+    },
+    description: "Отличная поездка",
+    rating: 5,
+    createdAt: overrides.createdAt === undefined ? new Date().toISOString() : overrides.createdAt,
+    images: [],
 });
+
+let reviewsQueryResult = { data: { data: [makeReview()], pagination: { total: 1, page: 1 } } };
+const getReviewsData = vi.fn().mockImplementation(() => ({
+    unwrap: () => Promise.resolve(reviewsQueryResult.data),
+}));
 const createOfferReview = vi.fn();
-// Стабильная ссылка важна: если этот объект пересоздавать на каждый вызов
-// мока, useEffect с [reviewsData] в зависимостях будет срабатывать на
-// каждый рендер и уходить в бесконечный цикл setState → ререндер.
-const reviewsQueryResult = { data: { data: [], pagination: { total: 0, page: 1 } } };
+const deleteOfferReview = vi.fn().mockReturnValue({ unwrap: () => Promise.resolve() });
+let mockMyProfileId: string | null = AUTHOR_ID;
 
 vi.mock("@/entities/Review", () => ({
     useLazyGetOfferReviewByVacancyIdQuery: () => [getReviewsData, reviewsQueryResult],
     useCreateOfferReviewMutation: () => [createOfferReview],
+    useDeleteOfferReviewMutation: () => [deleteOfferReview],
 }));
 
+vi.mock("@/routes/model/guards/AuthProvider", () => ({
+    useAuth: () => ({ myProfile: mockMyProfileId ? { id: mockMyProfileId } : null }),
+}));
+
+/**
+ * GS-91: форма написания отзыва (рейтинг + текст + загрузка фото) раньше
+ * рендерилась всегда, просто в disabled-состоянии, когда canReview=false —
+ * выглядело как баг для незалогиненных/неоткликнувшихся посетителей.
+ * Теперь форма не рендерится вовсе, если canReview=false; список
+ * существующих отзывов при этом остаётся видимым.
+ */
 describe("OfferReviewsCard", () => {
     beforeEach(() => {
         getReviewsData.mockClear();
+        deleteOfferReview.mockClear();
+        mockMyProfileId = AUTHOR_ID;
+        reviewsQueryResult = { data: { data: [makeReview()], pagination: { total: 1, page: 1 } } };
     });
 
     it("не показывает форму написания отзыва, если canReview=false", async () => {
-        render(<OfferReviewsCard offerId={1} canReview={false} />);
+        reviewsQueryResult = { data: { data: [], pagination: { total: 0, page: 1 } } };
+        render(<MemoryRouter><OfferReviewsCard offerId={1} canReview={false} /></MemoryRouter>);
 
         await waitFor(() => expect(getReviewsData).toHaveBeenCalled());
         expect(screen.queryByPlaceholderText("personalOffer.Ваш отзыв")).not.toBeInTheDocument();
@@ -48,10 +81,57 @@ describe("OfferReviewsCard", () => {
     });
 
     it("показывает форму написания отзыва, если canReview=true", async () => {
-        render(<OfferReviewsCard offerId={1} canReview />);
+        reviewsQueryResult = { data: { data: [], pagination: { total: 0, page: 1 } } };
+        render(<MemoryRouter><OfferReviewsCard offerId={1} canReview /></MemoryRouter>);
 
         await waitFor(() => expect(getReviewsData).toHaveBeenCalled());
         expect(screen.getByPlaceholderText("personalOffer.Ваш отзыв")).toBeInTheDocument();
         expect(screen.getByText("personalOffer.Написать отзыв")).toBeInTheDocument();
+    });
+
+    /**
+     * GS-132: самостоятельное удаление своего отзыва — только в течение
+     * 24 часов после публикации, только автору.
+     */
+    it("показывает кнопку удаления для своего свежего отзыва и удаляет по подтверждению", async () => {
+        vi.spyOn(window, "confirm").mockReturnValue(true);
+        render(<MemoryRouter><OfferReviewsCard offerId={1} canReview={false} /></MemoryRouter>);
+
+        const deleteBtn = await screen.findByRole("button", { name: /удалить отзыв/i });
+        await userEvent.click(deleteBtn);
+
+        expect(deleteOfferReview).toHaveBeenCalledWith("review-1");
+    });
+
+    it("не показывает кнопку удаления для чужого отзыва", async () => {
+        mockMyProfileId = OTHER_USER_ID;
+        render(<MemoryRouter><OfferReviewsCard offerId={1} canReview={false} /></MemoryRouter>);
+
+        await waitFor(() => expect(getReviewsData).toHaveBeenCalled());
+        expect(screen.queryByRole("button", { name: /удалить отзыв/i })).not.toBeInTheDocument();
+    });
+
+    it("не показывает кнопку удаления для своего отзыва старше 24 часов", async () => {
+        const staleCreatedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+        reviewsQueryResult = {
+            data: {
+                data: [makeReview({ createdAt: staleCreatedAt })],
+                pagination: { total: 1, page: 1 },
+            },
+        };
+        render(<MemoryRouter><OfferReviewsCard offerId={1} canReview={false} /></MemoryRouter>);
+
+        await waitFor(() => expect(getReviewsData).toHaveBeenCalled());
+        expect(screen.queryByRole("button", { name: /удалить отзыв/i })).not.toBeInTheDocument();
+    });
+
+    it("не удаляет отзыв, если пользователь отменил подтверждение", async () => {
+        vi.spyOn(window, "confirm").mockReturnValue(false);
+        render(<MemoryRouter><OfferReviewsCard offerId={1} canReview={false} /></MemoryRouter>);
+
+        const deleteBtn = await screen.findByRole("button", { name: /удалить отзыв/i });
+        await userEvent.click(deleteBtn);
+
+        expect(deleteOfferReview).not.toHaveBeenCalled();
     });
 });

--- a/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
+++ b/src/entities/Offer/ui/OfferReviewsCard/ui/OfferReviewsCard/OfferReviewsCard.tsx
@@ -6,11 +6,13 @@ import { useTranslation } from "react-i18next";
 
 import { Rating } from "@mui/material";
 import { useLocale } from "@/app/providers/LocaleProvider";
+import { useAuth } from "@/routes/model/guards/AuthProvider";
 
 import { ReviewWidget } from "@/widgets/ReviewWidget";
 
 import {
-    GetOfferReviewByVacancy, useCreateOfferReviewMutation, useLazyGetOfferReviewByVacancyIdQuery,
+    GetOfferReviewByVacancy, useCreateOfferReviewMutation, useDeleteOfferReviewMutation,
+    useLazyGetOfferReviewByVacancyIdQuery,
 } from "@/entities/Review";
 
 import { getVolunteerPersonalPageUrl } from "@/shared/config/routes/AppUrls";
@@ -30,6 +32,8 @@ interface OfferReviewsCardProps {
 }
 
 const VISIBLE_COUNT = 5;
+// Держим в синхроне с DeleteHandler::DELETE_WINDOW на бэкенде (GS-132).
+const DELETE_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
     (props: OfferReviewsCardProps) => {
@@ -44,9 +48,11 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
         const [reviews, setReviews] = useState<GetOfferReviewByVacancy[]>([]);
         const { locale } = useLocale();
         const { getFullName } = useGetFullName();
+        const { myProfile } = useAuth();
 
         const [getReviewsData, { data: reviewsData }] = useLazyGetOfferReviewByVacancyIdQuery();
         const [createOfferReview] = useCreateOfferReviewMutation();
+        const [deleteOfferReview] = useDeleteOfferReviewMutation();
 
         const fetchReviews = useCallback(async (pageItem: number) => {
             try {
@@ -101,17 +107,36 @@ export const OfferReviewsCard: FC<OfferReviewsCardProps> = memo(
             canReview, commentInput, rating, reviewImages, createOfferReview, offerId, fetchReviews,
         ]);
 
-        const renderReviews = reviews.map((review) => (
-            <ReviewWidget
-                name={getFullName(review.author.firstName, review.author.lastName)}
-                avatar={getMediaContent(review.author.image ?? undefined, "SMALL")}
-                reviewText={review.description}
-                stars={review.rating}
-                url={getVolunteerPersonalPageUrl(locale, review.author.id)}
-                images={review.images}
-                key={review.id}
-            />
-        ));
+        const handleDeleteReview = useCallback(async (reviewId: string) => {
+            if (!window.confirm("Удалить отзыв? Это действие нельзя отменить.")) return;
+
+            try {
+                await deleteOfferReview(reviewId).unwrap();
+                setReviews((prev) => prev.filter((review) => review.id !== reviewId));
+            } catch {
+                setError("Не удалось удалить отзыв. Попробуйте позже.");
+            }
+        }, [deleteOfferReview]);
+
+        const renderReviews = reviews.map((review) => {
+            const canDelete = myProfile?.id === review.author.id
+                && !!review.createdAt
+                && (Date.now() - new Date(review.createdAt).getTime()) < DELETE_WINDOW_MS;
+
+            return (
+                <ReviewWidget
+                    name={getFullName(review.author.firstName, review.author.lastName)}
+                    avatar={getMediaContent(review.author.image ?? undefined, "SMALL")}
+                    reviewText={review.description}
+                    stars={review.rating}
+                    url={getVolunteerPersonalPageUrl(locale, review.author.id)}
+                    images={review.images}
+                    canDelete={canDelete}
+                    onDelete={() => handleDeleteReview(review.id)}
+                    key={review.id}
+                />
+            );
+        });
 
         const renderContent = () => {
             if (error) {

--- a/src/entities/Review/api/reviewApi.ts
+++ b/src/entities/Review/api/reviewApi.ts
@@ -175,6 +175,13 @@ export const reviewApi = createApi({
             }),
             invalidatesTags: ["host", "volunteer"],
         }),
+        deleteOfferReview: build.mutation<void, string>({
+            query: (reviewId) => ({
+                url: `${API_BASE_URL_ABSOLUTE}review-vacancy/${reviewId}`,
+                method: "DELETE",
+            }),
+            invalidatesTags: ["host", "volunteer"],
+        }),
         getOfferReviews: build.query<GetOfferReviewRequest,
         GetOfferReviewParams>({
             query: (params) => ({
@@ -247,6 +254,7 @@ export const {
     useCreateVolunteerReviewMutation,
     useLazyGetAboutVolunteerReviewsQuery,
     useCreateOfferReviewMutation,
+    useDeleteOfferReviewMutation,
     useLazyGetOfferReviewsQuery,
     useGetMyVolunteerReviewsQuery,
     useLazyGetMyVolunteerReviewsQuery,

--- a/src/entities/Review/index.ts
+++ b/src/entities/Review/index.ts
@@ -12,6 +12,7 @@ export {
     useCreateVolunteerReviewMutation,
     useLazyGetAboutVolunteerReviewsQuery,
     useCreateOfferReviewMutation,
+    useDeleteOfferReviewMutation,
     useLazyGetOfferReviewsQuery,
     useGetMyVolunteerReviewsQuery,
     useLazyGetMyVolunteerReviewsQuery,

--- a/src/entities/Review/model/types/review.ts
+++ b/src/entities/Review/model/types/review.ts
@@ -111,6 +111,7 @@ export interface GetOfferReviewByVacancy {
     }
     description: string;
     rating: number;
+    createdAt: string | null;
     images: Image[];
 }
 

--- a/src/widgets/ReviewWidget/ui/ReviewWidget.module.scss
+++ b/src/widgets/ReviewWidget/ui/ReviewWidget.module.scss
@@ -3,6 +3,22 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+    position: relative;
+}
+
+.deleteBtn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 4px;
+
+    img {
+        width: 16px;
+        height: 16px;
+    }
 }
 
 .reviewInfo {

--- a/src/widgets/ReviewWidget/ui/ReviewWidget.tsx
+++ b/src/widgets/ReviewWidget/ui/ReviewWidget.tsx
@@ -2,6 +2,7 @@ import React, { FC, memo } from "react";
 
 import { useNavigate } from "react-router-dom";
 import star from "@/shared/assets/icons/offers/star.svg";
+import deleteIcon from "@/shared/assets/icons/delete.svg";
 import { Avatar } from "@/shared/ui/Avatar/Avatar";
 import { ReviewGallery } from "@/shared/ui/ReviewGallery/ReviewGallery";
 import { Image } from "@/types/media";
@@ -15,12 +16,14 @@ interface ReviewWidgetProps {
     name: string;
     url: string;
     images?: Image[];
+    canDelete?: boolean;
+    onDelete?: () => void;
 }
 
 export const ReviewWidget: FC<ReviewWidgetProps> = memo(
     (props: ReviewWidgetProps) => {
         const {
-            reviewText, stars, name, avatar, url, images,
+            reviewText, stars, name, avatar, url, images, canDelete, onDelete,
         } = props;
         const navigate = useNavigate();
 
@@ -30,6 +33,16 @@ export const ReviewWidget: FC<ReviewWidgetProps> = memo(
 
         return (
             <div className={styles.wrapper}>
+                {canDelete && (
+                    <button
+                        type="button"
+                        className={styles.deleteBtn}
+                        onClick={onDelete}
+                        aria-label="Удалить отзыв"
+                    >
+                        <img src={deleteIcon} alt="Удалить" />
+                    </button>
+                )}
                 <p className={styles.reviewText}>{reviewText}</p>
                 <ReviewGallery images={images} />
                 <div className={styles.reviewInfo}>


### PR DESCRIPTION
## Summary
- Adds a delete button on a reviewer's own review card (vacancy/host review list), shown only within 24h of publishing
- Wired via new `useDeleteOfferReviewMutation` → `DELETE /review-vacancy/{id}` (gs-backend#321)
- Ownership + time-window are both re-checked server-side; the frontend gating is UX only

## Test plan
- [x] New tests: delete button shows for own recent review, hides for other users' reviews, hides once >24h old, confirms before deleting, skips delete on cancel
- [x] Updated existing `OfferReviewsCard` tests for new `useAuth`/`useDeleteOfferReviewMutation` dependencies
- [x] revert-and-confirm-fails on the `canDelete` gating logic
- [x] Full frontend suite (479 tests), eslint, tsc — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)