### PR TITLE
fix(map): cluster click actually opens the Modal on real Yandex Maps

### DIFF
--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.test.tsx
@@ -336,6 +336,22 @@ describe("OffersMap", () => {
             });
             expect(screen.getByText("Вакансия в кластере")).toBeInTheDocument();
 
+            // Регресс: className={styles.clusterModal} передавался в Modal
+            // как className самого Modal — а он ложится на fixed-оверлей
+            // ВЕСЬ_ЭКРАН (Modal.module.scss .wrapper), а не на карточку
+            // внутри него, так что card-стили clusterModal (width: 280px,
+            // белый фон, border-radius) перетирали позиционирование самого
+            // оверлея. Правильно — свой div с этим классом ВНУТРИ Modal.
+            // [class~=...] ищет ТОЧНЫЙ класс-токен, а не подстроку — иначе
+            // closest('[class*="clusterModal"]') сработал бы уже на первом
+            // попавшемся потомке вроде clusterModalName/clusterModalList
+            // (они все начинаются с "clusterModal"), даже не поднимаясь до
+            // реального контейнера, и тест ничего бы не проверял.
+            const clusterModalBox = screen.getByText("Вакансия в кластере")
+                .closest("[class~=\"clusterModal\"]");
+            expect(clusterModalBox).not.toBeNull();
+            expect(clusterModalBox?.className).not.toMatch(/\bwrapper\b/);
+
             act(() => {
                 boundsChangeHandlers.forEach((handler) => handler());
             });
@@ -406,6 +422,31 @@ describe("OffersMap", () => {
                 );
             });
             expect(balloonOpen).not.toHaveBeenCalled();
+        },
+    );
+
+    it(
+        "передаёт ObjectManager clusterDisableClickZoom: true вместе с "
+        + "clusterOpenBalloonOnClick: false (регресс GS-119: без него клик по кластеру "
+        + "в реальных Яндекс.Картах ловит только встроенный zoom-in — событие \"click\" "
+        + "на clusters.events, которое слушает handleClusterClick, до кода приложения "
+        + "просто не доходит, хотя мок в этих тестах эмулирует его напрямую и не "
+        + "ловит такую регрессию)",
+        async () => {
+            render(
+                <OffersMap
+                    offersData={[offer({ id: 1 })]}
+                    isOffersLoading={false}
+                    selectedOfferCoordinates={null}
+                />,
+            );
+
+            await waitFor(() => expect(screen.getByTestId("object-manager")).toBeInTheDocument());
+
+            expect(capturedClustersProp).toMatchObject({
+                clusterOpenBalloonOnClick: false,
+                clusterDisableClickZoom: true,
+            });
         },
     );
 

--- a/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
+++ b/src/widgets/OffersMap/ui/OffersMap/OffersMap.tsx
@@ -741,6 +741,12 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
         // клик обрабатывается вручную (см. handleClusterClick ниже),
         // который открывает полностью наш React Modal.
         clusterOpenBalloonOnClick: false,
+        // Без этого клик по кластеру ловит только встроенный zoom-in
+        // Яндекса — он поглощает событие раньше, чем до него доходит наш
+        // clusters.events.add("click", ...) ниже, и Modal никогда не
+        // открывается (обнаружено живой проверкой на стейдже: клик всегда
+        // просто зумил карту).
+        clusterDisableClickZoom: true,
     } : undefined), [ymapState?.templateLayoutFactory]);
 
     return (
@@ -821,32 +827,34 @@ export const OffersMap: FC<OffersMapProps> = memo((props: OffersMapProps) => {
                 )}
             </Map>
             {activeClusterOffers && (
-                <Modal onClose={() => setActiveClusterOffers(null)} className={styles.clusterModal}>
-                    <h3 className={styles.clusterModalTitle}>{vacancyListTitle}</h3>
-                    <ul className={styles.clusterModalList}>
-                        {activeClusterOffers.map((offer) => (
-                            <li key={offer.id} className={styles.clusterModalItem}>
-                                <a href={offer.url} className={styles.clusterModalLink}>
-                                    <img
-                                        src={offer.image}
-                                        alt={offer.name}
-                                        className={styles.clusterModalImage}
-                                    />
-                                    <div className={styles.clusterModalText}>
-                                        <span className={styles.clusterModalName}>
-                                            {offer.name}
-                                        </span>
-                                        <span
-                                            className={styles.clusterModalCategory}
-                                            style={{ color: offer.categoryColor }}
-                                        >
-                                            {offer.categoryName}
-                                        </span>
-                                    </div>
-                                </a>
-                            </li>
-                        ))}
-                    </ul>
+                <Modal onClose={() => setActiveClusterOffers(null)}>
+                    <div className={styles.clusterModal}>
+                        <h3 className={styles.clusterModalTitle}>{vacancyListTitle}</h3>
+                        <ul className={styles.clusterModalList}>
+                            {activeClusterOffers.map((offer) => (
+                                <li key={offer.id} className={styles.clusterModalItem}>
+                                    <a href={offer.url} className={styles.clusterModalLink}>
+                                        <img
+                                            src={offer.image}
+                                            alt={offer.name}
+                                            className={styles.clusterModalImage}
+                                        />
+                                        <div className={styles.clusterModalText}>
+                                            <span className={styles.clusterModalName}>
+                                                {offer.name}
+                                            </span>
+                                            <span
+                                                className={styles.clusterModalCategory}
+                                                style={{ color: offer.categoryColor }}
+                                            >
+                                                {offer.categoryName}
+                                            </span>
+                                        </div>
+                                    </a>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
                 </Modal>
             )}
         </div>


### PR DESCRIPTION
## Summary
- GS-119 follow-up: live-verified PR #536 on staging and found the cluster popup still didn't work — clicking a cluster only zoomed the map, the custom `Modal` never opened.
- Root cause: Yandex's built-in click-to-zoom on clusters swallows the click before `clusters.events.add("click", ...)` sees it. `clusterOpenBalloonOnClick: false` only disables the native balloon, not the zoom — needed `clusterDisableClickZoom: true` too.
- Second bug found in the same pass: `<Modal className={styles.clusterModal}>` applies the card styles (280px width, white bg, border-radius) to the Modal's full-screen overlay wrapper instead of an inner box, breaking the overlay's own positioning/backdrop. Wrapped the content in its own `<div className={styles.clusterModal}>` instead, matching the pattern used elsewhere (`ConfirmActionModal`).
- Added regression tests for both (revert-and-confirm-fails verified locally).

## Test plan
- [x] `vitest run src/widgets/OffersMap` — 48 passed
- [x] `tsc --noEmit`, `eslint` clean
- [x] Live-verified root cause on staging by patching the served JS bundle in a real browser (clusters.click never fired without `clusterDisableClickZoom`; fired correctly with it)
- [ ] Live-verify actual deployed fix on staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)