### PR TITLE
fix(ci): disable buildx provenance attestation, YCR can't push it

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -49,6 +49,10 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.ref_name }}
             ${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-${{ github.sha }}
           push: true
+          # См. тот же provenance: false в deploy-staging.yml — Yandex
+          # Container Registry не переваривает OCI attestation-манифест,
+          # который buildx с 0.10 добавляет по умолчанию при push.
+          provenance: false
           cache-from: type=gha,scope=gs-frontend-prod
           cache-to: type=gha,mode=max,scope=gs-frontend-prod
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,6 +45,13 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE }}:staging
             ${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-${{ github.sha }}
           push: true
+          # buildx с версии 0.10 по умолчанию пушит provenance-attestation
+          # доп. манифестом в OCI image index — Yandex Container Registry
+          # такой manifest list не переваривает и роняет весь push с
+          # "unknown: Cannot read manifest data" (живой сбой на стейдже
+          # 2026-08-15, до этого недели пушилось нормально — судя по всему
+          # GitHub обновил бандленный buildx на раннерах).
+          provenance: false
           cache-from: type=gha,scope=gs-frontend
           cache-to: type=gha,mode=max,scope=gs-frontend
 


### PR DESCRIPTION
## Summary
- `deploy-to-staging` started failing today with `unknown: Cannot read manifest data` on every push — 6/6 attempts, ~1 hour, after 9 days of clean deploys and zero workflow changes.
- Root cause: `docker/build-push-action@v5` (buildx) defaults to pushing a provenance attestation as an extra manifest in the OCI image index since buildx v0.10 — Yandex Container Registry can't parse that manifest list and fails the whole push. Likely trigger: GitHub bumped the buildx version bundled on hosted runners between the last successful deploy (Aug 7) and today.
- Fix: explicit `provenance: false` on both `deploy-staging.yml` and `deploy-prod.yml` (same registry, same failure mode would hit prod on its next deploy).

## Test plan
- [ ] Merge and confirm the next staging deploy push succeeds
- [ ] Live-verify the previously-blocked offers-map marker contrast fix (#538) is now live on staging

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>